### PR TITLE
improve configuration error reporting

### DIFF
--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -102,16 +102,47 @@ struct has_configuration_save_object : decltype(_has_configuration_save_object::
  */
 struct MC_RTC_UTILS_DLLAPI Configuration
 {
+private:
+  /*! \brief Implementation details
+   *
+   * This structure is meant to hide the JSON library used by mc_rtc
+   * while allowing the template method implementation.
+   */
+  struct MC_RTC_UTILS_DLLAPI Json
+  {
+    bool isArray() const;
+    size_t size() const;
+    Json operator[](size_t idx) const;
+    bool isObject() const;
+    std::vector<std::string> keys() const;
+    Json operator[](const std::string & key) const;
+    bool isNumeric() const;
+    double asDouble() const;
+    void path(std::string & out) const;
+    void * value_;
+    std::shared_ptr<void> doc_;
+  };
 
+public:
   /*! \brief Exception thrown by this class when something bad occurs
    */
   struct MC_RTC_UTILS_DLLAPI Exception : public std::exception
   {
     /*! \brief Constructor
      *
-     * \param msg The message that will be returned by what()
+     * \param msg Exception message
+     *
+     * \param v Json value that was the source of the exception
      */
-    Exception(const std::string & msg);
+    Exception(const std::string & msg, const Json & v);
+
+    /*! \brief Constructor
+     *
+     * \param msg Exception message
+     *
+     * \param c Configuration object that was the source of the exception
+     */
+    Exception(const std::string & msg, const Configuration & c) : Exception(msg, c.v) {}
 
     ~Exception() noexcept;
 
@@ -119,7 +150,11 @@ struct MC_RTC_UTILS_DLLAPI Configuration
 
     void silence() noexcept;
 
-    std::string msg;
+    const std::string & msg() const noexcept;
+
+  private:
+    mutable std::string msg_;
+    mutable Json v_;
   };
 
   /*! \brief Deprecated, see has
@@ -295,7 +330,7 @@ struct MC_RTC_UTILS_DLLAPI Configuration
     }
     else
     {
-      throw Configuration::Exception("Stored Json value is not a vector");
+      throw Configuration::Exception("Stored Json value is not a vector", v);
     }
   }
 
@@ -319,7 +354,7 @@ struct MC_RTC_UTILS_DLLAPI Configuration
     }
     else
     {
-      throw Configuration::Exception("Stored Json value is not an array or its size is incorrect");
+      throw Configuration::Exception("Stored Json value is not an array or its size is incorrect", v);
     }
   }
 
@@ -337,7 +372,7 @@ struct MC_RTC_UTILS_DLLAPI Configuration
     }
     else
     {
-      throw Configuration::Exception("Stored Json value is not an array of size 2");
+      throw Configuration::Exception("Stored Json value is not an array of size 2", v);
     }
   }
 
@@ -363,7 +398,7 @@ struct MC_RTC_UTILS_DLLAPI Configuration
     }
     else
     {
-      throw Configuration::Exception("Stored Json value is not an object");
+      throw Configuration::Exception("Stored Json value is not an object", v);
     }
   }
 
@@ -384,14 +419,14 @@ struct MC_RTC_UTILS_DLLAPI Configuration
         auto ins = ret.insert(Configuration(v[i]));
         if(!ins.second)
         {
-          throw Configuration::Exception("Stored Json set does not hold unique values");
+          throw Configuration::Exception("Stored Json set does not hold unique values", v);
         }
       }
       return ret;
     }
     else
     {
-      throw Configuration::Exception("Stored Json value is not an array");
+      throw Configuration::Exception("Stored Json value is not an array", v);
     }
   }
 
@@ -412,14 +447,14 @@ struct MC_RTC_UTILS_DLLAPI Configuration
         auto ins = ret.insert(Configuration(v[i]));
         if(!ins.second)
         {
-          throw Configuration::Exception("Stored Json set does not hold unique values");
+          throw Configuration::Exception("Stored Json set does not hold unique values", v);
         }
       }
       return ret;
     }
     else
     {
-      throw Configuration::Exception("Stored Json value is not an array");
+      throw Configuration::Exception("Stored Json value is not an array", v);
     }
   }
 
@@ -1252,24 +1287,6 @@ struct MC_RTC_UTILS_DLLAPI Configuration
   ConfigurationArrayIterator end() const;
 
 private:
-  /*! \brief Implementation details
-   *
-   * This structure is meant to hide the JSON library used by mc_rtc
-   * while allowing the template method implementation.
-   */
-  struct MC_RTC_UTILS_DLLAPI Json
-  {
-    bool isArray() const;
-    size_t size() const;
-    Json operator[](size_t idx) const;
-    bool isObject() const;
-    std::vector<std::string> keys() const;
-    Json operator[](const std::string & key) const;
-    bool isNumeric() const;
-    double asDouble() const;
-    void * value_;
-    std::shared_ptr<void> doc_;
-  };
   Json v;
   Configuration(const Json & v);
 };

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -110,21 +110,49 @@ private:
    */
   struct MC_RTC_UTILS_DLLAPI Json
   {
+    /** True if the underlying value is an array */
     bool isArray() const;
+    /** Size of the array, 0 if the array is empty or the value is not an array */
     size_t size() const;
+    /** Access element at the provided index
+     *
+     * \throws If idx >= size()
+     */
     Json operator[](size_t idx) const;
+    /** True if the underlying value is an object */
     bool isObject() const;
+    /** Key of the object, empty if the object is or if the value is not an object */
     std::vector<std::string> keys() const;
+    /** Access element at the provided key
+     *
+     * \throws If key does not belong in keys()
+     */
     Json operator[](const std::string & key) const;
+    /** True if the value is numeric */
     bool isNumeric() const;
+    /** Access the value as a double
+     *
+     * \throws If isNumeric() is false
+     */
     double asDouble() const;
+    /** Output the path from the root of the document to this value
+     *
+     * \note This requires searching through the whole document for this value and is not very efficient
+     */
     void path(std::string & out) const;
+    /** Actually a RapidJSON value */
     void * value_;
+    /** Actually a RapidJSON document (root) */
     std::shared_ptr<void> doc_;
   };
 
 public:
   /*! \brief Exception thrown by this class when something bad occurs
+   *
+   * The exception message is generated when accessed via what() or msg(). It is printed when the exception is deleted
+   * and builds a path from the root of the document to the source of the error in order to help the user to find the
+   * source of the error. This operation can be expensive. If you do not need the message (e.g. you are attempting
+   * various conversions) then you should call silence() to prevent the generation of the message.
    */
   struct MC_RTC_UTILS_DLLAPI Exception : public std::exception
   {
@@ -146,10 +174,13 @@ public:
 
     ~Exception() noexcept;
 
+    /** Returns the error message */
     virtual const char * what() const noexcept override;
 
-    void silence() noexcept;
+    /** Empty the error message */
+    void silence() const noexcept;
 
+    /** Returns the error message */
     const std::string & msg() const noexcept;
 
   private:

--- a/include/mc_rtc/ConfigurationHelpers.h
+++ b/include/mc_rtc/ConfigurationHelpers.h
@@ -97,8 +97,9 @@ std::vector<T> fromVectorOrElement(const mc_rtc::Configuration & config, const s
     catch(mc_rtc::Configuration::Exception & notAnElem)
     {
       notAnElem.silence();
-      log::error_and_throw<mc_rtc::Configuration::Exception>(
-          "Configuration {} is not valid. It should be a vector or single element.", key);
+      auto msg = fmt::format("Configuration {} is not valid. It should be a vector or single element.", key);
+      log::critical(msg);
+      throw mc_rtc::Configuration::Exception(msg, c);
     }
   }
   return vec;

--- a/include/mc_rtc/logging.h
+++ b/include/mc_rtc/logging.h
@@ -38,6 +38,12 @@ void error_and_throw[[noreturn]](Args &&... args)
 }
 
 template<typename... Args>
+void critical(Args &&... args)
+{
+  details::cerr().critical(std::forward<Args>(args)...);
+}
+
+template<typename... Args>
 void error(Args &&... args)
 {
   details::cerr().error(std::forward<Args>(args)...);

--- a/src/mc_rbdyn/configuration_io.cpp
+++ b/src/mc_rbdyn/configuration_io.cpp
@@ -435,8 +435,9 @@ Eigen::Matrix<double, 6, Eigen::Dynamic> ConfigurationLoader<Eigen::Matrix<doubl
   auto data = config("data");
   if(static_cast<Eigen::DenseIndex>(data.size()) != 6 * m.cols())
   {
-    mc_rtc::log::error_and_throw<mc_rtc::Configuration::Exception>(
-        "Stored data size ({}) is different from the expected size ({})", data.size(), 6 * m.cols());
+    auto msg = fmt::format("Stored data size ({}) is different from the expected size ({})", data.size(), 6 * m.cols());
+    mc_rtc::log::critical(msg);
+    throw mc_rtc::Configuration::Exception(msg, data);
   }
   for(Eigen::DenseIndex i = 0; i < 6; ++i)
   {

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -159,7 +159,7 @@ const char * Configuration::Exception::what() const noexcept
   return msg().c_str();
 }
 
-void Configuration::Exception::silence() noexcept
+void Configuration::Exception::silence() const noexcept
 {
   msg_.resize(0);
   v_.value_ = nullptr;

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -171,7 +171,7 @@ const std::string & Configuration::Exception::msg() const noexcept
   {
     std::string path;
     v_.path(path);
-    msg_ = fmt::format("{} (error path: (){})", msg_, path);
+    msg_ = fmt::format("{} (error path: {})", msg_, path.size() ? path : "()");
     v_.value_ = nullptr;
   }
   return msg_;

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -973,3 +973,74 @@ BOOST_AUTO_TEST_CASE(TestConfigurartionRemove)
   BOOST_CHECK(config.remove("dict"));
   BOOST_CHECK(!config.has("dict"));
 }
+
+static std::string YAML_DATA3 = R"(
+v3d: [1.0, 2.0, 3.0]
+v3dPair:
+  - [1.0, 2.0, 3.0]
+  - [1.0, 2.0, 3.0]
+dict:
+  v3d: [1.0, 2.0, 3.0]
+  v3dPair:
+    - [1.0, 2.0, 3.0]
+    - [1.0, 2.0, 3.0]
+array:
+  - v3d: [1.0, 2.0, 3.0]
+  - v3dPair:
+      - [1.0, 2.0, 3.0]
+      - [1.0, 2.0, 3.0]
+deep:
+  - {}
+  - {}
+  - object1:
+      key1: {}
+      key2:
+        - {}
+        - object2:
+            key1: {}
+            v3d: [1.0, 2.0, 3.0]
+)";
+
+#define CHECK_ERROR_MESSAGE(EXPECTED, ...)      \
+  try                                           \
+  {                                             \
+    __VA_ARGS__;                                \
+  }                                             \
+  catch(mc_rtc::Configuration::Exception & exc) \
+  {                                             \
+    BOOST_REQUIRE(exc.msg() == EXPECTED);       \
+    exc.silence();                              \
+  }
+
+BOOST_AUTO_TEST_CASE(TestConfigurationErrorMessage)
+{
+  auto config = mc_rtc::Configuration::fromYAMLData(YAML_DATA3);
+  CHECK_ERROR_MESSAGE("No entry named NONE in the configuration (error path: ())", config("NONE"));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused"
+#ifdef __clang__
+#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#endif
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+  CHECK_ERROR_MESSAGE("Stored Json value is not a Vector6d (error path: (\"v3d\"))", Eigen::Vector6d v = config("v3d"));
+  CHECK_ERROR_MESSAGE("Stored Json value is not a Vector6d (error path: (\"v3dPair\")[0])",
+                      Eigen::Vector6d v = config("v3dPair")[0]);
+  CHECK_ERROR_MESSAGE("Stored Json value is not a Vector6d (error path: (\"v3dPair\")[1])",
+                      std::pair<Eigen::Vector3d, Eigen::Vector6d> v = config("v3dPair"));
+  CHECK_ERROR_MESSAGE("Stored Json value is not a Vector6d (error path: (\"dict\")(\"v3d\"))",
+                      Eigen::Vector6d v = config("dict")("v3d"));
+  CHECK_ERROR_MESSAGE("Stored Json value is not a Vector6d (error path: (\"dict\")(\"v3dPair\")[0])",
+                      Eigen::Vector6d v = config("dict")("v3dPair")[0]);
+  CHECK_ERROR_MESSAGE("Stored Json value is not a Vector6d (error path: (\"dict\")(\"v3dPair\")[1])",
+                      std::pair<Eigen::Vector3d, Eigen::Vector6d> v = config("dict")("v3dPair"));
+  CHECK_ERROR_MESSAGE("Stored Json value is not a Vector6d (error path: (\"array\")[0](\"v3d\"))",
+                      Eigen::Vector6d v = config("array")[0]("v3d"));
+  CHECK_ERROR_MESSAGE("Stored Json value is not a Vector6d (error path: (\"array\")[1](\"v3dPair\")[0])",
+                      Eigen::Vector6d v = config("array")[1]("v3dPair")[0]);
+  CHECK_ERROR_MESSAGE("Stored Json value is not a Vector6d (error path: (\"array\")[1](\"v3dPair\")[1])",
+                      std::pair<Eigen::Vector3d, Eigen::Vector6d> v = config("array")[1]("v3dPair"));
+  CHECK_ERROR_MESSAGE(
+      "Stored Json value is not a Vector6d (error path: (\"deep\")[2](\"object1\")(\"key2\")[1](\"object2\")(\"v3d\"))",
+      Eigen::Vector6d v = config("deep")[2]("object1")("key2")[1]("object2")("v3d"));
+#pragma GCC diagnostic pop
+}


### PR DESCRIPTION
This PR improves error reporting when an error occurs in a Configuration conversion. Instead of only reporting the failure it will also report the Configuration path that lead to the error.

This is (almost) free when the exception is caught and silenced but relatively expensive (a linear search on every configuration entries) otherwise as we need to look for the faulty value in the whole document. It is completely free when no exception is generated.

Generally this is fine as uncaught exception will lead to the program termination. Unsilenced exceptions are barely used in the framework and normally with small objects. (if I'm not mistaken this only done in the GUI callback handling)

Example outputs:

```
// code: Eigen::Vector3d v = config("v6d");
[error] Stored Json value is not a Vector3d (error path: ("v6d"))

// code: Eigen::Vector3d v = config("array")[2]("v6d");
[error] Stored Json value is not a Vector3d (error path: ("array")[2]("v6d"))

// In more realistic code this would be generated from something like:
// auto c = config("array")[2];
// ... later
// Eigen::Vector3d v = c("v6d");

// Can also report while converting array-types
// std::pair<double, double> p = config("doubleStringPair");
[error] Stored Json value is not a double (error path: ("doubleStringPair")[1])
```