### PR TITLE
Improvements to build_and_install (interfaces, user configuration)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         then
           ./build_and_install.sh --user-input false --with-python-support false --build-testing false --build-benchmarks true
         else
-          ./build_and_install.sh --user-input false --build-benchmarks true
+          ./build_and_install.sh --user-input false --build-benchmarks true --allow-root true
         fi
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master

--- a/.github/workflows/docker/Dockerfile
+++ b/.github/workflows/docker/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update -qq && apt-get install -qq cmake cmake-data cython cython3 dh
 RUN apt-get install -qq python-pip || (curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py && python get-pip.py)
 
 COPY source /source
-RUN cd /source/utils && ./build_and_install.sh --user-input false --build-benchmarks true
+RUN cd /source/utils && ./build_and_install.sh --user-input false --build-benchmarks true --allow-root true

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build/
 utils/mc_log_gui/*.png
 compile_commands.json
 .vscode/
+utils/build_and_install_user_config.sh

--- a/doc/tutorials/introduction/installation-guide.md
+++ b/doc/tutorials/introduction/installation-guide.md
@@ -71,7 +71,7 @@ Note: it should also work and compile with Visual Studio 2017. However, only Vis
 1. Clone the [mc\_rtc](https://github.com/jrl-umi3218/mc_rtc) repository;
 2. Go into the mc\_rtc directory and update submodules `git submodule update --init`;
 3. Go into the `utils` directory and locate the file named `build_and_install.sh`;
-4. Edit some of the options to your liking: `INSTALL_PREFIX`, `WITH_ROS_SUPPORT`, `ROS_DISTRO`. On Ubuntu, ROS will be installed if you enable ROS support and it was not already installed. Otherwise, you are required to install ROS by yourself before attempting to install mc\_rtc with ROS support;
+4. [optional] Create a custom configuration file `build_and_install_user_config.sh` and override some of the default options provided in `build_and_install_default_config.sh`: `INSTALL_PREFIX`, `WITH_ROS_SUPPORT`, `ROS_DISTRO`. On Ubuntu, ROS will be installed if you enable ROS support and it was not already installed. Otherwise, you are required to install ROS by yourself before attempting to install mc\_rtc with ROS support;
 5. Run `./build_and_install.sh`
 
 The script will take care of installing the required dependencies, clone all required source codes, build and install them. This may take a while.

--- a/doc/tutorials/introduction/installation-guide.md
+++ b/doc/tutorials/introduction/installation-guide.md
@@ -71,7 +71,11 @@ Note: it should also work and compile with Visual Studio 2017. However, only Vis
 1. Clone the [mc\_rtc](https://github.com/jrl-umi3218/mc_rtc) repository;
 2. Go into the mc\_rtc directory and update submodules `git submodule update --init`;
 3. Go into the `utils` directory and locate the file named `build_and_install.sh`;
-4. [optional] Create a custom configuration file `build_and_install_user_config.sh` and override some of the default options provided in `build_and_install_default_config.sh`: `INSTALL_PREFIX`, `WITH_ROS_SUPPORT`, `ROS_DISTRO`. On Ubuntu, ROS will be installed if you enable ROS support and it was not already installed. Otherwise, you are required to install ROS by yourself before attempting to install mc\_rtc with ROS support;
+4. [optional] Create a custom configuration file `build_and_install_user_config.sh` (overrides the corresponding variables from the default configuration `build_and_install_default_config.sh`)
+```sh
+cp build_and_install_user_config.sample.sh build_and_install_user_config.sh
+```
+5. [optional] Edit the `build_and_install_user_config.sh` and edit the options to your liking: `INSTALL_PREFIX`, `WITH_ROS_SUPPORT`, `ROS_DISTRO`. On Ubuntu, ROS will be installed if you enable ROS support and it was not already installed. Otherwise, you are required to install ROS by yourself before attempting to install mc\_rtc with ROS support;
 5. Run `./build_and_install.sh`
 
 The script will take care of installing the required dependencies, clone all required source codes, build and install them. This may take a while.

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -760,7 +760,7 @@ check_and_clone_git_dependency()
       # Ensure that the remote is correct
       echo "-- Checking remote URL"
       remote="`git remote get-url origin`"
-      if [ "$remote" != "$git_dep_uri" ]
+      if  [[ "$remote" == *"github"* ]] && [[ $git_dep_uri != *"github"* ]] ||  [[ "$remote" == *"gite"* ]] && [[ $git_dep_uri != *"gite"* ]]
       then
         echo_log "-- The remote has changed for $repo, previous remote: $remote, desired remote $git_dep_uri."
 

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -19,7 +19,7 @@ readonly PYTHON_VERSION=`python -c 'import sys; print("{}.{}".format(sys.version
 
 echo_log()
 {
-  echo $1 | $TEE -a $BUILD_LOGFILE
+  echo "$1" | $TEE -a $BUILD_LOGFILE
 }
 
 exec_log()
@@ -70,17 +70,20 @@ else
 fi
 
 readonly HELP_STRING="$(basename $0) [OPTIONS] ...
-    --help                     (-h)               : print this help
-    --install-prefix           (-i) PATH          : the directory used to install everything           (default $INSTALL_PREFIX)
-    --source-dir               (-s) PATH          : the directory used to clone everything             (default $SOURCE_DIR)
-    --build-type                    Type          : the build type to use                              (default $BUILD_TYPE)
-    --build-testing                 {true, false} : whether to build and run unit tests                (default $BUILD_TESTING)
-    --build-benchmarks              {true, false} : whether to build and run benchmarks                (default $BUILD_BENCHMARKS)
-    --build-core               (-j) N             : number of cores used for building                  (default $BUILD_CORE)
-    --with-lssol                                  : enable LSSOL (requires multi-contact group access) (default $WITH_LSSOL)
-    --with-hrp2                                   : enable HRP2 (requires mc-hrp2 group access)        (default $WITH_HRP2)
-    --with-hrp4                                   : enable HRP4 (requires mc-hrp4 group access)        (default $WITH_HRP4)
-    --with-hrp5                                   : enable HRP5 (requires mc-hrp5 group access)        (default $WITH_HRP5)
+    --help                (-h)               : print this help
+    --install-prefix      (-i) PATH          : the directory used to install everything                (default $INSTALL_PREFIX)
+    --source-dir          (-s) PATH          : the directory used to clone everything                  (default $SOURCE_DIR)
+    --build-type               Type          : the build type to use                                   (default $BUILD_TYPE)
+    --build-testing            {true, false} : whether to build and run unit tests                     (default $BUILD_TESTING)
+    --build-benchmarks         {true, false} : whether to build and run benchmarks                     (default $BUILD_BENCHMARKS)
+    --build-core          (-j) N             : number of cores used for building                       (default $BUILD_CORE)
+    --with-lssol                             : enable LSSOL (requires multi-contact group access)      (default $WITH_LSSOL)
+    --with-hrp2                              : enable HRP2 (requires mc-hrp2 group access)             (default $WITH_HRP2)
+    --with-hrp4                              : enable HRP4 (requires mc-hrp4 group access)             (default $WITH_HRP4)
+    --with-hrp4j                             : enable HRP4J (requires mc-hrp4 group access)            (default $WITH_HRP4J)
+    --with-hrp5                              : enable HRP5 (requires mc-hrp5 group access)             (default $WITH_HRP5)
+    --with-mc_openrtm                        : enable the mc_openrtm interface (requires hrpsys-base)  (default $WITH_MC_OPENRTM)
+    --with-mc_udp                            : enable the mc_udp interface (requires hrpsys-base)      (default $WITH_MC_UDP)
     --with-python-support           {true, false} : whether to build with Python support               (default $WITH_PYTHON_SUPPORT)
     --python-user-install           {true, false} : whether to install Python bindings with user       (default $PYTHON_USER_INSTALL)
     --python-force-python2          {true, false} : whether to enforce the use of Python 2             (default $PYTHON_FORCE_PYTHON2)
@@ -178,10 +181,28 @@ do
         check_true_false --with-hrp4 "$WITH_HRP4"
         ;;
 
+        --with-hrp4j)
+        i=$(($i+1))
+        WITH_HRP4J="${!i}"
+        check_true_false --with-hrp4j "$WITH_HRP4J"
+        ;;
+
         --with-hrp5)
         i=$(($i+1))
         WITH_HRP5="${!i}"
         check_true_false --with-hrp5 "$WITH_HRP5"
+        ;;
+
+        --with-mc_udp)
+        i=$(($i+1))
+        WITH_MC_UDP="${!i}"
+        check_true_false --with-mc_udp "$WITH_MC_UDP"
+        ;;
+
+        --with-mc_openrtm)
+        i=$(($i+1))
+        WITH_MC_OPENRTM="${!i}"
+        check_true_false --with-mc_openrtm "$WITH_MC_OPENRTM"
         ;;
 
         --build-type)
@@ -349,7 +370,12 @@ echo_log "   CLONE_ONLY=$CLONE_ONLY"
 echo_log "   WITH_LSSOL=$WITH_LSSOL"
 echo_log "   WITH_HRP2=$WITH_HRP2"
 echo_log "   WITH_HRP4=$WITH_HRP4"
+echo_log "   WITH_HRP4J=$WITH_HRP4J"
 echo_log "   WITH_HRP5=$WITH_HRP5"
+echo_log "   WITH_MC_UDP=$WITH_MC_UDP"
+echo_log "   MC_UDP_INSTALL_PREFIX=$MC_UDP_INSTALL_PREFIX"
+echo_log "   WITH_MC_OPENRTM=$WITH_MC_OPENRTM"
+echo_log "   MC_OPENRTM_INSTALL_PREFIX=$MC_OPENRTM_INSTALL_PREFIX"
 echo_log "   SKIP_UPDATE=$SKIP_UPDATE"
 echo_log "   SKIP_DIRTY_UPDATE=$SKIP_DIRTY_UPDATE"
 echo_log "   BUILD_LOGFILE=$BUILD_LOGFILE"
@@ -428,7 +454,12 @@ readonly CLONE_ONLY
 readonly WITH_LSSOL
 readonly WITH_HRP2
 readonly WITH_HRP4
+readonly WITH_HRP4J
 readonly WITH_HRP5
+readonly WITH_MC_OPENRTM
+readonly MC_OPENRTM_INSTALL_PREFIX
+readonly WITH_MC_UDP
+readonly MC_UDP_INSTALL_PREFIX
 readonly SKIP_UPDATE
 readonly SKIP_DIRTY_UPDATE
 readonly BUILD_LOGFILE
@@ -451,7 +482,12 @@ echo_log "   CLONE_ONLY=$CLONE_ONLY"
 echo_log "   WITH_LSSOL=$WITH_LSSOL"
 echo_log "   WITH_HRP2=$WITH_HRP2"
 echo_log "   WITH_HRP4=$WITH_HRP4"
+echo_log "   WITH_HRP4J=$WITH_HRP4J"
 echo_log "   WITH_HRP5=$WITH_HRP5"
+echo_log "   WITH_MC_UDP=$WITH_MC_UDP"
+echo_log "   MC_UDP_INSTALL_PREFIX=$MC_UDP_INSTALL_PREFIX"
+echo_log "   WITH_MC_OPENRTM=$WITH_MC_OPENRTM"
+echo_log "   MC_OPENRTM_INSTALL_PREFIX=$MC_OPENRTM_INSTALL_PREFIX"
 echo_log "   SKIP_UPDATE=$SKIP_UPDATE"
 echo_log "   SKIP_DIRTY_UPDATE=$SKIP_DIRTY_UPDATE"
 echo_log "   BUILD_LOGFILE=$BUILD_LOGFILE"
@@ -721,6 +757,33 @@ check_and_clone_git_dependency()
     echo_log "-- [OK] Found local repository for ${git_dep} in ${repo_dir}"
 
     if check_clean_work_tree; then
+      # Ensure that the remote is correct
+      echo "-- Checking remote URL"
+      remote="`git remote get-url origin`"
+      if [ "$remote" != "$git_dep_uri" ]
+      then
+        echo_log "-- The remote has changed for $repo, previous remote: $remote, desired remote $git_dep_uri."
+
+        if $ASK_USER_INPUT
+        then
+          read -r -p "--> Would you like to update to the new remote (warning this will overwrite the local master branch)? [y/N] " response
+          if [[ "$response" =~ ^([yY][eE][sS]|[yY])$ ]]
+          then
+            echo_log "-- Updating the remote url to $git_dep_uri"
+            git remote set-url origin $git_dep_uri
+            git remote update origin
+            exit_if_error "Failed to update the remote uri to $git_dep_uri"
+            git fetch origin
+            exit_if_error "Failed to fetch the remote uri to $git_dep_uri"
+            git reset --hard origin/master
+            exit_if_error "Failed to update to the the remote's master branch (new remote: $git_dep_uri)"
+          else
+            echo_log "-- Installation stopped because the locate remote $remote does not match the local remote uri ."
+            echo_log "   Please manually update the remote to $git_dep_uri and rerun the script."
+            exit_failure
+          fi
+        fi
+      fi
       prev_commit="`git rev-parse HEAD`"
       echo_log "-- [OK] repository is clean"
       echo_log "-- Attempting to update local repository from remote branch ${git_dep_branch}..."
@@ -808,6 +871,20 @@ then
   echo_log "-- [OK] Successfully cloned and updated the robot module $git_dep to $repo_dir"
 fi
 
+if $WITH_HRP4J
+then
+  if $WITH_ROS_SUPPORT
+  then
+    check_and_clone_git_dependency git@gite.lirmm.fr:mc-hrp4/hrp4j_description $CATKIN_DATA_WORKSPACE_SRC
+    echo_log "-- [OK] Successfully cloned and updated the robot description to $git_dep to $repo_dir (catkin)"
+  else
+    check_and_clone_git_dependency git@gite.lirmm.fr:mc-hrp4/hrp4j_description $SOURCE_DIR
+    echo_log "-- [OK] Successfully cloned and updated the robot description $git_dep to $repo_dir (no catkin)"
+  fi
+  check_and_clone_git_dependency git@gite.lirmm.fr:mc-hrp4/mc_hrp4j $SOURCE_DIR
+  echo_log "-- [OK] Successfully cloned and updated the robot module $git_dep to $repo_dir"
+fi
+
 if $WITH_HRP5
 then
   if $WITH_ROS_SUPPORT
@@ -820,6 +897,18 @@ then
   fi
   check_and_clone_git_dependency git@gite.lirmm.fr:mc-hrp5/mc_hrp5_p $SOURCE_DIR
   echo_log "-- [OK] Successfully cloned and updated the robot module $git_dep to $repo_dir"
+fi
+
+if $WITH_MC_UDP
+then
+  check_and_clone_git_dependency jrl-umi3218/mc_udp $SOURCE_DIR
+  echo_log "-- [OK] Successfully cloned and updated the interface $git_dep to $repo_dir"
+fi
+
+if $WITH_MC_OPENRTM
+then
+  check_and_clone_git_dependency jrl-umi3218/mc_openrtm $SOURCE_DIR
+  echo_log "-- [OK] Successfully cloned and updated the interface $git_dep to $repo_dir"
 fi
 
 echo_log "-- [OK] All extra repositiories have been successfully cloned or updated"
@@ -860,6 +949,9 @@ restore_path()
 
 build_project()
 {
+  # Build and install new version
+  exec_log cmake --build . --config ${BUILD_TYPE}
+  exit_if_error "[ERROR] Build failed for $1"
   # Uninstall previously installed files
   if [ -f install_manifest.txt ]
   then
@@ -869,9 +961,6 @@ build_project()
       echo_log "-- [WARNING] Uninstallation failed for $1"
     fi
   fi
-  # Build and install new version
-  exec_log cmake --build . --config ${BUILD_TYPE}
-  exit_if_error "[ERROR] Build failed for $1"
   exec_log ${SUDO_CMD} cmake --build . --target install --config ${BUILD_TYPE}
   exit_if_error "-- [ERROR] Installation failed for $1"
 }
@@ -920,7 +1009,12 @@ build_git_dependency_configure_and_build()
   then
     hide_sh
   fi
-  exec_log cmake .. -DCMAKE_INSTALL_PREFIX:STRING="$INSTALL_PREFIX" \
+  custom_install_prefix=$INSTALL_PREFIX
+  if [ ! -z "$2" ]
+  then
+    custom_install_prefix="$2"
+  fi
+  exec_log cmake .. -DCMAKE_INSTALL_PREFIX:STRING="$custom_install_prefix" \
                     -DPYTHON_BINDING:BOOL=${WITH_PYTHON_SUPPORT} \
                     -DPYTHON_BINDING_USER_INSTALL:BOOL=${PYTHON_USER_INSTALL} \
                     -DPYTHON_BINDING_FORCE_PYTHON2:BOOL=${PYTHON_FORCE_PYTHON2} \
@@ -953,7 +1047,7 @@ build_git_dependency_no_test()
   echo_log "-- Building git dependency $1 (no test)"
   OLD_CMAKE_OPTIONS="${CMAKE_ADDITIONAL_OPTIONS}"
   export CMAKE_ADDITIONAL_OPTIONS="${OLD_CMAKE_OPTIONS} -DBUILD_TESTING:BOOL=OFF"
-  build_git_dependency_configure_and_build $1
+  build_git_dependency_configure_and_build $1 $2
   export CMAKE_ADDITIONAL_OPTIONS="${OLD_CMAKE_OPTIONS}"
 }
 
@@ -1024,7 +1118,7 @@ echo_log "====================="
 echo_log ""
 
 cd $mc_rtc_dir
-git remote update
+git remote update origin
 current_commit=`git rev-parse HEAD`
 current_branch_name="`git rev-parse --abbrev-ref HEAD`"
 remote_commit=`git rev-parse master@{upstream}`
@@ -1129,6 +1223,18 @@ then
   echo_log "-- [OK] Successfully built the robot module $git_dep"
 fi
 
+if $WITH_HRP4J
+then
+  echo_log "-- Installing with HRP4J robot support"
+  if ! $WITH_ROS_SUPPORT
+  then
+    build_git_dependency git@gite.lirmm.fr:mc-hrp4/hrp4j
+    echo_log "-- [OK] Successfully built the robot description $git_dep (no catkin)"
+  fi
+  build_git_dependency git@gite.lirmm.fr:mc-hrp4/mc_hrp4j
+  echo_log "-- [OK] Successfully built the robot module $git_dep"
+fi
+
 if $WITH_HRP5
 then
   echo_log "-- Installing with HRP5 robot support"
@@ -1139,6 +1245,20 @@ then
   fi
   build_git_dependency git@gite.lirmm.fr:mc-hrp5/mc_hrp5_p
   echo_log "-- [OK] Successfully built the robot module $git_dep"
+fi
+
+if $WITH_MC_UDP
+then
+  echo_log "-- Installing with mc_udp interface support"
+  build_git_dependency_no_test jrl-umi3218/mc_udp $MC_UDP_INSTALL_PREFIX
+  echo_log "-- [OK] Successfully built the interface $git_dep"
+fi
+
+if $WITH_MC_OPENRTM
+then
+  echo_log "-- Installing with mc_udp interface support"
+  build_git_dependency_no_test jrl-umi3218/mc_openrtm $MC_OPENRTM_INSTALL_PREFIX
+  echo_log "-- [OK] Successfully built the interface $git_dep"
 fi
 
 echo_log "-- [SUCCESS] All extra dedencencies have been installed"

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -854,8 +854,7 @@ restore_path()
 
 build_project()
 {
-  exec_log cmake --build . --config ${BUILD_TYPE}
-  exit_if_error "[ERROR] Build failed for $1"
+  # Uninstall previously installed files
   if [ -f install_manifest.txt ]
   then
     exec_log ${SUDO_CMD} cmake --build . --target uninstall --config ${BUILD_TYPE}
@@ -864,6 +863,9 @@ build_project()
       echo_log "-- [WARNING] Uninstallation failed for $1"
     fi
   fi
+  # Build and install new version
+  exec_log cmake --build . --config ${BUILD_TYPE}
+  exit_if_error "[ERROR] Build failed for $1"
   exec_log ${SUDO_CMD} cmake --build . --target install --config ${BUILD_TYPE}
   exit_if_error "-- [ERROR] Installation failed for $1"
 }

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -85,6 +85,12 @@ mc_rtc_extra_steps()
   true
 }
 
+if [[ $(id -u) -eq 0 ]]
+then
+  echo_log "Please run this script as a non-root user. sudo permission will be asked where necessary."
+  exit_failure
+fi
+
 readonly HELP_STRING="$(basename $0) [OPTIONS] ...
     --help                     (-h)               : print this help
     --install-prefix           (-i) PATH          : the directory used to install everything           (default $INSTALL_PREFIX)

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -11,6 +11,12 @@ shopt -s expand_aliases
 #  --  Configuration --  #
 ##########################
 
+readonly this_dir=`cd $(dirname $0); pwd`
+readonly mc_rtc_dir=`cd $this_dir/..; pwd`
+readonly PYTHON_VERSION=`python -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))'`
+
+. "$this_dir/build_and_install_default_config.sh"
+
 echo_log()
 {
   echo $1 | $TEE -a $BUILD_LOGFILE
@@ -45,17 +51,22 @@ mc_rtc_extra_steps()
   true
 }
 
-readonly this_dir=`cd $(dirname $0); pwd`
-readonly mc_rtc_dir=`cd $this_dir/..; pwd`
-readonly PYTHON_VERSION=`python -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))'`
+echo_log ""
+echo_log "========================================"
+echo_log "== mc_rtc build_and_install.sh script =="
+echo_log "========================================"
+echo_log ""
 
-. "$this_dir/build_and_install_default_config.sh"
+
+echo_log "-- Loaded default configuration from $this_dir/build_and_install_default_config.sh"
 if [ -f "$this_dir/build_and_install_user_config.sh" ]; then
   . "$this_dir/build_and_install_user_config.sh"
-  echo_log "Loaded user configuration from $this_dir/build_and_install_user_config.sh"
+  echo_log "-- Loaded user configuration from $this_dir/build_and_install_user_config.sh"
 else
-  echo_log "No user configuration file $this_dir/build_and_install_user_config.sh provided, using default configuration"
-  echo_log "If you wish to create a custom user configuration, you may overwrite any of the variables defined in $this_dir/build_and_install_default_config.sh with values of your choice"
+  echo_log "-- No user configuration file $this_dir/build_and_install_user_config.sh provided, using default configuration from $this_dir/build_and_install_default_config.sh"
+  echo "   If you wish to create a custom user configuration:"
+  echo "     - Copy the sample configuration: cp $this_dir/build_and_install_user_config.sample.sh $this_dir/build_and_install_user_config.sh"
+  echo "     - Edit the options to your liking"
 fi
 
 readonly HELP_STRING="$(basename $0) [OPTIONS] ...
@@ -319,13 +330,8 @@ touch $BUILD_LOGFILE
 exit_if_error "-- [ERROR] Could not create log file $BUILD_LOGFILE"
 ln -sf $BUILD_LOGFILE "$LOG_PATH/build_and_install_warnings-latest.log"
 
+echo_log "-- Log file will be written to $BUILD_LOGFILE "
 echo_log ""
-echo_log "========================================"
-echo_log "== mc_rtc build_and_install.sh script =="
-echo_log "========================================"
-echo_log ""
-echo_log "-- Build and install log for mc_rtc generated on `date +%Y-%m-%d-%H:%M:%S`"
-echo "-- Log file will be written to $BUILD_LOGFILE "
 echo_log "-- Requested installation with the following options:"
 echo_log "   INSTALL_PREFIX=$INSTALL_PREFIX"
 echo_log "   SOURCE_DIR=$SOURCE_DIR"

--- a/utils/build_and_install_default_config.sh
+++ b/utils/build_and_install_default_config.sh
@@ -1,5 +1,5 @@
 #default settings
-export SOURCE_DIR=`cd $(dirname $0)/../; pwd`
+export SOURCE_DIR=`cd $(dirname $0)/../../; pwd`
 export INSTALL_PREFIX="/usr/local"
 export WITH_ROS_SUPPORT="true"
 export WITH_PYTHON_SUPPORT="true"
@@ -10,7 +10,12 @@ export PYTHON_BUILD_PYTHON2_AND_PYTHON3="false"
 export WITH_LSSOL="false"
 export WITH_HRP2="false"
 export WITH_HRP4="false"
+export WITH_HRP4J="false"
 export WITH_HRP5="false"
+export WITH_MC_OPENRTM="false"
+export MC_OPENRTM_INSTALL_PREFIX="$INSTALL_PREFIX"
+export WITH_MC_UDP="false"
+export MC_UDP_INSTALL_PREFIX="$INSTALL_PREFIX"
 export BUILD_TYPE="RelWithDebInfo"
 export BUILD_TESTING="true"
 export BUILD_BENCHMARKS="false"

--- a/utils/build_and_install_default_config.sh
+++ b/utils/build_and_install_default_config.sh
@@ -1,0 +1,35 @@
+#default settings
+export SOURCE_DIR=`cd $(dirname $0)/../; pwd`
+export INSTALL_PREFIX="/usr/local"
+export WITH_ROS_SUPPORT="true"
+export WITH_PYTHON_SUPPORT="true"
+export PYTHON_USER_INSTALL="false"
+export PYTHON_FORCE_PYTHON2="false"
+export PYTHON_FORCE_PYTHON3="false"
+export PYTHON_BUILD_PYTHON2_AND_PYTHON3="false"
+export WITH_LSSOL="false"
+export WITH_HRP2="false"
+export WITH_HRP4="false"
+export WITH_HRP5="false"
+export BUILD_TYPE="RelWithDebInfo"
+export BUILD_TESTING="true"
+export BUILD_BENCHMARKS="false"
+export INSTALL_SYSTEM_DEPENDENCIES="true"
+export CLONE_ONLY="false"
+export SKIP_UPDATE="false"
+# This configuration option lets the script choose what to do when local git repositories are in
+# an unclean state (have local changes). The default false will stop the script with an error.
+# If true, the repository will be compiled as-is without trying to fetch the remote changes.
+export SKIP_DIRTY_UPDATE="false"
+if command -v nproc > /dev/null
+then
+   export BUILD_CORE=`nproc`
+else
+   export BUILD_CORE=`sysctl -n hw.ncpu`
+fi
+export CMAKE_BUILD_PARALLEL_LEVEL=${BUILD_CORE}
+export LOG_PATH="/tmp"
+export BUILD_LOGFILE="$LOG_PATH/build_and_install_warnings-`date +%Y-%m-%d-%H-%M-%S`.log"
+export ASK_USER_INPUT="true"
+export TEE=`which tee`
+export ALLOW_ROOT="false"

--- a/utils/build_and_install_user_config.sample.sh
+++ b/utils/build_and_install_user_config.sample.sh
@@ -1,0 +1,61 @@
+####################################################
+# build_and_install.sh user configuration settings #
+####################################################
+# The option defined here override the corresponding default values
+# defined in build_and_install_default_config.sh script
+# Please uncomment and edit the desired options.
+###################################################
+
+# Directory where mc_rtc dependencies will be cloned
+# Defaults to the parent directory of the mc_rtc repository folder
+# export SOURCE_DIR=`cd $(dirname $0)/../; pwd`
+
+# Path in which mc_rtc and its dependencies will be installed
+# Note if different from /usr/local, make sure to appropriately set the paths variables
+# The script will automatically inform you of the required paths after successful installation.
+# export INSTALL_PREFIX="/usr/local"
+
+##
+# Build type.
+# - For performance on the robots use "Release"
+# - For normal development, "RelWithDebInfo" should be fast enough on most machines
+##
+# export BUILD_TYPE="RelWithDebInfo"
+
+##
+# Number of parallel builds. Default: automatically detected
+##
+# export CMAKE_BUILD_PARALLEL_LEVEL=${BUILD_CORE}
+
+##
+# When true, installs the required global system dependencies (APT on ubuntu)
+##
+# export INSTALL_SYSTEM_DEPENDENCIES="true"
+
+##
+# Whether to build with ROS support
+# On Ubuntu, ROS will be installed if you enable ROS support and it was not already installed. Otherwise, you are required to install ROS by yourself before attempting to install mc_rtc with ROS support;
+##
+#export WITH_ROS_SUPPORT="true"
+
+##
+# Python settings
+##
+# export WITH_PYTHON_SUPPORT="true"
+# export PYTHON_USER_INSTALL="false"
+# export PYTHON_FORCE_PYTHON2="false"
+# export PYTHON_FORCE_PYTHON3="false"
+# export PYTHON_BUILD_PYTHON2_AND_PYTHON3="false"
+
+##
+# These repositories require additional permissions.
+# If you're allowed access, you can set those to true
+##
+# export WITH_LSSOL="false"
+# export WITH_HRP2="false"
+# export WITH_HRP4="false"
+# export WITH_HRP5="false"
+
+##
+# For additional options, please refer to build_and_install_default_config.sh
+##

--- a/utils/build_and_install_user_config.sample.sh
+++ b/utils/build_and_install_user_config.sample.sh
@@ -57,5 +57,17 @@
 # export WITH_HRP5="false"
 
 ##
+# Interfaces -- allows communication with the choreonoid simulator, and with the HRP robots.
+# Both mc_udp and mc_openrtm require hrpsys-base and its dependencies to be installed. The script does not
+# automatically install these dependencies, please install them manually before running the script.
+# In case choreonoid was installed in a different path than $INSTALL_PREFIX, set
+# MC_UDP_INSTALL_PREFIX and MC_OPENRTM_INSTALL_PREFIX to choreonoid's base installation path
+##
+# export WITH_MC_OPENRTM="false"
+# export MC_OPENRTM_INSTALL_PREFIX="$INSTALL_PREFIX"
+# export WITH_MC_UDP="false"
+# export MC_UDP_INSTALL_PREFIX="$INSTALL_PREFIX"
+
+##
 # For additional options, please refer to build_and_install_default_config.sh
 ##

--- a/utils/build_and_install_user_config.sample.sh
+++ b/utils/build_and_install_user_config.sample.sh
@@ -54,6 +54,7 @@
 # export WITH_LSSOL="false"
 # export WITH_HRP2="false"
 # export WITH_HRP4="false"
+# export WITH_HRP4J="false"
 # export WITH_HRP5="false"
 
 ##


### PR DESCRIPTION
This PR proposes the following improvements to the `build_and_install.sh` script:

- Prevent running the script as `root` user by default.
  Doing so causes unexpected issues down the line when attempting to use mc_rtc as a normal user. Notably if one tries to use mc_rtc as a normal user after the script succeeds: the GUI silently fails as it cannot recreate the IPC files in `/tmp`, the unit tests fail as the log files cannot be created, etc etc.
Now by default, the script will stop with an error if you attempt to run it as root. Use `ALLOW_ROOT=true` or `--allow-root true` if you still wish to install everything as root (typically CI/Docker).

- Introduces user configuration:
  - The default configuration options are defined in `build_and_install_default_config.sh`
  - They may be overridden by the corresponding options in `build_and_install_user_config.sh` (ignored by git)
  - A sample user configuration file `build_and_install_user_config.sample.sh` is provided
  - Users should copy this sample and edit the file:
```sh
cp build_and_install_user_config.sample.sh build_and_install_user_config.sh 
vim build_and_install_user_config.sh 
```
- Supports building the interfaces `mc_udp`, `mc_openrtm`. Note that the script does not install `hrpsys-base` automatically.
- Support for `mc_hrp4j`
- Checks that the remote uri is correct before pulling. (Tsuru ran into an issue as he still had the deprecated lirmm remote for mc_openrtm)

This should hopefully prevent users from forgetting to recompile the robot modules/interfaces in the future
