### PR TITLE
[mc_solver] Add C-style string overload for GenericLoader

### DIFF
--- a/include/mc_solver/GenericLoader.h
+++ b/include/mc_solver/GenericLoader.h
@@ -84,6 +84,17 @@ struct GenericLoader
    */
   static T_ptr load(mc_solver::QPSolver & solver, const std::string & file);
 
+  /** Load an object from a file (C-style string)
+   *
+   * \param solver Solver to create the object for
+   *
+   * \param file File to load the object from
+   *
+   * \throws If the file does not exist or the loaded JSON object does not
+   * represent a known object
+   */
+  static T_ptr load(mc_solver::QPSolver & solver, const char * file);
+
   /** Load an object from an mc_rtc::Configuration object
    *
    * \param solver Solver to create the object for
@@ -98,6 +109,11 @@ struct GenericLoader
   template<typename U,
            typename std::enable_if<(!std::is_same<U, T>::value) && std::is_base_of<T, U>::value, int>::type = 0>
   static std::shared_ptr<U> load(mc_solver::QPSolver & solver, const std::string & file);
+
+  /** Retrieve a more precise object's type from a file (C-style string) */
+  template<typename U,
+           typename std::enable_if<(!std::is_same<U, T>::value) && std::is_base_of<T, U>::value, int>::type = 0>
+  static std::shared_ptr<U> load(mc_solver::QPSolver & solver, const char * file);
 
   /** Retrieve a more precise object's type from a Configuration entry */
   template<typename U,

--- a/include/mc_solver/GenericLoader.hpp
+++ b/include/mc_solver/GenericLoader.hpp
@@ -48,6 +48,13 @@ typename GenericLoader<Derived, T>::T_ptr GenericLoader<Derived, T>::load(mc_sol
 
 template<typename Derived, typename T>
 typename GenericLoader<Derived, T>::T_ptr GenericLoader<Derived, T>::load(mc_solver::QPSolver & solver,
+                                                                          const char * file)
+{
+  return load(solver, mc_rtc::Configuration(file));
+}
+
+template<typename Derived, typename T>
+typename GenericLoader<Derived, T>::T_ptr GenericLoader<Derived, T>::load(mc_solver::QPSolver & solver,
                                                                           const mc_rtc::Configuration & config)
 {
   static auto & fns = get_fns();
@@ -66,6 +73,13 @@ typename GenericLoader<Derived, T>::T_ptr GenericLoader<Derived, T>::load(mc_sol
 template<typename Derived, typename T>
 template<typename U, typename std::enable_if<(!std::is_same<U, T>::value) && std::is_base_of<T, U>::value, int>::type>
 std::shared_ptr<U> GenericLoader<Derived, T>::load(mc_solver::QPSolver & solver, const std::string & file)
+{
+  return cast<U>(load(solver, file));
+}
+
+template<typename Derived, typename T>
+template<typename U, typename std::enable_if<(!std::is_same<U, T>::value) && std::is_base_of<T, U>::value, int>::type>
+std::shared_ptr<U> GenericLoader<Derived, T>::load(mc_solver::QPSolver & solver, const char * file)
 {
   return cast<U>(load(solver, file));
 }


### PR DESCRIPTION
This solves ambiguous call in cases such as:

```cpp
auto task = mc_tasks::MetaTaskLoader::load(solver(), "/my/path/task.yaml");
```

which are advertised in the [tutorials](https://jrl-umi3218.github.io/mc_rtc/tutorials/introduction/ef-controller.html)