### PR TITLE
[mc_solver] Compute output torques if a DynamicsConstraint is added

### DIFF
--- a/include/mc_solver/QPSolver.h
+++ b/include/mc_solver/QPSolver.h
@@ -324,6 +324,9 @@ private:
   /** Holds MetaTask currently in the solver */
   std::vector<mc_tasks::MetaTask *> metaTasks_;
 
+  /** Holds dynamics constraint currently in the solver */
+  std::vector<mc_solver::DynamicsConstraint *> dynamicsConstraints_;
+
 private:
   /** The actual solver instance */
   tasks::qp::QPSolver solver;

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -210,7 +210,6 @@ bool MCController::run(mc_solver::FeedbackType fType)
     mc_rtc::log::error("QP failed to run()");
     return false;
   }
-  qpsolver->fillTorque(dynamicsConstraint);
   return true;
 }
 

--- a/src/mc_solver/QPSolver.cpp
+++ b/src/mc_solver/QPSolver.cpp
@@ -80,6 +80,10 @@ void QPSolver::addConstraintSet(ConstraintSet & cs)
   cs.addToSolver(robots().mbs(), solver);
   solver.updateConstrSize();
   solver.updateNrVars(robots().mbs());
+  if(dynamic_cast<DynamicsConstraint *>(&cs) != nullptr)
+  {
+    dynamicsConstraints_.push_back(static_cast<DynamicsConstraint *>(&cs));
+  }
 }
 
 void QPSolver::removeConstraintSet(ConstraintSet & cs)
@@ -87,6 +91,11 @@ void QPSolver::removeConstraintSet(ConstraintSet & cs)
   cs.removeFromSolver(solver);
   solver.updateConstrSize();
   solver.updateNrVars(robots().mbs());
+  auto it = std::find(dynamicsConstraints_.begin(), dynamicsConstraints_.end(), static_cast<DynamicsConstraint *>(&cs));
+  if(it != dynamicsConstraints_.end())
+  {
+    dynamicsConstraints_.erase(it);
+  }
 }
 
 void QPSolver::addTask(tasks::qp::Task * task)
@@ -483,6 +492,10 @@ void QPSolver::__fillResult()
     qpRes.zmps[i].z = robot.zmpTarget().z();
   }
   qpRes.lambdaVec = solver.lambdaVec();
+  for(const auto & dynamics : dynamicsConstraints_)
+  {
+    fillTorque(*dynamics);
+  }
 }
 
 const mc_rbdyn::Robot & QPSolver::robot() const


### PR DESCRIPTION
This PR keeps track of dynamics constraints that are added to the solver in order to compute output torques automatically after a successful solve

Closes #209 (GitLab)