### PR TITLE
[MetaTasks] Ensures that joints exist for selectActiveJoints*

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 ### Fixes
 
 - Enforce the list of supported robots provided by a controller
+- Throws an error if selected joints do not exist
 
 ## [1.2.1] - 2020-03-18
 

--- a/include/mc_tasks/MetaTask.h
+++ b/include/mc_tasks/MetaTask.h
@@ -247,6 +247,19 @@ protected:
     t.removeFromGUI(gui);
   }
 
+  void ensureHasJoints(const mc_rbdyn::Robot & robot,
+                       const std::vector<std::string> & joints,
+                       const std::string & prefix) const
+  {
+    for(const auto & jName : joints)
+    {
+      if(!robot.hasJoint(jName))
+      {
+        LOG_ERROR_AND_THROW(std::runtime_error, prefix << " No joint named " << jName << " in robot " << robot.name());
+      }
+    }
+  }
+
   /** Add additional completion criterias to mc_control::CompletionCriteria
    * object
    *

--- a/include/mc_tasks/MetaTask.h
+++ b/include/mc_tasks/MetaTask.h
@@ -247,9 +247,9 @@ protected:
     t.removeFromGUI(gui);
   }
 
-  void ensureHasJoints(const mc_rbdyn::Robot & robot,
-                       const std::vector<std::string> & joints,
-                       const std::string & prefix) const
+  inline static void ensureHasJoints(const mc_rbdyn::Robot & robot,
+                                     const std::vector<std::string> & joints,
+                                     const std::string & prefix)
   {
     for(const auto & jName : joints)
     {

--- a/include/mc_tasks/TrajectoryTaskGeneric.h
+++ b/include/mc_tasks/TrajectoryTaskGeneric.h
@@ -164,9 +164,13 @@ struct TrajectoryTaskGeneric : public MetaTask
    *
    * @param activeJointsName Name of the joints activated for this task
    * \param activeDofs Allow to select only part of the dofs of a joint
+   * \param checkJoints When true, checks whether the joints exist in the robot
+   * \throws If checkJoints is true and a joint name in activeJointsName is not
+   * part of the robot
    */
   virtual void selectActiveJoints(const std::vector<std::string> & activeJointsName,
-                                  const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {});
+                                  const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {},
+                                  bool checkJoints = true);
 
   /** \brief Create an active joints selector
    *
@@ -178,6 +182,7 @@ struct TrajectoryTaskGeneric : public MetaTask
    *
    * @param activeJointsName Name of the joints activated for this task
    * \param activeDofs Allow to select only part of the dofs of a joint
+   * \throws If a joint name in activeJointsName is not part of the robot
    */
   virtual void selectActiveJoints(
       mc_solver::QPSolver & solver,
@@ -193,9 +198,13 @@ struct TrajectoryTaskGeneric : public MetaTask
    *
    * @param unactiveJointsName Name of the joints not activated for this task
    * \param unactiveDofs Allow to select only part of the dofs of a joint
+   * \param checkJoints When true, checks whether the joints exist in the robot
+   * \throws If checkJoints is true and a joint name in unactiveJointsName is not
+   * part of the robot
    */
   virtual void selectUnactiveJoints(const std::vector<std::string> & unactiveJointsName,
-                                    const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {});
+                                    const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {},
+                                    bool checkJoints = true);
 
   /** \brief Create an unactive joints selector
    *
@@ -207,6 +216,7 @@ struct TrajectoryTaskGeneric : public MetaTask
    *
    * @param unactiveJointsName Name of the joints not activated for this task
    * \param unactiveDofs Allow to select only part of the dofs of a joint
+   * \throws If a joint name in unactiveJointsName is not part of the robot
    */
   virtual void selectUnactiveJoints(
       mc_solver::QPSolver & solver,

--- a/include/mc_tasks/TrajectoryTaskGeneric.hpp
+++ b/include/mc_tasks/TrajectoryTaskGeneric.hpp
@@ -200,13 +200,18 @@ Eigen::VectorXd TrajectoryTaskGeneric<T>::dimWeight() const
 template<typename T>
 void TrajectoryTaskGeneric<T>::selectActiveJoints(
     const std::vector<std::string> & activeJointsName,
-    const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
+    const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs,
+    bool checkJoints)
 {
   if(inSolver_)
   {
     LOG_WARNING("selectActiveJoints(names) ignored: use selectActiveJoints(solver, names) for a task already added to "
                 "the solver");
     return;
+  }
+  if(checkJoints)
+  {
+    ensureHasJoints(robots.robot(rIndex), activeJointsName, "[selectActiveJoints]");
   }
   selectorT_ = std::make_shared<tasks::qp::JointsSelector>(tasks::qp::JointsSelector::ActiveJoints(
       robots.mbs(), static_cast<int>(rIndex), errorT.get(), activeJointsName, activeDofs));
@@ -220,28 +225,34 @@ void TrajectoryTaskGeneric<T>::selectActiveJoints(
     const std::vector<std::string> & activeJointsName,
     const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
 {
+  ensureHasJoints(robots.robot(rIndex), activeJointsName, "[selectActiveJoints]");
   if(inSolver_)
   {
     removeFromSolver(solver);
-    selectActiveJoints(activeJointsName, activeDofs);
+    selectActiveJoints(activeJointsName, activeDofs, false);
     addToSolver(solver);
   }
   else
   {
-    selectActiveJoints(activeJointsName, activeDofs);
+    selectActiveJoints(activeJointsName, activeDofs, false);
   }
 }
 
 template<typename T>
 void TrajectoryTaskGeneric<T>::selectUnactiveJoints(
     const std::vector<std::string> & unactiveJointsName,
-    const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
+    const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs,
+    bool checkJoints)
 {
   if(inSolver_)
   {
     LOG_WARNING("selectUnactiveJoints(names) ignored: use selectUnactiveJoints(solver, names) for a task already added "
                 "to the solver");
     return;
+  }
+  if(checkJoints)
+  {
+    ensureHasJoints(robots.robot(rIndex), unactiveJointsName, "[selectUnactiveJoints]");
   }
   selectorT_ = std::make_shared<tasks::qp::JointsSelector>(tasks::qp::JointsSelector::UnactiveJoints(
       robots.mbs(), static_cast<int>(rIndex), errorT.get(), unactiveJointsName, unactiveDofs));
@@ -255,15 +266,16 @@ void TrajectoryTaskGeneric<T>::selectUnactiveJoints(
     const std::vector<std::string> & unactiveJointsName,
     const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
 {
+  ensureHasJoints(robots.robot(rIndex), unactiveJointsName, "[selectUnactiveJoints]");
   if(inSolver_)
   {
     removeFromSolver(solver);
-    selectUnactiveJoints(unactiveJointsName, unactiveDofs);
+    selectUnactiveJoints(unactiveJointsName, unactiveDofs, false);
     addToSolver(solver);
   }
   else
   {
-    selectUnactiveJoints(unactiveJointsName, unactiveDofs);
+    selectUnactiveJoints(unactiveJointsName, unactiveDofs, false);
   }
 }
 

--- a/include/mc_tasks/TrajectoryTaskGeneric.hpp
+++ b/include/mc_tasks/TrajectoryTaskGeneric.hpp
@@ -211,7 +211,7 @@ void TrajectoryTaskGeneric<T>::selectActiveJoints(
   }
   if(checkJoints)
   {
-    ensureHasJoints(robots.robot(rIndex), activeJointsName, "[selectActiveJoints]");
+    ensureHasJoints(robots.robot(rIndex), activeJointsName, "[" + name() + "::selectActiveJoints]");
   }
   selectorT_ = std::make_shared<tasks::qp::JointsSelector>(tasks::qp::JointsSelector::ActiveJoints(
       robots.mbs(), static_cast<int>(rIndex), errorT.get(), activeJointsName, activeDofs));
@@ -225,7 +225,7 @@ void TrajectoryTaskGeneric<T>::selectActiveJoints(
     const std::vector<std::string> & activeJointsName,
     const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
 {
-  ensureHasJoints(robots.robot(rIndex), activeJointsName, "[selectActiveJoints]");
+  ensureHasJoints(robots.robot(rIndex), activeJointsName, "[" + name() + "::selectActiveJoints]");
   if(inSolver_)
   {
     removeFromSolver(solver);
@@ -246,13 +246,15 @@ void TrajectoryTaskGeneric<T>::selectUnactiveJoints(
 {
   if(inSolver_)
   {
-    LOG_WARNING("selectUnactiveJoints(names) ignored: use selectUnactiveJoints(solver, names) for a task already added "
-                "to the solver");
+    LOG_WARNING(
+        name()
+        + "::selectUnactiveJoints(names) ignored: use selectUnactiveJoints(solver, names) for a task already added "
+          "to the solver");
     return;
   }
   if(checkJoints)
   {
-    ensureHasJoints(robots.robot(rIndex), unactiveJointsName, "[selectUnactiveJoints]");
+    ensureHasJoints(robots.robot(rIndex), unactiveJointsName, "[" + name() + "::selectUnActiveJoints]");
   }
   selectorT_ = std::make_shared<tasks::qp::JointsSelector>(tasks::qp::JointsSelector::UnactiveJoints(
       robots.mbs(), static_cast<int>(rIndex), errorT.get(), unactiveJointsName, unactiveDofs));
@@ -266,7 +268,7 @@ void TrajectoryTaskGeneric<T>::selectUnactiveJoints(
     const std::vector<std::string> & unactiveJointsName,
     const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
 {
-  ensureHasJoints(robots.robot(rIndex), unactiveJointsName, "[selectUnactiveJoints]");
+  ensureHasJoints(robots.robot(rIndex), unactiveJointsName, "[" + name() + "::selectUnActiveJoints]");
   if(inSolver_)
   {
     removeFromSolver(solver);
@@ -285,7 +287,8 @@ void TrajectoryTaskGeneric<T>::resetJointsSelector()
   if(inSolver_)
   {
     LOG_WARNING(
-        "resetJointsSelector() ignored: use resetJointsSelector(solver) for a task already added to the solver");
+        name()
+        + "::resetJointsSelector() ignored: use resetJointsSelector(solver) for a task already added to the solver");
     return;
   }
   selectorT_ = nullptr;

--- a/src/mc_tasks/ComplianceTask.cpp
+++ b/src/mc_tasks/ComplianceTask.cpp
@@ -140,6 +140,7 @@ void ComplianceTask::selectActiveJoints(mc_solver::QPSolver & solver,
                                         const std::vector<std::string> & activeJointsName,
                                         const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
 {
+  ensureHasJoints(robots_.robot(rIndex_), activeJointsName, "[ComplianceTask::selectActiveJoints]");
   efTask_->selectActiveJoints(solver, activeJointsName, activeDofs);
 }
 
@@ -147,6 +148,7 @@ void ComplianceTask::selectUnactiveJoints(mc_solver::QPSolver & solver,
                                           const std::vector<std::string> & unactiveJointsName,
                                           const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
 {
+  ensureHasJoints(robots_.robot(rIndex_), unactiveJointsName, "[ComplianceTask::selectUnactiveJoints]");
   efTask_->selectUnactiveJoints(solver, unactiveJointsName, unactiveDofs);
 }
 

--- a/src/mc_tasks/ComplianceTask.cpp
+++ b/src/mc_tasks/ComplianceTask.cpp
@@ -140,7 +140,7 @@ void ComplianceTask::selectActiveJoints(mc_solver::QPSolver & solver,
                                         const std::vector<std::string> & activeJointsName,
                                         const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
 {
-  ensureHasJoints(robots_.robot(rIndex_), activeJointsName, "[ComplianceTask::selectActiveJoints]");
+  ensureHasJoints(robots_.robot(rIndex_), activeJointsName, "[" + name() + "::selectActiveJoints]");
   efTask_->selectActiveJoints(solver, activeJointsName, activeDofs);
 }
 
@@ -148,7 +148,7 @@ void ComplianceTask::selectUnactiveJoints(mc_solver::QPSolver & solver,
                                           const std::vector<std::string> & unactiveJointsName,
                                           const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
 {
-  ensureHasJoints(robots_.robot(rIndex_), unactiveJointsName, "[ComplianceTask::selectUnactiveJoints]");
+  ensureHasJoints(robots_.robot(rIndex_), unactiveJointsName, "[" + name() + "::selectUnActiveJoints]");
   efTask_->selectUnactiveJoints(solver, unactiveJointsName, unactiveDofs);
 }
 

--- a/src/mc_tasks/EndEffectorTask.cpp
+++ b/src/mc_tasks/EndEffectorTask.cpp
@@ -106,6 +106,7 @@ void EndEffectorTask::selectActiveJoints(mc_solver::QPSolver & solver,
                                          const std::vector<std::string> & activeJointsName,
                                          const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
 {
+  ensureHasJoints(robots.robot(robotIndex), activeJointsName, "[EndEffectorTask::selectActiveJoints]");
   positionTask->selectActiveJoints(solver, activeJointsName, activeDofs);
   orientationTask->selectActiveJoints(solver, activeJointsName, activeDofs);
 }
@@ -114,6 +115,7 @@ void EndEffectorTask::selectUnactiveJoints(mc_solver::QPSolver & solver,
                                            const std::vector<std::string> & unactiveJointsName,
                                            const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
 {
+  ensureHasJoints(robots.robot(robotIndex), unactiveJointsName, "[EndEffectorTask::selectUnactiveJoints]");
   positionTask->selectUnactiveJoints(solver, unactiveJointsName, unactiveDofs);
   orientationTask->selectUnactiveJoints(solver, unactiveJointsName, unactiveDofs);
 }

--- a/src/mc_tasks/EndEffectorTask.cpp
+++ b/src/mc_tasks/EndEffectorTask.cpp
@@ -106,7 +106,7 @@ void EndEffectorTask::selectActiveJoints(mc_solver::QPSolver & solver,
                                          const std::vector<std::string> & activeJointsName,
                                          const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs)
 {
-  ensureHasJoints(robots.robot(robotIndex), activeJointsName, "[EndEffectorTask::selectActiveJoints]");
+  ensureHasJoints(robots.robot(robotIndex), activeJointsName, "[" + name() + "::selectActiveJoints]");
   positionTask->selectActiveJoints(solver, activeJointsName, activeDofs);
   orientationTask->selectActiveJoints(solver, activeJointsName, activeDofs);
 }
@@ -115,7 +115,7 @@ void EndEffectorTask::selectUnactiveJoints(mc_solver::QPSolver & solver,
                                            const std::vector<std::string> & unactiveJointsName,
                                            const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs)
 {
-  ensureHasJoints(robots.robot(robotIndex), unactiveJointsName, "[EndEffectorTask::selectUnactiveJoints]");
+  ensureHasJoints(robots.robot(robotIndex), unactiveJointsName, "[" + name() + "::selectUnActiveJoints]");
   positionTask->selectUnactiveJoints(solver, unactiveJointsName, unactiveDofs);
   orientationTask->selectUnactiveJoints(solver, unactiveJointsName, unactiveDofs);
 }

--- a/src/mc_tasks/PostureTask.cpp
+++ b/src/mc_tasks/PostureTask.cpp
@@ -43,7 +43,7 @@ void PostureTask::selectActiveJoints(mc_solver::QPSolver & solver,
                                      const std::vector<std::string> & activeJointsName,
                                      const std::map<std::string, std::vector<std::array<int, 2>>> &)
 {
-  ensureHasJoints(robots_.robot(rIndex_), activeJointsName, "[PostureTask::selectActiveJoints]");
+  ensureHasJoints(robots_.robot(rIndex_), activeJointsName, "[" + name() + "::selectActiveJoints]");
   std::vector<std::string> unactiveJoints = {};
   for(const auto & j : robots_.robot(rIndex_).mb().joints())
   {
@@ -59,7 +59,7 @@ void PostureTask::selectUnactiveJoints(mc_solver::QPSolver & solver,
                                        const std::vector<std::string> & unactiveJointsName,
                                        const std::map<std::string, std::vector<std::array<int, 2>>> &)
 {
-  ensureHasJoints(robots_.robot(rIndex_), unactiveJointsName, "[PostureTask::selectUnActiveJoints]");
+  ensureHasJoints(robots_.robot(rIndex_), unactiveJointsName, "[" + name() + "::selectUnActiveJoints]");
   std::vector<tasks::qp::JointStiffness> jsv;
   for(const auto & j : unactiveJointsName)
   {

--- a/src/mc_tasks/PostureTask.cpp
+++ b/src/mc_tasks/PostureTask.cpp
@@ -43,6 +43,7 @@ void PostureTask::selectActiveJoints(mc_solver::QPSolver & solver,
                                      const std::vector<std::string> & activeJointsName,
                                      const std::map<std::string, std::vector<std::array<int, 2>>> &)
 {
+  ensureHasJoints(robots_.robot(rIndex_), activeJointsName, "[PostureTask::selectActiveJoints]");
   std::vector<std::string> unactiveJoints = {};
   for(const auto & j : robots_.robot(rIndex_).mb().joints())
   {
@@ -58,6 +59,7 @@ void PostureTask::selectUnactiveJoints(mc_solver::QPSolver & solver,
                                        const std::vector<std::string> & unactiveJointsName,
                                        const std::map<std::string, std::vector<std::array<int, 2>>> &)
 {
+  ensureHasJoints(robots_.robot(rIndex_), unactiveJointsName, "[PostureTask::selectUnActiveJoints]");
   std::vector<tasks::qp::JointStiffness> jsv;
   for(const auto & j : unactiveJointsName)
   {


### PR DESCRIPTION
Ensures that joint names are valid before passing them to tasks' `JointSelector`.

Fixes https://gite.lirmm.fr/multi-contact/mc_rtc/issues/151