### PR TITLE
[CoMTask] Fix computation of logged CoM position with dimWeight

### DIFF
--- a/include/mc_tasks/CoMTask.h
+++ b/include/mc_tasks/CoMTask.h
@@ -52,7 +52,13 @@ public:
    *
    * \returns The current CoM target
    */
-  Eigen::Vector3d com();
+  const Eigen::Vector3d & com() const;
+
+  /** \brief Actual CoM position (computed at the previous iteration)
+   *
+   * \return Return the current CoM position
+   */
+  const Eigen::Vector3d & actual() const;
 
   /*! \brief Load from configuration */
   void load(mc_solver::QPSolver &, const mc_rtc::Configuration & config) override;

--- a/src/mc_tasks/CoMTask.cpp
+++ b/src/mc_tasks/CoMTask.cpp
@@ -74,15 +74,20 @@ void CoMTask::com(const Eigen::Vector3d & com)
   errorT->com(com);
 }
 
-Eigen::Vector3d CoMTask::com()
+const Eigen::Vector3d & CoMTask::com() const
 {
   return errorT->com();
+}
+
+const Eigen::Vector3d & CoMTask::actual() const
+{
+  return errorT->actual();
 }
 
 void CoMTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  logger.addLogEntry(name_ + "_pos", [this]() -> Eigen::Vector3d { return cur_com_ - eval(); });
+  logger.addLogEntry(name_ + "_pos", [this]() -> const Eigen::Vector3d & { return actual(); });
   logger.addLogEntry(name_ + "_target", [this]() -> const Eigen::Vector3d & { return cur_com_; });
 }
 
@@ -97,9 +102,9 @@ void CoMTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
 {
   TrajectoryTaskGeneric<tasks::qp::CoMTask>::addToGUI(gui);
   gui.addElement({"Tasks", name_},
-                 mc_rtc::gui::Point3D("com_target", [this]() { return this->com(); },
+                 mc_rtc::gui::Point3D("com_target", [this]() -> const Eigen::Vector3d & { return this->com(); },
                                       [this](const Eigen::Vector3d & com) { this->com(com); }),
-                 mc_rtc::gui::Point3D("com", [this]() { return (this->com() - this->eval()).eval(); }));
+                 mc_rtc::gui::Point3D("com", [this]() -> const Eigen::Vector3d & { return this->actual(); }));
 }
 
 } // namespace mc_tasks


### PR DESCRIPTION
Fixes #14: Fixes a bug in logging/gui of the com position when using `dimWeight`.
Requires the corresponding PR in `Tasks`: https://github.com/jrl-umi3218/Tasks/pull/64

Note that this MR has an important implications for existing logs:
- The logged `CoM` position from the task (e.g `com_<RobotName>_pos`) is wrong along the dimensions where `dimWeight != 1`.