### PR TITLE
Add contact friction for FSM contacts

### DIFF
--- a/binding/python/mc_control/fsm/c_fsm.pxd
+++ b/binding/python/mc_control/fsm/c_fsm.pxd
@@ -34,13 +34,14 @@ cdef extern from "mc_control_fsm_wrapper.hpp":
 
 cdef extern from "<mc_control/fsm/Controller.h>" namespace "mc_control::fsm":
   cdef cppclass Contact:
-    Contact(const string&, const string&, const string&, const string&)
-    Contact(const string&, const string&, const string&, const string&, const c_eigen.Vector6d)
+    Contact(const string&, const string&, const string&, const string&, double)
+    Contact(const string&, const string&, const string&, const string&, double, const c_eigen.Vector6d)
     Contact()
     string r1
     string r2
     string r1Surface
     string r2Surface
+    double friction
     c_eigen.Vector6d dof
 
   # Actually std::set<Contact, std::less<Contact>, Eigen::aligned_allocator<Contact>> but Cython only know std::set<T>

--- a/binding/python/mc_control/fsm/fsm.pyx
+++ b/binding/python/mc_control/fsm/fsm.pyx
@@ -23,7 +23,7 @@ from libcpp.string cimport string
 from libcpp.vector cimport vector
 
 cdef class Contact(object):
-  def __ctor__(self, r1, r2, r1Surface, r2Surface, eigen.Vector6d dof = None):
+  def __ctor__(self, r1, r2, r1Surface, r2Surface, friction = mc_rbdyn.Contact.defaultFriction, eigen.Vector6d dof = None):
     if isinstance(r1, unicode):
       r1 = r1.encode(u'ascii')
     if isinstance(r1Surface, unicode):
@@ -33,9 +33,9 @@ cdef class Contact(object):
     if isinstance(r2Surface, unicode):
       r2Surface = r2Surface.encode(u'ascii')
     if dof is None:
-      self.impl = c_fsm.Contact(r1, r2, r1Surface, r2Surface)
+      self.impl = c_fsm.Contact(r1, r2, r1Surface, r2Surface, friction)
     else:
-      self.impl = c_fsm.Contact(r1, r2, r1Surface, r2Surface, dof.impl)
+      self.impl = c_fsm.Contact(r1, r2, r1Surface, r2Surface, friction, dof.impl)
   def __cinit__(self, *args):
     if len(args) > 0:
       self.__ctor__(*args)
@@ -67,6 +67,11 @@ cdef class Contact(object):
       if isinstance(r2Surface, unicode):
         r2Surface = r2Surface.encode(u'ascii')
       self.impl.r2Surface = r2Surface
+  property friction:
+    def __get__(self):
+      return self.impl.friction
+    def __set__(self, friction):
+      self.impl.friction = friction
   property dof:
     def __get__(self):
       return eigen.Vector6dFromC(self.impl.dof)

--- a/doc/_data/schemas/common/fsm_contact.json
+++ b/doc/_data/schemas/common/fsm_contact.json
@@ -8,6 +8,7 @@
     "r2": { "type": "string", "description": "Name of the second robot in the contact" },
     "r1Surface": { "type": "string", "description": "Name of the first robot's surface in the contact" },
     "r2Surface": { "type": "string", "description": "Name of the second robot's surface in the contact" },
+    "friction": { "type": "number", "description": "Contact's coefficient of friction", "default": "0.7" },
     "dof": { "$ref": "/../../Eigen/Vector6d.json", "description": "Contact DoF", "default": "[1, 1, 1, 1, 1, 1]" }
   },
   "required": ["r1", "r2", "r1Surface", "r2Surface"]

--- a/doc/_data/schemas/mc_rbdyn/Contact.json
+++ b/doc/_data/schemas/mc_rbdyn/Contact.json
@@ -6,12 +6,13 @@
   {
     "r1Surface": { "type": "string" },
     "r2Surface": { "type": "string" },
-    "r1Index": { "type": "number", "default": "0" },
-    "r2Index": { "type": "number", "default": "1" },
+    "r1Index": { "type": "integer", "default": "0" },
+    "r2Index": { "type": "integer", "default": "1" },
     "isFixed": { "type": "boolean" },
     "X_r2s_r1s": { "$ref": "/../../SpaceVecAlg/PTransformd.json" },
     "X_b_s": { "$ref": "/../../SpaceVecAlg/PTransformd.json" },
-    "ambiguityId": { "type": "integer" }
+    "friction": { "type": "number", "default": "0.7" },
+    "ambiguityId": { "type": "integer", "default": "-1" }
   },
   "required": ["r1Surface", "r2Surface", "isFixed"],
   "additionalProperties": false

--- a/doc/_examples/json/mc_rbdyn/Contact.json
+++ b/doc/_examples/json/mc_rbdyn/Contact.json
@@ -3,5 +3,6 @@
   "r2Surface": "surf2",
   "r1Index": 0,
   "r2Index": 1,
+  "friction": 0.7,
   "isFixed": false
 }

--- a/doc/_examples/yaml/mc_rbdyn/Contact.yaml
+++ b/doc/_examples/yaml/mc_rbdyn/Contact.yaml
@@ -2,4 +2,5 @@ r1Surface: surf1
 r2Surface: surf2
 r1Index: 0
 r2Index: 1
+friction: 0.7
 isFixed: false

--- a/include/mc_control/fsm/Controller.h
+++ b/include/mc_control/fsm/Controller.h
@@ -31,8 +31,9 @@ struct MC_CONTROL_FSM_DLLAPI Contact
           const std::string & r2,
           const std::string & r1Surface,
           const std::string & r2Surface,
+          double friction = mc_rbdyn::Contact::defaultFriction,
           const Eigen::Vector6d & dof = Eigen::Vector6d::Ones())
-  : r1(r1), r2(r2), r1Surface(r1Surface), r2Surface(r2Surface), dof(dof)
+  : r1(r1), r2(r2), r1Surface(r1Surface), r2Surface(r2Surface), friction(friction), dof(dof)
   {
   }
 
@@ -40,6 +41,7 @@ struct MC_CONTROL_FSM_DLLAPI Contact
   std::string r2;
   std::string r1Surface;
   std::string r2Surface;
+  mutable double friction;
   mutable Eigen::Vector6d dof;
 
   bool operator<(const Contact & rhs) const

--- a/src/mc_control/fsm/states/Parallel.cpp
+++ b/src/mc_control/fsm/states/Parallel.cpp
@@ -51,7 +51,6 @@ void ParallelState::DelayedState::createState(Controller & ctl)
 void ParallelState::configure(const mc_rtc::Configuration & config)
 {
   config_.load(config);
-  outputStates_ = mc_rtc::fromVectorOrElement<std::string>(config, "outputs", {});
 }
 
 void ParallelState::start(Controller & ctl)
@@ -69,6 +68,7 @@ void ParallelState::start(Controller & ctl)
     }
   }
   // Check validity of output states names
+  outputStates_ = mc_rtc::fromVectorOrElement<std::string>(config_, "outputs", {});
   for(const auto & sName : outputStates_)
   {
     if(std::find(states.begin(), states.end(), sName) == states.end())

--- a/src/mc_control/samples/FSM/etc/FSM.conf.cmake
+++ b/src/mc_control/samples/FSM/etc/FSM.conf.cmake
@@ -232,7 +232,7 @@
     {
       "base": "Parallel",
       "states": ["MoveLeftFoot", "RightCoM", "HalfSitting"],
-      "outputStates": ["MoveLeftFoot", "RightCoM"]
+      "outputs": ["MoveLeftFoot", "RightCoM"]
     },
     "MoveRightFoot":
     {
@@ -250,7 +250,7 @@
       },
       // When this list contains tasks names, these
       // tasks' completion criteria will be used to generate an output string for the state
-      "outputCriteriaTasks": ["MoveFoot"],
+      "outputs": ["MoveFoot"],
       "RemoveContacts":
       [
         {

--- a/src/mc_rbdyn/Contact.cpp
+++ b/src/mc_rbdyn/Contact.cpp
@@ -19,6 +19,10 @@
 namespace mc_rbdyn
 {
 
+// Repeat static constexpr declarations
+// See also https://stackoverflow.com/q/8016780
+constexpr double Contact::defaultFriction;
+
 struct ContactImpl
 {
 public:

--- a/src/mc_rbdyn/Contact.cpp
+++ b/src/mc_rbdyn/Contact.cpp
@@ -241,6 +241,7 @@ Contact & Contact::operator=(const Contact & rhs)
   this->impl->X_r2s_r1s = rhs.X_r2s_r1s();
   this->impl->is_fixed = rhs.isFixed();
   this->impl->X_b_s = rhs.X_b_s();
+  this->impl->friction = rhs.friction();
   this->impl->ambiguityId = rhs.ambiguityId();
   return *this;
 }

--- a/src/mc_rbdyn/configuration_io.cpp
+++ b/src/mc_rbdyn/configuration_io.cpp
@@ -826,10 +826,10 @@ mc_rbdyn::Contact ConfigurationLoader<mc_rbdyn::Contact>::load(const mc_rtc::Con
   std::string r1Surface = config("r1Surface");
   sva::PTransformd X_b_s = robots.robot(r1Index).surface(r1Surface).X_b_s();
   config("X_b_s", X_b_s);
-  int ambiguityId = -1;
-  config("ambiguityId", ambiguityId);
+  double friction = config("friction", mc_rbdyn::Contact::defaultFriction);
+  int ambiguityId = config("ambiguityId", -1);
   return mc_rbdyn::Contact(robots, r1Index, r2Index, config("r1Surface"), config("r2Surface"), X_r2s_r1s, X_b_s,
-                           ambiguityId);
+                           friction, ambiguityId);
 }
 
 mc_rtc::Configuration ConfigurationLoader<mc_rbdyn::Contact>::save(const mc_rbdyn::Contact & c)

--- a/src/mc_solver/QPSolver.cpp
+++ b/src/mc_solver/QPSolver.cpp
@@ -589,36 +589,39 @@ void QPSolver::gui(std::shared_ptr<mc_rtc::gui::StateBuilder> gui)
     {
       addTaskToGUI(t);
     }
-    gui_->addElement({"Contacts", "Add"},
-                     mc_rtc::gui::Form("Add contact",
-                                       [this](const mc_rtc::Configuration & data) {
-                                         LOG_INFO("Add contact " << data("R0") << "::" << data("R0 surface") << "/"
-                                                                 << data("R1") << "::" << data("R1 surface"))
-                                         auto str2idx = [this](const std::string & rName) {
-                                           for(const auto & r : robots())
-                                           {
-                                             if(r.name() == rName)
-                                             {
-                                               return r.robotIndex();
-                                             }
-                                           }
-                                           LOG_ERROR("The robot name you provided does not match any in the solver")
-                                           return static_cast<unsigned int>(robots().size());
-                                         };
-                                         unsigned int r0Index = str2idx(data("R0"));
-                                         unsigned int r1Index = str2idx(data("R1"));
-                                         std::string r0Surface = data("R0 surface");
-                                         std::string r1Surface = data("R1 surface");
-                                         if(r0Index < robots().size() && r1Index < robots().size())
-                                         {
-                                           contacts_.push_back({robots(), r0Index, r1Index, r0Surface, r1Surface});
-                                           setContacts(contacts_);
-                                         }
-                                       },
-                                       mc_rtc::gui::FormDataComboInput{"R0", true, {"robots"}},
-                                       mc_rtc::gui::FormDataComboInput{"R0 surface", true, {"surfaces", "$R0"}},
-                                       mc_rtc::gui::FormDataComboInput{"R1", true, {"robots"}},
-                                       mc_rtc::gui::FormDataComboInput{"R1 surface", true, {"surfaces", "$R1"}}));
+    gui_->addElement(
+        {"Contacts", "Add"},
+        mc_rtc::gui::Form("Add contact",
+                          [this](const mc_rtc::Configuration & data) {
+                            LOG_INFO("Add contact " << data("R0") << "::" << data("R0 surface") << "/" << data("R1")
+                                                    << "::" << data("R1 surface"))
+                            auto str2idx = [this](const std::string & rName) {
+                              for(const auto & r : robots())
+                              {
+                                if(r.name() == rName)
+                                {
+                                  return r.robotIndex();
+                                }
+                              }
+                              LOG_ERROR("The robot name you provided does not match any in the solver")
+                              return static_cast<unsigned int>(robots().size());
+                            };
+                            unsigned int r0Index = str2idx(data("R0"));
+                            unsigned int r1Index = str2idx(data("R1"));
+                            std::string r0Surface = data("R0 surface");
+                            std::string r1Surface = data("R1 surface");
+                            double friction = data("Friction");
+                            if(r0Index < robots().size() && r1Index < robots().size())
+                            {
+                              contacts_.push_back({robots(), r0Index, r1Index, r0Surface, r1Surface, friction});
+                              setContacts(contacts_);
+                            }
+                          },
+                          mc_rtc::gui::FormDataComboInput{"R0", true, {"robots"}},
+                          mc_rtc::gui::FormDataComboInput{"R0 surface", true, {"surfaces", "$R0"}},
+                          mc_rtc::gui::FormDataComboInput{"R1", true, {"robots"}},
+                          mc_rtc::gui::FormDataComboInput{"R1 surface", true, {"surfaces", "$R1"}},
+                          mc_rtc::gui::FormNumberInput{"Friction", false, mc_rbdyn::Contact::defaultFriction}));
   }
 }
 

--- a/src/mc_solver/QPSolver.cpp
+++ b/src/mc_solver/QPSolver.cpp
@@ -186,7 +186,7 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
     return ret;
   };
 
-  for(const mc_rbdyn::Contact & c : contacts)
+  for(const mc_rbdyn::Contact & c : contacts_)
   {
     QPContactPtr qcptr = c.taskContact(*robots_p);
     if(qcptr.unilateralContact)
@@ -205,7 +205,7 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
     {
       std::string bName = robot(c.r1Index()).name() + "::" + c.r1Surface()->name() + " & " + robot(c.r2Index()).name()
                           + "::" + c.r2Surface()->name();
-      auto nContacts = allBut(contacts, c);
+      auto nContacts = allBut(contacts_, c);
       gui_->addElement({"Contacts", "Remove"},
                        mc_rtc::gui::Button(bName, [nContacts, this]() { setContacts(nContacts); }));
     }
@@ -213,7 +213,7 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
 
   solver.nrVars(robots_p->mbs(), uniContacts, biContacts);
   const tasks::qp::SolverData & data = solver.data();
-  qpRes.contacts = contactsMsgFromContacts(*robots_p, contacts);
+  qpRes.contacts = contactsMsgFromContacts(*robots_p, contacts_);
   qpRes.contacts_lambda_begin.clear();
   for(int i = 0; i < data.nrContacts(); ++i)
   {


### PR DESCRIPTION
This brings friction setting support for FSM contacts as well

This also fixes small issues with friction support in `mc_rbdyn::Contact` and a bug in removing contact from the GUI