### PR TITLE
[MCController] Enforce the list of supported robots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - mc\_tasks::MomentumTask
 
+### Fixes
+
+- Enforce the list of supported robots provided by a controller
+
 ## [1.2.1] - 2020-03-18
 
 ### Added

--- a/binding/python/mc_control/c_mc_control.pxd
+++ b/binding/python/mc_control/c_mc_control.pxd
@@ -44,7 +44,7 @@ cdef extern from "<mc_control/mc_controller.h>" namespace "mc_control":
     Robot& env()
     Robots& robots()
     c_mc_rtc.Configuration & config()
-    vector[string] supported_robots()
+    void supported_robots(vector[string] &)
     c_mc_rtc.Logger & logger()
     shared_ptr[c_mc_rtc_gui.StateBuilder] gui()
 

--- a/binding/python/mc_control/mc_control.pyx
+++ b/binding/python/mc_control/mc_control.pyx
@@ -72,7 +72,9 @@ cdef class MCController(object):
   def robots(self):
     return mc_rbdyn.RobotsFromRawPtr(&(self.base.robots()))
   def supported_robots(self):
-    return self.base.supported_robots()
+    supported = []
+    self.base.supported_robots(supported)
+    return supported
   def config(self):
     return mc_rtc.ConfigurationFromRef(self.base.config())
   def logger(self):

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -184,6 +184,8 @@ public:
    * The default implementation reset the main robot's state to that provided by
    * reset_data (with a null speed/acceleration). It maintains the contacts as
    * they were set by the controller previously.
+   *
+   * \throws if the main robot is not supported (see supported_robots())
    */
   virtual void reset(const ControllerResetData & reset_data);
 
@@ -262,8 +264,11 @@ public:
    * \return Vector of supported robots designed by name (as returned by
    * RobotModule::name())
    * \note
-   * Default implementation returns an empty list which indicates that all
+   * - Default implementation returns an empty list which indicates that all
    * robots are supported.
+   * - If the list is not empty, only the robots in that list are allowed to be
+   *   used with the controller. The main robot will be checked against the list of supported robots
+   * upon call to reset(), and an exception will be thrown if the robot is not supported.
    */
   virtual std::vector<std::string> supported_robots() const;
 

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -261,7 +261,7 @@ public:
   mc_rbdyn::Robot & realRobot();
 
   /** Returns a list of robots supported by the controller.
-   * \return Vector of supported robots designed by name (as returned by
+   * \param out Vector of supported robots designed by name (as returned by
    * RobotModule::name())
    * \note
    * - Default implementation returns an empty list which indicates that all
@@ -270,7 +270,7 @@ public:
    *   used with the controller. The main robot will be checked against the list of supported robots
    * upon call to reset(), and an exception will be thrown if the robot is not supported.
    */
-  virtual std::vector<std::string> supported_robots() const;
+  virtual void supported_robots(std::vector<std::string> & out) const;
 
   /** Load an additional robot into the controller
    *

--- a/include/mc_rtc/ConfigurationHelpers.h
+++ b/include/mc_rtc/ConfigurationHelpers.h
@@ -54,15 +54,17 @@ std::vector<T> fromVectorOrElement(const mc_rtc::Configuration & config,
     std::vector<T> vec = c;
     return vec;
   }
-  catch(...)
+  catch(mc_rtc::Configuration::Exception & notAVec)
   { // If that fails, try to convert as an element
+    notAVec.silence();
     try
     {
       T elem = c;
       return {elem};
     }
-    catch(...)
+    catch(mc_rtc::Configuration::Exception & notAnElem)
     { // If that fails as well, return the default
+      notAnElem.silence();
       return defaultVec;
     }
   }
@@ -84,15 +86,17 @@ std::vector<T> fromVectorOrElement(const mc_rtc::Configuration & config, const s
   {
     vec = c;
   }
-  catch(...)
+  catch(mc_rtc::Configuration::Exception & notAVec)
   {
+    notAVec.silence();
     try
     {
       T elem = c;
       vec.push_back(elem);
     }
-    catch(...)
+    catch(mc_rtc::Configuration::Exception & notAnElem)
     {
+      notAnElem.silence();
       LOG_ERROR_AND_THROW(mc_rtc::Configuration::Exception,
                           "Configuration " << key << " is not valid. It should be a vector or single element.");
     }

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -253,7 +253,8 @@ const mc_solver::QPResultMsg & MCController::send(const double & t)
 
 void MCController::reset(const ControllerResetData & reset_data)
 {
-  const auto supported = supported_robots();
+  std::vector<std::string> supported;
+  supported_robots(supported);
   if(supported.size() && std::find(supported.cbegin(), supported.cend(), robot().name()) == supported.end())
   {
     LOG_ERROR_AND_THROW(std::runtime_error, "[MCController] The main robot "
@@ -316,9 +317,9 @@ mc_rtc::Logger & MCController::logger()
   return *logger_;
 }
 
-std::vector<std::string> MCController::supported_robots() const
+void MCController::supported_robots(std::vector<std::string> & out) const
 {
-  return {};
+  out = {};
 }
 
 void MCController::realRobots(std::shared_ptr<mc_rbdyn::Robots> realRobots)

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -9,6 +9,7 @@
 
 #include <mc_rtc/config.h>
 #include <mc_rtc/gui/Schema.h>
+#include <mc_rtc/io_utils.h>
 #include <mc_rtc/logging.h>
 
 #include <mc_tasks/MetaTaskLoader.h>
@@ -252,6 +253,15 @@ const mc_solver::QPResultMsg & MCController::send(const double & t)
 
 void MCController::reset(const ControllerResetData & reset_data)
 {
+  const auto supported = supported_robots();
+  if(supported.size() && std::find(supported.cbegin(), supported.cend(), robot().name()) == supported.end())
+  {
+    LOG_ERROR_AND_THROW(std::runtime_error, "[MCController] The main robot "
+                                                << robot().name()
+                                                << " is not supported by this controller. Supported robots are: ["
+                                                << mc_rtc::io::to_string(supported) << "].");
+  }
+
   robot().mbc().zero(robot().mb());
   robot().mbc().q = reset_data.q;
   postureTask->posture(reset_data.q);

--- a/src/mc_control/samples/FSM/src/mc_fsm_controller.h
+++ b/src/mc_control/samples/FSM/src/mc_fsm_controller.h
@@ -16,6 +16,11 @@ struct MC_CONTROL_DLLAPI FSMController : public mc_control::fsm::Controller
 
   void reset(const mc_control::ControllerResetData & reset_data) override;
 
+  std::vector<std::string> supported_robots() const override
+  {
+    return {"jvrc1"};
+  }
+
 private:
   mc_rtc::Configuration config_;
 };

--- a/src/mc_control/samples/FSM/src/mc_fsm_controller.h
+++ b/src/mc_control/samples/FSM/src/mc_fsm_controller.h
@@ -16,9 +16,9 @@ struct MC_CONTROL_DLLAPI FSMController : public mc_control::fsm::Controller
 
   void reset(const mc_control::ControllerResetData & reset_data) override;
 
-  std::vector<std::string> supported_robots() const override
+  void supported_robots(std::vector<std::string> & out) const override
   {
-    return {"jvrc1"};
+    out = {"jvrc1"};
   }
 
 private:

--- a/src/mc_control/samples/LIPMStabilizer/src/mc_lipm_stabilizer.h
+++ b/src/mc_control/samples/LIPMStabilizer/src/mc_lipm_stabilizer.h
@@ -16,6 +16,11 @@ struct MC_CONTROL_DLLAPI LIPMStabilizerController : public mc_control::fsm::Cont
 
   void reset(const mc_control::ControllerResetData & reset_data) override;
 
+  std::vector<std::string> supported_robots() const override
+  {
+    return {"jvrc1", "hrp2_drc", "hrp4", "hrp5_p"};
+  }
+
 private:
   mc_rtc::Configuration config_;
 };

--- a/src/mc_control/samples/LIPMStabilizer/src/mc_lipm_stabilizer.h
+++ b/src/mc_control/samples/LIPMStabilizer/src/mc_lipm_stabilizer.h
@@ -16,9 +16,9 @@ struct MC_CONTROL_DLLAPI LIPMStabilizerController : public mc_control::fsm::Cont
 
   void reset(const mc_control::ControllerResetData & reset_data) override;
 
-  std::vector<std::string> supported_robots() const override
+  void supported_robots(std::vector<std::string> & out) const override
   {
-    return {"jvrc1", "hrp2_drc", "hrp4", "hrp5_p"};
+    out = {"jvrc1", "hrp2_drc", "hrp4", "hrp5_p"};
   }
 
 private:


### PR DESCRIPTION
- Enforces the list of supported robots defined through MCController::supported_robots() (previously ignored):
  - If the list is empty, all robots are considered supported
  - If there are robot names in the list, then only these robots are allowed as the main robot, and the controller will throw upon `MCController::reset`.

- Properly silences exceptions in ConfigurationHelpers.