### PR TITLE
Topic/load alias of alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+## [Unreleased]
+
+## [1.0.0] - 2019-12-23
+
+Initial release
+
+[Unreleased]: https://github.com/jrl-umi3218/mc_rtc/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/jrl-umi3218/mc_rtc/releases/tag/v1.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Fixes
 
 - [mc\_rbdyn] Allow aliases to specify a string
+- [mc\_rbdyn] Allow loading aliases of aliases
 
 ## [1.0.0] - 2019-12-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- [mc\_rbdyn] Allow aliases to specify a string
+
 ## [1.0.0] - 2019-12-23
 
 Initial release

--- a/include/mc_rbdyn/RobotLoader.h
+++ b/include/mc_rbdyn/RobotLoader.h
@@ -75,7 +75,7 @@ public:
     {
       return get_robot_module(name, details::to_string(args)...);
     }
-    std::lock_guard<std::mutex> guard{mtx};
+    std::unique_lock<std::mutex> guard{mtx};
     init();
     mc_rbdyn::RobotModulePtr rm = nullptr;
     if(aliases.count(name))
@@ -83,15 +83,18 @@ public:
       const auto & params = aliases[name];
       if(params.size() == 1)
       {
-        rm = robot_loader->create_object(params[0]);
+        guard.unlock();
+        return get_robot_module(params[0]);
       }
       else if(params.size() == 2)
       {
-        rm = robot_loader->create_object(params[0], params[1]);
+        guard.unlock();
+        return get_robot_module(params[0], params[1]);
       }
       else if(params.size() == 3)
       {
-        rm = robot_loader->create_object(params[0], params[1], params[2]);
+        guard.unlock();
+        return get_robot_module(params[0], params[1], params[2]);
       }
       else
       {

--- a/src/mc_rbdyn/RobotLoader.cpp
+++ b/src/mc_rbdyn/RobotLoader.cpp
@@ -49,7 +49,7 @@ void mc_rbdyn::RobotLoader::load_aliases(const std::string & fname)
   mc_rtc::Configuration data(fname);
   try
   {
-    std::map<std::string, std::vector<std::string>> new_aliases = data;
+    std::map<std::string, mc_rtc::Configuration> new_aliases = data;
     for(const auto & a : new_aliases)
     {
       if(robot_loader->has_object(a.first))
@@ -62,7 +62,14 @@ void mc_rbdyn::RobotLoader::load_aliases(const std::string & fname)
       {
         LOG_WARNING("Aliases " << a.first << " was already declared, new declaration from " << fname << " will prevail")
       }
-      aliases[a.first] = a.second;
+      if(a.second.size())
+      {
+        aliases[a.first] = a.second;
+      }
+      else
+      {
+        aliases[a.first] = {static_cast<std::string>(a.second)};
+      }
       if(verbose_)
       {
         LOG_INFO("New alias " << a.first << ": " << data(a.first).dump(true, true))


### PR DESCRIPTION
This PR allows to specify aliases of aliases and ease parsing restriction on aliases entries.

For example, this becomes valid:
```yaml
Robot_WithGripper: [object, /path/to/robot, robot_with_gripper]
Robot_WithoutGripper: [objct, /path/to/robot, robot_without_gripper]
Robot: RobotWithGripper
```