### PR TITLE
Graceful global plugin crashes

### DIFF
--- a/binding/python/CMakeLists.txt
+++ b/binding/python/CMakeLists.txt
@@ -20,7 +20,7 @@ endif()
 
 add_cython_bindings(mc_rtc
   TARGETS ${BINDINGS_LIBRARIES}
-  VERSION 1.0.0
+  VERSION ${PROJECT_VERSION}
   MODULES mc_control.mc_control
           mc_control.fsm.fsm
           mc_rbdyn.mc_rbdyn

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -133,7 +133,15 @@ MCGlobalController::MCGlobalController(const GlobalConfiguration & conf)
   }
   for(const auto & plugin : config.global_plugins)
   {
-    plugins_.emplace_back(plugin, plugin_loader->create_unique_object(plugin));
+    try
+    {
+      plugins_.emplace_back(plugin, plugin_loader->create_unique_object(plugin));
+    }
+    catch(mc_rtc::LoaderException & exc)
+    {
+      LOG_ERROR("Global plugin " << plugin
+                                 << " failed to load, functions provided by this plugin will not be available")
+    }
   }
 
   // Loading controller modules


### PR DESCRIPTION
This PR makes sure mc_rtc doesn't crash right away if a global plugin fails to load

Closes https://github.com/jrl-umi3218/mc_openrtm/issues/2