### PR TITLE
Simpler and safer device interface

### DIFF
--- a/include/mc_rbdyn/BodySensor.h
+++ b/include/mc_rbdyn/BodySensor.h
@@ -36,6 +36,31 @@ struct MC_RBDYN_DLLAPI BodySensor : public Device
     type_ = "BodySensor";
   }
 
+  BodySensor(const BodySensor & bs) : BodySensor(bs.name(), bs.parent(), bs.X_b_s())
+  {
+    position_ = bs.position_;
+    orientation_ = bs.orientation_;
+    linear_velocity_ = bs.linear_velocity_;
+    angular_velocity_ = bs.angular_velocity_;
+    acceleration_ = bs.acceleration_;
+  }
+
+  BodySensor & operator=(const BodySensor & bs)
+  {
+    name_ = bs.name_;
+    parent_ = bs.parent_;
+    X_p_s_ = bs.X_p_s_;
+    position_ = bs.position_;
+    orientation_ = bs.orientation_;
+    linear_velocity_ = bs.linear_velocity_;
+    angular_velocity_ = bs.angular_velocity_;
+    acceleration_ = bs.acceleration_;
+    return *this;
+  }
+
+  BodySensor(BodySensor &&) = default;
+  BodySensor & operator=(BodySensor &&) = default;
+
   ~BodySensor() noexcept override;
 
   /** Get the sensor's parent body name */

--- a/include/mc_rbdyn/Device.h
+++ b/include/mc_rbdyn/Device.h
@@ -56,6 +56,12 @@ struct MC_RBDYN_DLLAPI Device
     return parent_;
   }
 
+  /** Returns the transformation from the parent body to the device */
+  inline const sva::PTransformd & X_p_d() const
+  {
+    return X_p_s_;
+  }
+
   /** Returns the transformation from the parent body to the sensor */
   inline const sva::PTransformd & X_p_s() const
   {

--- a/include/mc_rbdyn/Device.h
+++ b/include/mc_rbdyn/Device.h
@@ -30,6 +30,12 @@ struct MC_RBDYN_DLLAPI Device
 {
   Device(const std::string & name, const std::string & parent, const sva::PTransformd & X_p_s);
 
+  Device(const Device &) = delete;
+  Device & operator=(const Device &) = delete;
+
+  Device(Device &&) = default;
+  Device & operator=(Device &&) = default;
+
   virtual ~Device() noexcept = default;
 
   /** Returns the name of the sensor */

--- a/include/mc_rbdyn/Device.h
+++ b/include/mc_rbdyn/Device.h
@@ -28,6 +28,13 @@ using SensorPtr = DevicePtr;
  */
 struct MC_RBDYN_DLLAPI Device
 {
+  /** Build a device not specifically attached to the robot
+   *
+   * When the Device becomes part of a Robot instance it is attached to the
+   * origin of the robot */
+  Device(const std::string & name);
+
+  /** Build a device attached to a specific body of the robot */
   Device(const std::string & name, const std::string & parent, const sva::PTransformd & X_p_s);
 
   Device(const Device &) = delete;
@@ -56,6 +63,12 @@ struct MC_RBDYN_DLLAPI Device
     return parent_;
   }
 
+  /** Change the parent body of the sensor */
+  inline void parent(const std::string & p)
+  {
+    parent_ = p;
+  }
+
   /** Returns the transformation from the parent body to the device */
   inline const sva::PTransformd & X_p_d() const
   {
@@ -68,9 +81,28 @@ struct MC_RBDYN_DLLAPI Device
     return X_p_s_;
   }
 
+  /** Change the parent to device transformation */
+  inline void X_p_d(const sva::PTransformd & pt)
+  {
+    X_p_s_ = pt;
+  }
+
+  /** Change the parent to sensor transformation */
+  inline void X_p_s(const sva::PTransformd & pt)
+  {
+    X_p_s_ = pt;
+  }
+
+  /** Returns the deviec position in the inertial frame (convenience function) */
+  inline sva::PTransformd X_0_d(const mc_rbdyn::Robot & robot) const
+  {
+    return X_0_s(robot);
+  }
+
   /** Returns the sensor position in the inertial frame (convenience function) */
   sva::PTransformd X_0_s(const mc_rbdyn::Robot & robot) const;
 
+  /** Perform a device copy */
   virtual DevicePtr clone() const = 0;
 
 protected:

--- a/include/mc_rbdyn/ForceSensor.h
+++ b/include/mc_rbdyn/ForceSensor.h
@@ -40,6 +40,13 @@ public:
    */
   ForceSensor(const std::string & name, const std::string & parentBodyName, const sva::PTransformd & X_p_f);
 
+  ForceSensor(const ForceSensor & fs);
+
+  ForceSensor & operator=(const ForceSensor & fs);
+
+  ForceSensor(ForceSensor &&) = default;
+  ForceSensor & operator=(ForceSensor &&) = default;
+
   /** Destructor */
   ~ForceSensor() noexcept override;
 

--- a/src/mc_rbdyn/Device.cpp
+++ b/src/mc_rbdyn/Device.cpp
@@ -5,6 +5,8 @@
 namespace mc_rbdyn
 {
 
+Device::Device(const std::string & name) : Device(name, "", sva::PTransformd::Identity()) {}
+
 Device::Device(const std::string & name, const std::string & parent, const sva::PTransformd & X_p_s)
 : type_(""), name_(name), parent_(parent), X_p_s_(X_p_s)
 {

--- a/src/mc_rbdyn/ForceSensor.cpp
+++ b/src/mc_rbdyn/ForceSensor.cpp
@@ -137,6 +137,26 @@ ForceSensor::ForceSensor(const std::string & name, const std::string & parentBod
   type_ = "ForceSensor";
 }
 
+ForceSensor::ForceSensor(const ForceSensor & fs) : ForceSensor(fs.name_, fs.parentBody(), fs.X_p_f())
+{
+  wrench_ = fs.wrench_;
+  *calibration_ = *fs.calibration_;
+}
+
+ForceSensor & ForceSensor::operator=(const ForceSensor & fs)
+{
+  if(&fs == this)
+  {
+    return *this;
+  }
+  name_ = fs.name_;
+  parent_ = fs.parent_;
+  X_p_s_ = fs.X_p_s_;
+  *calibration_ = *fs.calibration_;
+  wrench_ = fs.wrench_;
+  return *this;
+}
+
 ForceSensor::~ForceSensor() noexcept = default;
 
 void ForceSensor::loadCalibrator(const std::string & calib_file, const Eigen::Vector3d & gravity)

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -254,7 +254,11 @@ Robot::Robot(Robots & robots,
   devices_ = module_.devices();
   for(size_t i = 0; i < devices_.size(); ++i)
   {
-    const auto & d = devices_[i];
+    auto & d = devices_[i];
+    if(d->parent() == "")
+    {
+      d->parent(mb().body(0).name());
+    }
     devicesIndex_[d->name()] = i;
   }
 
@@ -1315,6 +1319,11 @@ void Robot::addDevice(DevicePtr device)
         "You cannot have multiple generic sensor with the same name in a robot");
   }
   devices_.push_back(std::move(device));
+  auto & d = devices_.back();
+  if(d->parent() == "")
+  {
+    d->parent(mb().body(0).name());
+  }
   devicesIndex_[device->name()] = devices_.size() - 1;
 }
 


### PR DESCRIPTION
This PR simplifies writing new devices extension:
- Allow to create a Device without specifying dummy values for the parent body and transformation, those are filled up when the device is created in the robot
- Make Device non-copiable by default