### PR TITLE
Simple collisions, wildcard support and collision monitoring

### DIFF
--- a/binding/python/mc_rbdyn/c_mc_rbdyn.pxd
+++ b/binding/python/mc_rbdyn/c_mc_rbdyn.pxd
@@ -210,6 +210,8 @@ cdef extern from "<mc_rbdyn/Robot.h>" namespace "mc_rbdyn":
 
     const pair[string, shared_ptr[sch.S_Object]]& convex(string)
 
+    const map[string, pair[string, shared_ptr[sch.S_Object]]] & convexes()
+
     const PTransformd& bodyTransform(const string&)
 
     const PTransformd& collisionTransform(const string&)

--- a/binding/python/mc_rbdyn/mc_rbdyn.pyx
+++ b/binding/python/mc_rbdyn/mc_rbdyn.pyx
@@ -800,6 +800,16 @@ cdef class Robot(object):
       name = name.encode(u'ascii')
     return (self.impl.convex(name).first,sch.S_ObjectFromPtr(self.impl.convex(name).second.get()))
 
+  def convexes(self):
+    self.__is_valid()
+    end = deref(self.impl).convexes().const_end()
+    it = deref(self.impl).convexes().const_begin()
+    ret = {}
+    while it  != end:
+      ret[deref(it).first] = self.convex(deref(it).first)
+      preinc(it)
+    return ret
+
   def bodyTransform(self, bName):
     self.__is_valid()
     if isinstance(bName, unicode):

--- a/doc/_data/schemas/mc_rbdyn/Collision.json
+++ b/doc/_data/schemas/mc_rbdyn/Collision.json
@@ -3,11 +3,11 @@
   "type": "object",
   "properties":
   {
-    "body1": { "type": "string" },
-    "body2": { "type": "string" },
-    "iDist": { "type": "number" },
-    "sDist": { "type": "number" },
-    "damping": { "type": "number" }
+    "body1": { "type": "string", "description": "First convex body used, wildcards can be used" },
+    "body2": { "type": "string", "description": "Second convex body used, wildcards can be used" },
+    "iDist": { "type": "number", "description": "Interaction distance" },
+    "sDist": { "type": "number", "description": "Safety distance" },
+    "damping": { "type": "number", "description": "Damping, 0 enables automatic computation" }
   },
   "required": ["body1", "body2", "iDist", "sDist", "damping"],
   "additionalProperties": false

--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -730,6 +730,12 @@ public:
   /** Access a convex named \p cName (const) */
   const convex_pair_t & convex(const std::string & cName) const;
 
+  /** Access all convexes available in this robot
+   *
+   * \returns a map where keys are the convex name and values are those returned by \ref convex
+   */
+  const std::map<std::string, convex_pair_t> & convexes() const;
+
   /** Add a convex online
    *
    * This has no effect if \p name is already a convex of the robot

--- a/include/mc_rbdyn/RobotModule.h
+++ b/include/mc_rbdyn/RobotModule.h
@@ -544,6 +544,8 @@ struct MC_RBDYN_DLLAPI RobotModule
   std::map<std::string, std::pair<std::string, std::string>> _stpbvHull;
   /** Holds visual representation of bodies in the robot */
   VisualMap _visual;
+  /** Holds collision representation of bodies in the robot */
+  VisualMap _collision;
   /** \see collisionTransforms() */
   std::map<std::string, sva::PTransformd> _collisionTransforms;
   /** \see flexibility() */

--- a/include/mc_solver/CollisionsConstraint.h
+++ b/include/mc_solver/CollisionsConstraint.h
@@ -7,6 +7,7 @@
 #include <mc_rbdyn/Collision.h>
 #include <mc_rbdyn/Contact.h>
 #include <mc_rbdyn/Robots.h>
+#include <mc_rtc/gui/StateBuilder.h>
 #include <mc_solver/ConstraintSet.h>
 
 #include <Tasks/QPConstr.h>
@@ -97,11 +98,17 @@ public:
 private:
   /* Internal sauce to manage collisions */
   int collId;
-  std::map<std::string, std::pair<unsigned int, mc_rbdyn::Collision>> collIdDict;
+  std::map<std::string, std::pair<int, mc_rbdyn::Collision>> collIdDict;
   std::string __keyByNames(const std::string & name1, const std::string & name2);
   int __createCollId(const mc_rbdyn::Collision & col);
   std::pair<int, mc_rbdyn::Collision> __popCollId(const std::string & name1, const std::string & name2);
-  void __addCollision(const mc_rbdyn::Robots & robots, const mc_rbdyn::Collision & col);
+  void __addCollision(const mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col);
+
+  /* Internal management for collision display */
+  std::unordered_set<int> monitored_;
+  std::shared_ptr<mc_rtc::gui::StateBuilder> gui_;
+  std::vector<std::string> category_;
+  void toggleCollisionMonitor(int collId);
 
 public:
   /** \deprecated{Default constructor, not made for general usage} */

--- a/include/mc_solver/CollisionsConstraint.h
+++ b/include/mc_solver/CollisionsConstraint.h
@@ -65,12 +65,21 @@ public:
   bool removeCollisionByBody(QPSolver & solver, const std::string & byName, const std::string & b2Name);
 
   /** Add a collision represented by mc_rbdyn::Collision
-   * \param solver The solver into which this constraint was added
-   * \param col The collision that should be added
+   *
+   * The collision object is allowed to specify wildcard names to add multiple
+   * collisions at once, if body1 is named bodyA* and body2 is named bodyB*
+   * then collision constraints will be added for all convex objects in robot1
+   * (resp. robot2) that start with bodyA (resp. bodyB)
+   *
+   * \param solver The solver into which this constraint was added \param col
+   * The collision that should be added
    */
   void addCollision(QPSolver & solver, const mc_rbdyn::Collision & col);
 
   /** Add a set of collisions
+   *
+   * \see addCollision for details on wildcard collision specification
+   *
    * \param solver The solver into which this constraint was added
    * \param cols The set of collisions that should be added
    */
@@ -102,6 +111,7 @@ private:
   std::string __keyByNames(const std::string & name1, const std::string & name2);
   int __createCollId(const mc_rbdyn::Collision & col);
   std::pair<int, mc_rbdyn::Collision> __popCollId(const std::string & name1, const std::string & name2);
+  /** Actually adds the collision to the constraint, handles id creation and wildcard support */
   void __addCollision(const mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col);
 
   /* Internal management for collision display */

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -1073,6 +1073,11 @@ const Robot::convex_pair_t & Robot::convex(const std::string & cName) const
   return convexes_.at(cName);
 }
 
+const std::map<std::string, Robot::convex_pair_t> & Robot::convexes() const
+{
+  return convexes_;
+}
+
 void Robot::addConvex(const std::string & cName,
                       const std::string & body,
                       Robot::S_ObjectPtr convex,

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -18,7 +18,7 @@
 #include <RBDyn/FK.h>
 #include <RBDyn/FV.h>
 
-#include <sch/S_Object/S_Capsule.h>
+#include <sch/S_Object/S_Cylinder.h>
 #include <sch/S_Object/S_Superellipsoid.h>
 
 #include <boost/filesystem.hpp>
@@ -187,8 +187,8 @@ bool VisualToConvex(const std::string & robot,
   };
   auto fromCylinder = [&]() {
     const auto & cyl = boost::get<rbd::parsers::Geometry::Cylinder>(visual.geometry.data);
-    convexes[cName] = {
-        bName, std::make_shared<sch::S_Capsule>(sch::Point3(0, 0, 0), sch::Point3(0, 0, cyl.length), cyl.radius)};
+    convexes[cName] = {bName, std::make_shared<sch::S_Cylinder>(sch::Point3(0, 0, -cyl.length / 2),
+                                                                sch::Point3(0, 0, cyl.length / 2), cyl.radius)};
   };
   auto fromSphere = [&]() {
     const auto & sph = boost::get<rbd::parsers::Geometry::Sphere>(visual.geometry.data);

--- a/src/mc_rbdyn/RobotModule.cpp
+++ b/src/mc_rbdyn/RobotModule.cpp
@@ -153,6 +153,7 @@ void RobotModule::init(const rbd::parsers::ParserResult & res)
   }
   boundsFromURDF(res.limits);
   _visual = res.visual;
+  _collision = res.collision;
   make_default_ref_joint_order();
   expand_stance();
 }

--- a/src/mc_solver/CollisionsConstraint.cpp
+++ b/src/mc_solver/CollisionsConstraint.cpp
@@ -4,6 +4,9 @@
 
 #include <mc_rbdyn/SCHAddon.h>
 #include <mc_rbdyn/configuration_io.h>
+#include <mc_rtc/gui/Arrow.h>
+#include <mc_rtc/gui/Checkbox.h>
+#include <mc_rtc/gui/Label.h>
 #include <mc_solver/CollisionsConstraint.h>
 #include <mc_solver/ConstraintSetLoader.h>
 #include <mc_solver/QPSolver.h>
@@ -25,6 +28,14 @@ bool CollisionsConstraint::removeCollision(QPSolver & solver, const std::string 
   auto p = __popCollId(b1Name, b2Name);
   if(!p.second.isNone())
   {
+    if(monitored_.count(p.first))
+    {
+      toggleCollisionMonitor(p.first);
+      category_.push_back("Monitors");
+      std::string name = "Monitor " + p.second.body1 + "/" + p.second.body2;
+      gui_->removeElement(category_, name);
+      category_.pop_back();
+    }
     cols.erase(std::find(cols.begin(), cols.end(), p.second));
     bool ret = collConstr->rmCollision(p.first);
     if(ret)
@@ -59,6 +70,14 @@ bool CollisionsConstraint::removeCollisionByBody(QPSolver & solver,
       auto out = __popCollId(col.body1, col.body2);
       toRm.push_back(out.second);
       collConstr->rmCollision(out.first);
+      if(monitored_.count(out.first))
+      {
+        toggleCollisionMonitor(out.first);
+        category_.push_back("Monitors");
+        std::string name = "Monitor " + out.second.body1 + "/" + out.second.body2;
+        gui_->removeElement(category_, name);
+        category_.pop_back();
+      }
     }
   }
   for(const auto & it : toRm)
@@ -73,19 +92,81 @@ bool CollisionsConstraint::removeCollisionByBody(QPSolver & solver,
   return toRm.size() > 0;
 }
 
-void CollisionsConstraint::__addCollision(const mc_rbdyn::Robots & robots, const mc_rbdyn::Collision & col)
+void CollisionsConstraint::__addCollision(const mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col)
 {
+  const auto & robots = solver.robots();
   const mc_rbdyn::Robot & r1 = robots.robot(r1Index);
   const mc_rbdyn::Robot & r2 = robots.robot(r2Index);
   const auto & body1 = r1.convex(col.body1);
   const auto & body2 = r2.convex(col.body2);
-  const sva::PTransformd & X_b1_c = r1.collisionTransform(body1.first);
-  const sva::PTransformd & X_b2_c = r2.collisionTransform(body2.first);
+  const sva::PTransformd & X_b1_c = r1.collisionTransform(col.body1);
+  const sva::PTransformd & X_b2_c = r2.collisionTransform(col.body2);
   int collId = __createCollId(col);
+  if(collId < 0)
+  {
+    return;
+  }
   cols.push_back(col);
   collConstr->addCollision(robots.mbs(), collId, static_cast<int>(r1Index), body1.first, body1.second.get(), X_b1_c,
                            static_cast<int>(r2Index), body2.first, body2.second.get(), X_b2_c, col.iDist, col.sDist,
                            col.damping, defaultDampingOffset);
+  if(solver.gui())
+  {
+    if(!gui_)
+    {
+      gui_ = solver.gui();
+      category_ = {"Collisions", r1.name() + "/" + r2.name()};
+    }
+    auto & gui = *gui_;
+    std::string collisionName = col.body1 + "/" + col.body2;
+    category_.push_back("Monitors");
+    gui.addElement(category_, mc_rtc::gui::Checkbox("Monitor " + collisionName,
+                                                    [collId, this]() { return monitored_.count(collId) != 0; },
+                                                    [collId, this]() { toggleCollisionMonitor(collId); }));
+    category_.pop_back();
+  }
+}
+
+void CollisionsConstraint::toggleCollisionMonitor(int collId)
+{
+  auto findCollisionById = [this, collId]() -> const mc_rbdyn::Collision & {
+    for(const auto & c : collIdDict)
+    {
+      if(c.second.first == collId)
+      {
+        return c.second.second;
+      }
+    }
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "[CollisionConstraint] Attempted to toggleCollisionMonitor on non-existent collision");
+  };
+  const auto & col = findCollisionById();
+  auto & gui = *gui_;
+  std::string label = col.body1 + "::" + col.body2;
+  if(monitored_.count(collId))
+  {
+    // Remove the monitor
+    gui.removeElement(category_, label);
+    category_.push_back("Arrows");
+    gui.removeElement(category_, label);
+    category_.pop_back();
+    monitored_.erase(collId);
+  }
+  else
+  {
+    // Add the monitor
+    gui.addElement(category_, mc_rtc::gui::Label(label, [this, collId]() {
+                     return fmt::format("{:0.2f} cm", collConstr->getCollisionData(collId).distance * 100);
+                   }));
+    category_.push_back("Arrows");
+    gui.addElement(
+        category_,
+        mc_rtc::gui::Arrow(
+            label, [this, collId]() -> const Eigen::Vector3d & { return collConstr->getCollisionData(collId).p1; },
+            [this, collId]() -> const Eigen::Vector3d & { return collConstr->getCollisionData(collId).p2; }));
+    category_.pop_back();
+    monitored_.insert(collId);
+  }
 }
 
 void CollisionsConstraint::addCollision(QPSolver & solver, const mc_rbdyn::Collision & col)
@@ -97,7 +178,7 @@ void CollisionsConstraint::addCollisions(QPSolver & solver, const std::vector<mc
 {
   for(const auto & c : cols)
   {
-    __addCollision(solver.robots(), c);
+    __addCollision(solver, c);
   }
   collConstr->updateNrVars({}, solver.data());
   solver.updateConstrSize();
@@ -116,6 +197,10 @@ void CollisionsConstraint::removeFromSolver(tasks::qp::QPSolver & solver)
   if(collConstr)
   {
     collConstr->removeFromSolver(solver);
+    if(gui_)
+    {
+      gui_->removeCategory(category_);
+    }
   }
 }
 
@@ -124,6 +209,10 @@ void CollisionsConstraint::reset()
   cols.clear();
   collIdDict.clear();
   collConstr->reset();
+  if(gui_)
+  {
+    gui_->removeCategory(category_);
+  }
 }
 
 std::string CollisionsConstraint::__keyByNames(const std::string & name1, const std::string & name2)
@@ -134,8 +223,13 @@ std::string CollisionsConstraint::__keyByNames(const std::string & name1, const 
 int CollisionsConstraint::__createCollId(const mc_rbdyn::Collision & col)
 {
   std::string key = __keyByNames(col.body1, col.body2);
+  auto it = collIdDict.find(key);
+  if(it != collIdDict.end())
+  {
+    return -1;
+  }
   int collId = this->collId;
-  collIdDict[key] = std::pair<unsigned int, mc_rbdyn::Collision>(collId, col);
+  collIdDict[key] = std::pair<int, mc_rbdyn::Collision>(collId, col);
   this->collId += 1;
   return collId;
 }

--- a/src/mc_solver/CollisionsConstraint.cpp
+++ b/src/mc_solver/CollisionsConstraint.cpp
@@ -143,23 +143,6 @@ void CollisionsConstraint::__addCollision(const mc_solver::QPSolver & solver, co
   {
     return;
   }
-  if(col.body1.back() == '*')
-  {
-    std::string search = col.body1.substr(0, col.body1.size() - 1);
-    for(const auto & convex : r1.convexes())
-    {
-      const auto & cName = convex.first;
-      if(cName.size() < search.size())
-      {
-        continue;
-      }
-      if(cName.substr(0, search.size()) == search)
-      {
-        __addCollision(solver, {cName, col.body2, col.iDist, col.sDist, col.damping});
-      }
-    }
-    return;
-  }
   const auto & body1 = r1.convex(col.body1);
   const auto & body2 = r2.convex(col.body2);
   const sva::PTransformd & X_b1_c = r1.collisionTransform(col.body1);


### PR DESCRIPTION
This PR:
- Loads simple collision shapes defined in URDF files `<collision>` tags, for each `<collision>` tag in the URDF it will create a collision object named `body_{i}` where `i` depends of the order in which these collision tags are in the URDF file. When a single collision entry exist then the suffix is dropped. If there is a single collision entry and a convex already exists then the simple collision shape is dropped in favor of the convex
- Supports wildcard when adding collisions, so instead of adding MxN collision (in yaml or code) for `[bodyA_0, bodyA_1, ..., bodyA_M]` and ``[bodyB_0, bodyB_1, ..., bodyB_N]` we can simply specify collision avoidance between `bodyA*` and `bodyB*`
- Use newly added accessors in Tasks to provide visual feedback on collision avoidance (show distance in the GUI and an arrow joining the two closest point), this is off by default and only activable via GUI interaction but maybe we can add a flag either to `mc_rbdyn::Collision` or `mc_solver::CollisionConstraint` to toggle the display on by default

There will be a corresponding PR for mc_rtc_ros to support these new shapes in `mc_convex_visualization`

It also adds a utility function to list available collisions in a robot (with Python bindings)