### PR TITLE
[Global+Stabilizer] Various existence checks for robots 

### DIFF
--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -184,6 +184,8 @@ public:
    * The default implementation reset the main robot's state to that provided by
    * reset_data (with a null speed/acceleration). It maintains the contacts as
    * they were set by the controller previously.
+   *
+   * \throws if the main robot is not supported (see supported_robots())
    */
   virtual void reset(const ControllerResetData & reset_data);
 
@@ -262,8 +264,11 @@ public:
    * \return Vector of supported robots designed by name (as returned by
    * RobotModule::name())
    * \note
-   * Default implementation returns an empty list which indicates that all
+   * - Default implementation returns an empty list which indicates that all
    * robots are supported.
+   * - If the list is not empty, only the robots in that list are allowed to be
+   *   used with the controller. The main robot will be checked against the list of supported robots
+   * upon call to reset(), and an exception will be thrown if the robot is not supported.
    */
   virtual std::vector<std::string> supported_robots() const;
 

--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -714,6 +714,17 @@ protected:
   /** Used to set the collision transforms correctly */
   void fixCollisionTransforms();
 
+  /** Unsafe version of bodyIndexByName */
+  unsigned int bodyIndexByName_(const std::string & name) const;
+  /** Throws if the joint is not in this robot */
+  void ensureHasJoint(const std::string & name) const;
+  /** Throws if the body is not in this robot */
+  void ensureHasBody(const std::string & name) const;
+  /** Throws if the surface is not in this robot */
+  void ensureHasSurface(const std::string & name) const;
+  /** Throws if the convex is not in this robot */
+  void ensureHasConvex(const std::string & name) const;
+
 private:
   Robot(const Robot &) = delete;
   Robot & operator=(const Robot &) = delete;

--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -55,13 +55,14 @@ public:
 
   /** Return the first BodySensor in the robot
    *
-   * If the robot does not have body sensors, it returns a default
-   * (invalid) one
-   *
+   * \throw if the robot does not have any body sensor
    */
   BodySensor & bodySensor();
 
-  /** Return the first BodySensor in the robot (const) */
+  /** Return the first BodySensor in the robot (const)
+   *
+   * \throw if the robot does not have any body sensor
+   */
   const BodySensor & bodySensor() const;
 
   /** Return true if the robot has a body sensor named name
@@ -83,7 +84,6 @@ public:
    * @param name Name of the sensor
    *
    * @throws If the sensor does not exist
-   *
    */
   BodySensor & bodySensor(const std::string & name);
 

--- a/include/mc_rtc/ConfigurationHelpers.h
+++ b/include/mc_rtc/ConfigurationHelpers.h
@@ -54,15 +54,17 @@ std::vector<T> fromVectorOrElement(const mc_rtc::Configuration & config,
     std::vector<T> vec = c;
     return vec;
   }
-  catch(...)
+  catch(mc_rtc::Configuration::Exception & notAVec)
   { // If that fails, try to convert as an element
+    notAVec.silence();
     try
     {
       T elem = c;
       return {elem};
     }
-    catch(...)
+    catch(mc_rtc::Configuration::Exception & notAnElem)
     { // If that fails as well, return the default
+      notAnElem.silence();
       return defaultVec;
     }
   }
@@ -84,15 +86,17 @@ std::vector<T> fromVectorOrElement(const mc_rtc::Configuration & config, const s
   {
     vec = c;
   }
-  catch(...)
+  catch(mc_rtc::Configuration::Exception & notAVec)
   {
+    notAVec.silence();
     try
     {
       T elem = c;
       vec.push_back(elem);
     }
-    catch(...)
+    catch(mc_rtc::Configuration::Exception & notAnElem)
     {
+      notAnElem.silence();
       LOG_ERROR_AND_THROW(mc_rtc::Configuration::Exception,
                           "Configuration " << key << " is not valid. It should be a vector or single element.");
     }

--- a/include/mc_tasks/MetaTask.h
+++ b/include/mc_tasks/MetaTask.h
@@ -247,6 +247,27 @@ protected:
     t.removeFromGUI(gui);
   }
 
+  void ensureHasJoints(const mc_rbdyn::Robot & robot,
+                       const std::vector<std::string> & joints,
+                       const std::string & prefix = "")
+  {
+    for(const auto & jName : joints)
+    {
+      if(!robot.hasJoint(jName))
+      {
+        if(prefix.size())
+        {
+          LOG_ERROR_AND_THROW(std::runtime_error,
+                              prefix << " No joint named " << jName << " in robot " << robot.name());
+        }
+        else
+        {
+          LOG_ERROR_AND_THROW(std::runtime_error, "No joint named " << jName << " in robot " << robot.name());
+        }
+      }
+    }
+  }
+
   /** Add additional completion criterias to mc_control::CompletionCriteria
    * object
    *

--- a/include/mc_tasks/TrajectoryTaskGeneric.h
+++ b/include/mc_tasks/TrajectoryTaskGeneric.h
@@ -164,9 +164,13 @@ struct TrajectoryTaskGeneric : public MetaTask
    *
    * @param activeJointsName Name of the joints activated for this task
    * \param activeDofs Allow to select only part of the dofs of a joint
+   * \param checkJoints When true, checks whether the joints exist in the robot
+   * \throws If checkJoints is true and a joint name in activeJointsName is not
+   * part of the robot
    */
   virtual void selectActiveJoints(const std::vector<std::string> & activeJointsName,
-                                  const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {});
+                                  const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {},
+                                  bool checkJoints = true);
 
   /** \brief Create an active joints selector
    *
@@ -178,6 +182,7 @@ struct TrajectoryTaskGeneric : public MetaTask
    *
    * @param activeJointsName Name of the joints activated for this task
    * \param activeDofs Allow to select only part of the dofs of a joint
+   * \throws If a joint name in activeJointsName is not part of the robot
    */
   virtual void selectActiveJoints(
       mc_solver::QPSolver & solver,
@@ -193,9 +198,13 @@ struct TrajectoryTaskGeneric : public MetaTask
    *
    * @param unactiveJointsName Name of the joints not activated for this task
    * \param unactiveDofs Allow to select only part of the dofs of a joint
+   * \param checkJoints When true, checks whether the joints exist in the robot
+   * \throws If checkJoints is true and a joint name in unactiveJointsName is not
+   * part of the robot
    */
   virtual void selectUnactiveJoints(const std::vector<std::string> & unactiveJointsName,
-                                    const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {});
+                                    const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {},
+                                    bool checkJoints = true);
 
   /** \brief Create an unactive joints selector
    *
@@ -207,6 +216,7 @@ struct TrajectoryTaskGeneric : public MetaTask
    *
    * @param unactiveJointsName Name of the joints not activated for this task
    * \param unactiveDofs Allow to select only part of the dofs of a joint
+   * \throws If a joint name in unactiveJointsName is not part of the robot
    */
   virtual void selectUnactiveJoints(
       mc_solver::QPSolver & solver,

--- a/include/mc_tasks/TrajectoryTaskGeneric.hpp
+++ b/include/mc_tasks/TrajectoryTaskGeneric.hpp
@@ -200,13 +200,18 @@ Eigen::VectorXd TrajectoryTaskGeneric<T>::dimWeight() const
 template<typename T>
 void TrajectoryTaskGeneric<T>::selectActiveJoints(
     const std::vector<std::string> & activeJointsName,
-    const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
+    const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs,
+    bool checkJoints)
 {
   if(inSolver_)
   {
     LOG_WARNING("selectActiveJoints(names) ignored: use selectActiveJoints(solver, names) for a task already added to "
                 "the solver");
     return;
+  }
+  if(checkJoints)
+  {
+    ensureHasJoints(robots.robot(rIndex), activeJointsName, "[selectActiveJoints]");
   }
   selectorT_ = std::make_shared<tasks::qp::JointsSelector>(tasks::qp::JointsSelector::ActiveJoints(
       robots.mbs(), static_cast<int>(rIndex), errorT.get(), activeJointsName, activeDofs));
@@ -220,28 +225,34 @@ void TrajectoryTaskGeneric<T>::selectActiveJoints(
     const std::vector<std::string> & activeJointsName,
     const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
 {
+  ensureHasJoints(robots.robot(rIndex), activeJointsName, "[selectActiveJoints]");
   if(inSolver_)
   {
     removeFromSolver(solver);
-    selectActiveJoints(activeJointsName, activeDofs);
+    selectActiveJoints(activeJointsName, activeDofs, false);
     addToSolver(solver);
   }
   else
   {
-    selectActiveJoints(activeJointsName, activeDofs);
+    selectActiveJoints(activeJointsName, activeDofs, false);
   }
 }
 
 template<typename T>
 void TrajectoryTaskGeneric<T>::selectUnactiveJoints(
     const std::vector<std::string> & unactiveJointsName,
-    const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
+    const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs,
+    bool checkJoints)
 {
   if(inSolver_)
   {
     LOG_WARNING("selectUnactiveJoints(names) ignored: use selectUnactiveJoints(solver, names) for a task already added "
                 "to the solver");
     return;
+  }
+  if(checkJoints)
+  {
+    ensureHasJoints(robots.robot(rIndex), unactiveJointsName, "[selectUnactiveJoints]");
   }
   selectorT_ = std::make_shared<tasks::qp::JointsSelector>(tasks::qp::JointsSelector::UnactiveJoints(
       robots.mbs(), static_cast<int>(rIndex), errorT.get(), unactiveJointsName, unactiveDofs));
@@ -255,15 +266,16 @@ void TrajectoryTaskGeneric<T>::selectUnactiveJoints(
     const std::vector<std::string> & unactiveJointsName,
     const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
 {
+  ensureHasJoints(robots.robot(rIndex), unactiveJointsName, "[selectUnactiveJoints]");
   if(inSolver_)
   {
     removeFromSolver(solver);
-    selectUnactiveJoints(unactiveJointsName, unactiveDofs);
+    selectUnactiveJoints(unactiveJointsName, unactiveDofs, false);
     addToSolver(solver);
   }
   else
   {
-    selectUnactiveJoints(unactiveJointsName, unactiveDofs);
+    selectUnactiveJoints(unactiveJointsName, unactiveDofs, false);
   }
 }
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -448,6 +448,9 @@ protected:
    */
   void configure_(mc_solver::QPSolver & solver);
 
+  /** Ensures that the configuration is valid */
+  void checkConfiguration(const mc_rbdyn::lipm_stabilizer::StabilizerConfiguration & config);
+
 protected:
   /**
    * @brief Workaround a C++11 standard bug: no specialization of the hash

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -467,7 +467,8 @@ protected:
   std::unordered_map<ContactState, internal::Contact, EnumClassHash> contacts_;
   std::vector<ContactState> addContacts_; /**< Contacts to add to the QPSolver when the task is inserted */
   std::unordered_map<ContactState, std::shared_ptr<mc_tasks::force::CoPTask>, EnumClassHash> footTasks;
-  std::vector<std::shared_ptr<mc_tasks::force::CoPTask>> contactTasks;
+  std::vector<std::shared_ptr<mc_tasks::force::CoPTask>> contactTasks; /** Foot tasks for the established contacts */
+  std::vector<std::string> contactSensors; /** Force sensors corresponding to established contacts */
 
   std::vector<std::vector<Eigen::Vector3d>> supportPolygons_; /**< For GUI display */
   Eigen::Vector2d supportMin_ = Eigen::Vector2d::Zero();
@@ -525,10 +526,8 @@ protected:
   double mass_ = 38.; /**< Robot mass in [kg] */
   double runTime_ = 0.;
   double vdcHeightError_ = 0.; /**< Average height error used in vertical drift compensation */
-  sva::ForceVecd distribWrench_ = sva::ForceVecd::Zero();
-  std::vector<std::string> sensorNames_ = {
-      "LeftFootForceSensor", "RightFootForceSensor"}; /** Force sensors corresponding to established contacts */
-  sva::PTransformd zmpFrame_;
+  sva::ForceVecd distribWrench_ = sva::ForceVecd::Zero(); /**< Result of the force distribution QP */
+  sva::PTransformd zmpFrame_ = sva::PTransformd::Identity(); /**< Frame in which the ZMP is computed */
 };
 
 } // namespace lipm_stabilizer

--- a/plugins/ROS/src/mc_rtc_ros/ros.cpp
+++ b/plugins/ROS/src/mc_rtc_ros/ros.cpp
@@ -166,8 +166,11 @@ void RobotPublisherImpl::init(const mc_rbdyn::Robot & robot)
     }
   }
 
-  data.odom.header.frame_id = "robot_map";
-  data.odom.child_frame_id = prefix + robot.bodySensor().parentBody();
+  if(robot.bodySensors().size())
+  {
+    data.odom.header.frame_id = "robot_map";
+    data.odom.child_frame_id = prefix + robot.bodySensor().parentBody();
+  }
 
   auto id = sva::PTransformd::Identity();
   data.tfs.push_back(PT2TF(id, tm, "robot_map", prefix + robot.mb().body(0).name(), 0));
@@ -294,42 +297,45 @@ void RobotPublisherImpl::update(double,
     }
   }
 
-  data.imu.header = data.js.header;
-  const auto & imu_linear_acceleration = robot.bodySensor().acceleration();
-  data.imu.linear_acceleration.x = imu_linear_acceleration.x();
-  data.imu.linear_acceleration.y = imu_linear_acceleration.y();
-  data.imu.linear_acceleration.z = imu_linear_acceleration.z();
-  const auto & imu_angular_velocity = robot.bodySensor().angularVelocity();
-  data.imu.angular_velocity.x = imu_angular_velocity.x();
-  data.imu.angular_velocity.y = imu_angular_velocity.y();
-  data.imu.angular_velocity.z = imu_angular_velocity.z();
-  const auto & imu_orientation = robot.bodySensor().orientation();
-  data.imu.orientation.x = imu_orientation.x();
-  data.imu.orientation.y = imu_orientation.y();
-  data.imu.orientation.z = imu_orientation.z();
+  if(robot.bodySensors().size())
+  {
+    data.imu.header = data.js.header;
+    const auto & imu_linear_acceleration = robot.bodySensor().acceleration();
+    data.imu.linear_acceleration.x = imu_linear_acceleration.x();
+    data.imu.linear_acceleration.y = imu_linear_acceleration.y();
+    data.imu.linear_acceleration.z = imu_linear_acceleration.z();
+    const auto & imu_angular_velocity = robot.bodySensor().angularVelocity();
+    data.imu.angular_velocity.x = imu_angular_velocity.x();
+    data.imu.angular_velocity.y = imu_angular_velocity.y();
+    data.imu.angular_velocity.z = imu_angular_velocity.z();
+    const auto & imu_orientation = robot.bodySensor().orientation();
+    data.imu.orientation.x = imu_orientation.x();
+    data.imu.orientation.y = imu_orientation.y();
+    data.imu.orientation.z = imu_orientation.z();
 
-  data.odom.header.seq = data.js.header.seq;
-  data.odom.header.stamp = data.js.header.stamp;
-  const auto & odom_p = robot.bodySensor().position();
-  Eigen::Quaterniond odom_q = robot.bodySensor().orientation();
-  data.odom.pose.pose.position.x = odom_p.x();
-  data.odom.pose.pose.position.y = odom_p.y();
-  data.odom.pose.pose.position.z = odom_p.z();
-  data.odom.pose.pose.orientation.w = odom_q.w();
-  data.odom.pose.pose.orientation.x = odom_q.x();
-  data.odom.pose.pose.orientation.y = odom_q.y();
-  data.odom.pose.pose.orientation.z = odom_q.z();
-  data.odom.pose.covariance.fill(0);
-  /* Provide linear and angular velocity */
-  const auto & vel = robot.bodySensor().linearVelocity();
-  data.odom.twist.twist.linear.x = vel.x();
-  data.odom.twist.twist.linear.y = vel.y();
-  data.odom.twist.twist.linear.z = vel.z();
-  const auto & rate = robot.bodySensor().angularVelocity();
-  data.odom.twist.twist.angular.x = rate.x();
-  data.odom.twist.twist.angular.y = rate.y();
-  data.odom.twist.twist.angular.z = rate.z();
-  data.odom.twist.covariance.fill(0);
+    data.odom.header.seq = data.js.header.seq;
+    data.odom.header.stamp = data.js.header.stamp;
+    const auto & odom_p = robot.bodySensor().position();
+    Eigen::Quaterniond odom_q = robot.bodySensor().orientation();
+    data.odom.pose.pose.position.x = odom_p.x();
+    data.odom.pose.pose.position.y = odom_p.y();
+    data.odom.pose.pose.position.z = odom_p.z();
+    data.odom.pose.pose.orientation.w = odom_q.w();
+    data.odom.pose.pose.orientation.x = odom_q.x();
+    data.odom.pose.pose.orientation.y = odom_q.y();
+    data.odom.pose.pose.orientation.z = odom_q.z();
+    data.odom.pose.covariance.fill(0);
+    /* Provide linear and angular velocity */
+    const auto & vel = robot.bodySensor().linearVelocity();
+    data.odom.twist.twist.linear.x = vel.x();
+    data.odom.twist.twist.linear.y = vel.y();
+    data.odom.twist.twist.linear.z = vel.z();
+    const auto & rate = robot.bodySensor().angularVelocity();
+    data.odom.twist.twist.angular.x = rate.x();
+    data.odom.twist.twist.angular.y = rate.y();
+    data.odom.twist.twist.angular.z = rate.z();
+    data.odom.twist.covariance.fill(0);
+  }
 
   {
     size_t wrench_i = 0;

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -9,6 +9,7 @@
 
 #include <mc_rtc/config.h>
 #include <mc_rtc/gui/Schema.h>
+#include <mc_rtc/io_utils.h>
 #include <mc_rtc/logging.h>
 
 #include <mc_tasks/MetaTaskLoader.h>
@@ -252,6 +253,15 @@ const mc_solver::QPResultMsg & MCController::send(const double & t)
 
 void MCController::reset(const ControllerResetData & reset_data)
 {
+  const auto supported = supported_robots();
+  if(supported.size() && std::find(supported.cbegin(), supported.cend(), robot().name()) == supported.end())
+  {
+    LOG_ERROR_AND_THROW(std::runtime_error, "[MCController] The main robot "
+                                                << robot().name()
+                                                << " is not supported by this controller. Supported robots are: ["
+                                                << mc_rtc::io::to_string(supported) << "].");
+  }
+
   robot().mbc().zero(robot().mb());
   robot().mbc().q = reset_data.q;
   postureTask->posture(reset_data.q);

--- a/src/mc_control/fsm/states/data/StabilizerStanding.yaml
+++ b/src/mc_control/fsm/states/data/StabilizerStanding.yaml
@@ -7,8 +7,6 @@ Stabilizer::Standing:
   StabilizerConfig:
     type: lipm_stabilizer
     robotIndex: 0
-    leftFootSurface: LeftFootCenter
-    rightFootSurface: RightFootCenter
     enabled: true
     contacts: [Left, Right]
     admittance:

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -301,14 +301,20 @@ void MCGlobalController::init(const std::vector<double> & initq, const std::arra
 
 void MCGlobalController::setSensorPosition(const Eigen::Vector3d & pos)
 {
-  robot().bodySensor().position(pos);
-  realRobot().bodySensor().position(pos);
+  if(robot().bodySensors().size())
+  {
+    robot().bodySensor().position(pos);
+    realRobot().bodySensor().position(pos);
+  }
 }
 
 void MCGlobalController::setSensorPositions(const std::map<std::string, Eigen::Vector3d> & poses)
 {
-  setSensorPositions(robot(), poses);
-  setSensorPositions(realRobot(), poses);
+  if(robot().bodySensors().size())
+  {
+    setSensorPositions(robot(), poses);
+    setSensorPositions(realRobot(), poses);
+  }
 }
 
 void MCGlobalController::setSensorPositions(mc_rbdyn::Robot & robot,
@@ -322,8 +328,11 @@ void MCGlobalController::setSensorPositions(mc_rbdyn::Robot & robot,
 
 void MCGlobalController::setSensorOrientation(const Eigen::Quaterniond & ori)
 {
-  robot().bodySensor().orientation(ori);
-  realRobot().bodySensor().orientation(ori);
+  if(robot().bodySensors().size())
+  {
+    robot().bodySensor().orientation(ori);
+    realRobot().bodySensor().orientation(ori);
+  }
 }
 
 void MCGlobalController::setSensorOrientations(const std::map<std::string, Eigen::Quaterniond> & oris)
@@ -343,8 +352,11 @@ void MCGlobalController::setSensorOrientations(mc_rbdyn::Robot & robot,
 
 void MCGlobalController::setSensorLinearVelocity(const Eigen::Vector3d & vel)
 {
-  robot().bodySensor().linearVelocity(vel);
-  realRobot().bodySensor().linearVelocity(vel);
+  if(robot().bodySensors().size())
+  {
+    robot().bodySensor().linearVelocity(vel);
+    realRobot().bodySensor().linearVelocity(vel);
+  }
 }
 
 void MCGlobalController::setSensorLinearVelocities(const std::map<std::string, Eigen::Vector3d> & linearVels)
@@ -364,8 +376,11 @@ void MCGlobalController::setSensorLinearVelocities(mc_rbdyn::Robot & robot,
 
 void MCGlobalController::setSensorAngularVelocity(const Eigen::Vector3d & vel)
 {
-  robot().bodySensor().angularVelocity(vel);
-  realRobot().bodySensor().angularVelocity(vel);
+  if(robot().bodySensors().size())
+  {
+    robot().bodySensor().angularVelocity(vel);
+    realRobot().bodySensor().angularVelocity(vel);
+  }
 }
 
 void MCGlobalController::setSensorAngularVelocities(const std::map<std::string, Eigen::Vector3d> & angularVels)
@@ -384,8 +399,11 @@ void MCGlobalController::setSensorAngularVelocities(mc_rbdyn::Robot & robot,
 
 void MCGlobalController::setSensorAcceleration(const Eigen::Vector3d & acc)
 {
-  robot().bodySensor().acceleration(acc);
-  realRobot().bodySensor().acceleration(acc);
+  if(robot().bodySensors().size())
+  {
+    robot().bodySensor().acceleration(acc);
+    realRobot().bodySensor().acceleration(acc);
+  }
 }
 
 void MCGlobalController::setSensorAccelerations(const std::map<std::string, Eigen::Vector3d> & accels)
@@ -908,21 +926,10 @@ void MCGlobalController::setup_log()
       return controller->robot().forceSensor(fs_name).wrench();
     });
   }
-  controller->logger().addLogEntry(
-      "pIn", [controller]() -> const Eigen::Vector3d & { return controller->robot().bodySensor().position(); });
-  controller->logger().addLogEntry(
-      "rpyIn", [controller]() -> const Eigen::Quaterniond & { return controller->robot().bodySensor().orientation(); });
-  controller->logger().addLogEntry(
-      "velIn", [controller]() -> const Eigen::Vector3d & { return controller->robot().bodySensor().linearVelocity(); });
-  controller->logger().addLogEntry("rateIn", [controller]() -> const Eigen::Vector3d & {
-    return controller->robot().bodySensor().angularVelocity();
-  });
-  controller->logger().addLogEntry(
-      "accIn", [controller]() -> const Eigen::Vector3d & { return controller->robot().bodySensor().acceleration(); });
 
   // Log all other body sensors
   const auto & bodySensors = controller->robot().bodySensors();
-  for(size_t i = 1; i < bodySensors.size(); ++i)
+  for(size_t i = 0; i < bodySensors.size(); ++i)
   {
     const auto & name = bodySensors[i].name();
     controller->logger().addLogEntry(name + "_pIn", [controller, name]() -> const Eigen::Vector3d & {

--- a/src/mc_control/samples/FSM/src/mc_fsm_controller.h
+++ b/src/mc_control/samples/FSM/src/mc_fsm_controller.h
@@ -16,6 +16,11 @@ struct MC_CONTROL_DLLAPI FSMController : public mc_control::fsm::Controller
 
   void reset(const mc_control::ControllerResetData & reset_data) override;
 
+  std::vector<std::string> supported_robots() const override
+  {
+    return {"jvrc1"};
+  }
+
 private:
   mc_rtc::Configuration config_;
 };

--- a/src/mc_control/samples/LIPMStabilizer/etc/LIPMStabilizer.in.yaml
+++ b/src/mc_control/samples/LIPMStabilizer/etc/LIPMStabilizer.in.yaml
@@ -66,12 +66,12 @@ states:
     AddContacts:
     - r1: hrp2_drc
       r2: ground
-      r1Surface: LeftFootCenter
+      r1Surface: LeftFoot
       r2Surface: AllGround
       dof: [0, 0, 1, 1, 1, 0]
     - r1: hrp2_drc
       r2: ground
-      r1Surface: RightFootCenter
+      r1Surface: RightFoot
       r2Surface: AllGround
       dof: [0, 0, 1, 1, 1, 0]
 
@@ -85,8 +85,8 @@ states:
       # Default values for these robot-specific parameters are set in the corresponding robot module.
       # You may choose to override any of them here, with due caution.
       hrp2_drc:
-        leftFootSurface: LeftFootCenter
-        rightFootSurface: RightFootCenter
+        leftFootSurface: LeftFoot
+        rightFootSurface: RightFoot
         friction: 0.8
         torsoBodyName: CHEST_LINK1
         # Configuration  of the QP tasks used by the stabilizer
@@ -150,7 +150,7 @@ states:
         stiffness: 10
         weight: 500
         robotIndex: 0
-        surface: "RightFootCenter"
+        surface: "RightFoot"
         moveWorld:
           translation: [0,0,0.1]
         completion:
@@ -164,7 +164,7 @@ states:
     base: LIPMStabilizer::LiftRightFoot
     tasks:
       LiftFootTask:
-        surface: "LeftFootCenter"
+        surface: LeftFoot
   
   LIPMStabilizer::PutRightFoot:
     base: MetaTasks
@@ -172,7 +172,7 @@ states:
       PutFootAdmittance:
         type: admittance
         robotIndex: 0
-        surface: "RightFootCenter"
+        surface: RightFoot
         stiffness: [10, 10, 10, 10, 10, 3]
         damping: [6.3, 6.3, 6.3, 6.3, 6.3, 300]
         admittance: [0,0,0,0,0,0.001]
@@ -194,7 +194,7 @@ states:
     base: LIPMStabilizer::PutRightFoot
     tasks:
       PutFootAdmittance:
-        surface: "LeftFootCenter"
+        surface: LeftFoot
   
   LIPMStabilizer::Stabilized::LiftRightFoot:
     base: Parallel
@@ -264,7 +264,7 @@ states:
     tasks:
       SwingFootTrajectory:
         type: exact_cubic_trajectory
-        surface: RightFootCenter
+        surface: RightFoot
         robotIndex: 0
         stiffness: 10000.0
         duration: 5.0
@@ -277,7 +277,7 @@ states:
               - timeout: 2.5
               - wrench: [.nan, .nan, .nan, .nan, .nan, 20] 
         targetSurface:
-          surface: RightFootCenter
+          surface: RightFoot
           robotIndex: 0
           # Aim 5mm above ground as the FSM does not have early-impact detection
           translation: [0.1, 0.0, 0.005]
@@ -290,9 +290,9 @@ states:
     base: LIPMStabilizer::RightFootTrajectory
     tasks:
       SwingFootTrajectory:
-        surface: LeftFootCenter
+        surface: LeftFoot
         targetSurface:
-          surface: LeftFootCenter
+          surface: LeftFoot
           translation: [0.1, 0.0, 0.005]
           rotation: [0,0,0]
           # control points in target surface frame
@@ -334,7 +334,7 @@ states:
     tasks:
       SwingFootTrajectory:
         targetSurface:
-          surface: RightFootCenter
+          surface: RightFoot
           robotIndex: 0
           translation: [-0.1, 0.0, 0.005]
           rotation: [0, 0, 0]
@@ -346,9 +346,9 @@ states:
     base: LIPMStabilizer::RightFootBackwardTrajectory
     tasks:
       SwingFootTrajectory:
-        surface: LeftFootCenter
+        surface: LeftFoot
         targetSurface:
-          surface: LeftFootCenter
+          surface: LeftFoot
           translation: [-0.1, 0.0, 0.005]
           rotation: [0,0,0]
           # control points in target surface frame

--- a/src/mc_control/samples/LIPMStabilizer/src/mc_lipm_stabilizer.h
+++ b/src/mc_control/samples/LIPMStabilizer/src/mc_lipm_stabilizer.h
@@ -16,6 +16,11 @@ struct MC_CONTROL_DLLAPI LIPMStabilizerController : public mc_control::fsm::Cont
 
   void reset(const mc_control::ControllerResetData & reset_data) override;
 
+  std::vector<std::string> supported_robots() const override
+  {
+    return {"jvrc1", "hrp2_drc", "hrp4", "hrp5_p"};
+  }
+
 private:
   mc_rtc::Configuration config_;
 };

--- a/src/mc_observers/KinematicInertialPoseObserver.cpp
+++ b/src/mc_observers/KinematicInertialPoseObserver.cpp
@@ -22,6 +22,11 @@ KinematicInertialPoseObserver::KinematicInertialPoseObserver(const std::string &
 
 void KinematicInertialPoseObserver::reset(const mc_control::MCController & ctl)
 {
+  if(ctl.robot().bodySensors().empty())
+  {
+    LOG_ERROR_AND_THROW(std::runtime_error,
+                        "KinematicInertialPoseObserver requires the robot to have at least one body sensor");
+  }
   run(ctl);
 }
 

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -345,6 +345,7 @@ bool Robot::hasBody(const std::string & name) const
 
 unsigned int Robot::jointIndexByName(const std::string & name) const
 {
+  ensureHasJoint(name);
   return mb().jointIndexByName().at(name);
 }
 
@@ -354,6 +355,12 @@ int Robot::jointIndexInMBC(size_t jointIndex) const
 }
 
 unsigned int Robot::bodyIndexByName(const std::string & name) const
+{
+  ensureHasBody(name);
+  return bodyIndexByName_(name);
+}
+
+unsigned int Robot::bodyIndexByName_(const std::string & name) const
 {
   return mb().bodyIndexByName().at(name);
 }
@@ -452,26 +459,32 @@ std::vector<sva::MotionVecd> & Robot::bodyAccB()
 
 const sva::PTransformd & Robot::bodyPosW(const std::string & name) const
 {
+  ensureHasBody(name);
   return bodyPosW()[bodyIndexByName(name)];
 }
 
 sva::PTransformd Robot::X_b1_b2(const std::string & b1, const std::string & b2) const
 {
+  ensureHasBody(b1);
+  ensureHasBody(b2);
   return bodyPosW()[bodyIndexByName(b2)] * bodyPosW()[bodyIndexByName(b1)].inv();
 }
 
 const sva::MotionVecd & Robot::bodyVelW(const std::string & name) const
 {
+  ensureHasBody(name);
   return bodyVelW()[bodyIndexByName(name)];
 }
 
 const sva::MotionVecd & Robot::bodyVelB(const std::string & name) const
 {
+  ensureHasBody(name);
   return bodyVelB()[bodyIndexByName(name)];
 }
 
 const sva::MotionVecd & Robot::bodyAccB(const std::string & name) const
 {
+  ensureHasBody(name);
   return bodyAccB()[bodyIndexByName(name)];
 }
 
@@ -720,6 +733,7 @@ const std::vector<ForceSensor> & Robot::forceSensors() const
 
 mc_rbdyn::Surface & Robot::surface(const std::string & sName)
 {
+  ensureHasSurface(sName);
   return const_cast<mc_rbdyn::Surface &>(static_cast<const Robot *>(this)->surface(sName));
 }
 
@@ -730,10 +744,7 @@ sva::PTransformd Robot::surfacePose(const std::string & sName) const
 
 const mc_rbdyn::Surface & Robot::surface(const std::string & sName) const
 {
-  if(!hasSurface(sName))
-  {
-    LOG_ERROR_AND_THROW(std::runtime_error, "No surface named " << sName << " found in robot " << this->name())
-  }
+  ensureHasSurface(sName);
   return *(surfaces_.at(sName));
 }
 
@@ -760,15 +771,12 @@ bool Robot::hasConvex(const std::string & name) const
 
 Robot::convex_pair_t & Robot::convex(const std::string & cName)
 {
+  ensureHasConvex(cName);
   return const_cast<Robot::convex_pair_t &>(static_cast<const Robot *>(this)->convex(cName));
 }
 const Robot::convex_pair_t & Robot::convex(const std::string & cName) const
 {
-  if(convexes_.count(cName) == 0)
-  {
-    LOG_ERROR_AND_THROW(std::runtime_error,
-                        "No convex named " << cName << " found in this robot (" << this->name_ << ")")
-  }
+  ensureHasConvex(cName);
   return convexes_.at(cName);
 }
 
@@ -798,10 +806,7 @@ void Robot::removeConvex(const std::string & cName)
 
 const sva::PTransformd & Robot::bodyTransform(const std::string & bName) const
 {
-  if(!hasBody(bName))
-  {
-    LOG_ERROR_AND_THROW(std::runtime_error, "No body transform with name " << bName << " found in this robot")
-  }
+  ensureHasBody(bName);
   return bodyTransforms_[bodyIndexByName(bName)];
 }
 
@@ -1048,6 +1053,38 @@ void mc_rbdyn::Robot::zmpTarget(const Eigen::Vector3d & zmp)
 const Eigen::Vector3d & mc_rbdyn::Robot::zmpTarget() const
 {
   return zmp_;
+}
+
+void mc_rbdyn::Robot::ensureHasBody(const std::string & name) const
+{
+  if(!hasBody(name))
+  {
+    LOG_ERROR_AND_THROW(std::runtime_error, "[Robot] No body named \"" << name << "\" in robot " << this->name());
+  }
+}
+
+void mc_rbdyn::Robot::ensureHasJoint(const std::string & name) const
+{
+  if(!hasJoint(name))
+  {
+    LOG_ERROR_AND_THROW(std::runtime_error, "[Robot] No joint named \"" << name << "\" in robot " << this->name());
+  }
+}
+
+void mc_rbdyn::Robot::ensureHasSurface(const std::string & name) const
+{
+  if(!hasSurface(name))
+  {
+    LOG_ERROR_AND_THROW(std::runtime_error, "[Robot] No surface named \"" << name << "\" in robot " << this->name());
+  }
+}
+
+void mc_rbdyn::Robot::ensureHasConvex(const std::string & name) const
+{
+  if(!hasConvex(name))
+  {
+    LOG_ERROR_AND_THROW(std::runtime_error, "[Robot] No convex named \"" << name << "\" in robot " << this->name());
+  }
 }
 
 } // namespace mc_rbdyn

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -231,11 +231,6 @@ Robot::Robot(Robots & robots,
   stance_ = module_.stance();
 
   bodySensors_ = module_.bodySensors();
-  // Add a single default sensor if no sensor on the robot
-  if(bodySensors_.size() == 0)
-  {
-    bodySensors_.emplace_back();
-  }
   for(size_t i = 0; i < bodySensors_.size(); ++i)
   {
     const auto & bS = bodySensors_[i];
@@ -282,11 +277,19 @@ const RobotModule & Robot::module() const
 
 BodySensor & Robot::bodySensor()
 {
+  if(bodySensors_.empty())
+  {
+    LOG_ERROR_AND_THROW(std::runtime_error, "[Robot] Robot " << name() << " does not have a default bodySensor");
+  }
   return bodySensors_[0];
 }
 
 const BodySensor & Robot::bodySensor() const
 {
+  if(bodySensors_.empty())
+  {
+    LOG_ERROR_AND_THROW(std::runtime_error, "[Robot] Robot " << name() << " does not have a default bodySensor");
+  }
   return bodySensors_[0];
 }
 

--- a/src/mc_tasks/ComplianceTask.cpp
+++ b/src/mc_tasks/ComplianceTask.cpp
@@ -140,6 +140,7 @@ void ComplianceTask::selectActiveJoints(mc_solver::QPSolver & solver,
                                         const std::vector<std::string> & activeJointsName,
                                         const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
 {
+  ensureHasJoints(robots_.robot(rIndex_), activeJointsName, "[ComplianceTask::selectActiveJoints]");
   efTask_->selectActiveJoints(solver, activeJointsName, activeDofs);
 }
 
@@ -147,6 +148,7 @@ void ComplianceTask::selectUnactiveJoints(mc_solver::QPSolver & solver,
                                           const std::vector<std::string> & unactiveJointsName,
                                           const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
 {
+  ensureHasJoints(robots_.robot(rIndex_), unactiveJointsName, "[ComplianceTask::selectUnactiveJoints]");
   efTask_->selectUnactiveJoints(solver, unactiveJointsName, unactiveDofs);
 }
 

--- a/src/mc_tasks/EndEffectorTask.cpp
+++ b/src/mc_tasks/EndEffectorTask.cpp
@@ -106,6 +106,7 @@ void EndEffectorTask::selectActiveJoints(mc_solver::QPSolver & solver,
                                          const std::vector<std::string> & activeJointsName,
                                          const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
 {
+  ensureHasJoints(robots.robot(robotIndex), activeJointsName, "[EndEffectorTask::selectActiveJoints]");
   positionTask->selectActiveJoints(solver, activeJointsName, activeDofs);
   orientationTask->selectActiveJoints(solver, activeJointsName, activeDofs);
 }
@@ -114,6 +115,7 @@ void EndEffectorTask::selectUnactiveJoints(mc_solver::QPSolver & solver,
                                            const std::vector<std::string> & unactiveJointsName,
                                            const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
 {
+  ensureHasJoints(robots.robot(robotIndex), unactiveJointsName, "[EndEffectorTask::selectUnactiveJoints]");
   positionTask->selectUnactiveJoints(solver, unactiveJointsName, unactiveDofs);
   orientationTask->selectUnactiveJoints(solver, unactiveJointsName, unactiveDofs);
 }

--- a/src/mc_tasks/PostureTask.cpp
+++ b/src/mc_tasks/PostureTask.cpp
@@ -43,6 +43,7 @@ void PostureTask::selectActiveJoints(mc_solver::QPSolver & solver,
                                      const std::vector<std::string> & activeJointsName,
                                      const std::map<std::string, std::vector<std::array<int, 2>>> &)
 {
+  ensureHasJoints(robots_.robot(rIndex_), activeJointsName, "[PostureTask::selectActiveJoints]");
   std::vector<std::string> unactiveJoints = {};
   for(const auto & j : robots_.robot(rIndex_).mb().joints())
   {
@@ -58,6 +59,7 @@ void PostureTask::selectUnactiveJoints(mc_solver::QPSolver & solver,
                                        const std::vector<std::string> & unactiveJointsName,
                                        const std::map<std::string, std::vector<std::array<int, 2>>> &)
 {
+  ensureHasJoints(robots_.robot(rIndex_), unactiveJointsName, "[PostureTask::selectUnActiveJoints]");
   std::vector<tasks::qp::JointStiffness> jsv;
   for(const auto & j : unactiveJointsName)
   {

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -201,6 +201,7 @@ void StabilizerTask::updateContacts(mc_solver::QPSolver & solver)
       MetaTask::removeFromSolver(*contactT, solver);
     }
     contactTasks.clear();
+    contactSensors.clear();
 
     // Add new contacts
     for(const auto contactState : addContacts_)
@@ -210,6 +211,9 @@ void StabilizerTask::updateContacts(mc_solver::QPSolver & solver)
       MetaTask::addToSolver(*footTask, solver);
       MetaTask::addToLogger(*footTask, *solver.logger());
       contactTasks.push_back(footTask);
+      const auto & bodyName = robot().surface(footTask->surface()).bodyName();
+      const auto & fs = robot().bodyForceSensor(bodyName);
+      contactSensors.push_back(fs.name());
     }
     addContacts_.clear();
   }
@@ -576,7 +580,7 @@ void StabilizerTask::run()
   updateZMPFrame();
   if(!inTheAir_)
   {
-    measuredNetWrench_ = robots_.robot(robotIndex_).netWrench(sensorNames_);
+    measuredNetWrench_ = robots_.robot(robotIndex_).netWrench(contactSensors);
     measuredZMP_ = robots_.robot(robotIndex_).zmp(measuredNetWrench_, zmpFrame_, MIN_NET_TOTAL_FORCE_ZMP);
   }
   else

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -285,22 +285,18 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   });
 
   // Log computed robot properties
-  logger.addLogEntry(name_ + "_controlRobot_LeftFoot", [this]() { return robot().surfacePose("LeftFoot"); });
-  logger.addLogEntry(name_ + "_controlRobot_LeftFootCenter",
-                     [this]() { return robot().surfacePose("LeftFootCenter"); });
-  logger.addLogEntry(name_ + "_controlRobot_RightFoot", [this]() { return robot().surfacePose("RightFoot"); });
-  logger.addLogEntry(name_ + "_controlRobot_RightFootCenter",
-                     [this]() { return robot().surfacePose("RightFootCenter"); });
+  logger.addLogEntry(name_ + "_controlRobot_LeftFoot",
+                     [this]() { return robot().surfacePose(footSurface(ContactState::Left)); });
+  logger.addLogEntry(name_ + "_controlRobot_RightFoot",
+                     [this]() { return robot().surfacePose(footSurface(ContactState::Right)); });
   logger.addLogEntry(name_ + "_controlRobot_com", [this]() { return robot().com(); });
   logger.addLogEntry(name_ + "_controlRobot_comd", [this]() { return robot().comVelocity(); });
   logger.addLogEntry(name_ + "_controlRobot_posW", [this]() { return robot().posW(); });
 
-  logger.addLogEntry(name_ + "_realRobot_LeftFoot", [this]() { return realRobot().surfacePose("LeftFoot"); });
-  logger.addLogEntry(name_ + "_realRobot_LeftFootCenter",
-                     [this]() { return realRobot().surfacePose("LeftFootCenter"); });
-  logger.addLogEntry(name_ + "_realRobot_RightFoot", [this]() { return realRobot().surfacePose("RightFoot"); });
-  logger.addLogEntry(name_ + "_realRobot_RightFootCenter",
-                     [this]() { return realRobot().surfacePose("RightFootCenter"); });
+  logger.addLogEntry(name_ + "_realRobot_LeftFoot",
+                     [this]() { return realRobot().surfacePose(footSurface(ContactState::Left)); });
+  logger.addLogEntry(name_ + "_realRobot_RightFoot",
+                     [this]() { return realRobot().surfacePose(footSurface(ContactState::Right)); });
   logger.addLogEntry(name_ + "_realRobot_com", [this]() { return measuredCoM_; });
   logger.addLogEntry(name_ + "_realRobot_comd", [this]() { return measuredCoMd_; });
   logger.addLogEntry(name_ + "_realRobot_dcm", [this]() -> Eigen::Vector3d { return measuredDCM_; });
@@ -350,16 +346,12 @@ void StabilizerTask::removeFromLogger(mc_rtc::Logger & logger)
   logger.removeLogEntry(name_ + "_target_pendulum_omega");
   logger.removeLogEntry(name_ + "_target_pendulum_zmp");
   logger.removeLogEntry(name_ + "_controlRobot_LeftFoot");
-  logger.removeLogEntry(name_ + "_controlRobot_LeftFootCenter");
   logger.removeLogEntry(name_ + "_controlRobot_RightFoot");
-  logger.removeLogEntry(name_ + "_controlRobot_RightFootCenter");
   logger.removeLogEntry(name_ + "_controlRobot_com");
   logger.removeLogEntry(name_ + "_controlRobot_comd");
   logger.removeLogEntry(name_ + "_controlRobot_posW");
   logger.removeLogEntry(name_ + "_realRobot_LeftFoot");
-  logger.removeLogEntry(name_ + "_realRobot_LeftFootCenter");
   logger.removeLogEntry(name_ + "_realRobot_RightFoot");
-  logger.removeLogEntry(name_ + "_realRobot_RightFootCenter");
   logger.removeLogEntry(name_ + "_realRobot_com");
   logger.removeLogEntry(name_ + "_realRobot_comd");
   logger.removeLogEntry(name_ + "_realRobot_dcm");


### PR DESCRIPTION
This PR brings in various changes made while starting to use the `HRP-5P` robot. This mainly consists in improved error reporting, and minor fixes.

- Consistently checks whether body/surface/convex/joint are part of a robot before attempting to use them. We pay a minor overhead there (typically a check for `count` in a map), but this allows to report a much nicer error than the standard `map.at(..)` exception/segfault.
- Ensures that joint names are valid before creating a `JointSelector`. This fixes https://gite.lirmm.fr/multi-contact/mc_rtc/issues/151
- Changes the logic behind handling of `BodySensors` when no default sensor is defined in the `RobotModule/URDF`.  Previously, a default invalid robot module would get created and used throughout the framework. However, we can no longer rely on artificially adding an invalid sensor any more, as multiple components now require it to have a valid state (mainly Observers and Plugins). With the new behaviour, no `BodySensor` is present unless explicitly added, and the appropriate checks are added where necessary. In addition the `KinematicInertialPoseObserver` will now throw an exception if the robot does not have any `BodySensor`.
- Enforces the list of supported robots defined through `MCController::supported_robots()` (previously ignored)
- Properly silences exceptions in `ConfigurationHelpers`.
- Fixes two minor bugs in the `StabilizerTask`:
  - Force sensor names were previously hardcoded. They are now found automatically from the foot surfaces or raise an exception if no sensor is attached to the surface.
  - `netWrench` measurements are now computed only from the force sensors in contact. This prevents undue noise from the sensors in the air during the swing foot phase.
- The sample `LIPMStabilizer` FSM now supports the `JVRC` robot and all HRP-variants (including `HRP-5P`)

Most of this will need to be refactored again while integrating TVM ;)