### PR TITLE
[SurfaceTransform] Support for wrench completion criteria

### DIFF
--- a/doc/_data/schemas/MetaTask/SurfaceTransformTask.json
+++ b/doc/_data/schemas/MetaTask/SurfaceTransformTask.json
@@ -28,7 +28,8 @@
         "stiffness": { "default": 2 },
         "dimWeight": { "$ref": "/../../Eigen/Vector6d.json" },
         "refVel": {"$ref": "/../../Eigen/Vector6d.json", "description": "Trajectory's reference velocity" },
-        "refAccel": {"$ref": "/../../Eigen/Vector6d.json", "description": "Trajectory's reference acceleration" }
+        "refAccel": {"$ref": "/../../Eigen/Vector6d.json", "description": "Trajectory's reference acceleration" },
+        "completion": { "$ref": "/../../common/completion_wrench.json" }
       }
     }
   ],

--- a/doc/_data/schemas/common/completion_wrench.json
+++ b/doc/_data/schemas/common/completion_wrench.json
@@ -2,6 +2,6 @@
   "type": "object",
   "properties":
   {
-    "wrench": {"$ref": "/../../Eigen/Vector6d.json", "description": "True when the measured wrench reaches the desired wrench ([torque, force] in controlled surface frame). If some values are NaN, this direction is ignored"}
+    "wrench": {"$ref": "/../../Eigen/Vector6d.json", "description": "True when the measured wrench reaches the desired wrench ([torque, force] in controlled surface frame). If some values are NaN, this direction is ignored. Only valid if the controlled surface is attached to a force sensor (throws otherwise)."}
   }
 }

--- a/include/mc_tasks/AdmittanceTask.h
+++ b/include/mc_tasks/AdmittanceTask.h
@@ -221,16 +221,6 @@ protected:
 
   void update(mc_solver::QPSolver &) override;
 
-  /** Add support for the following criterias:
-   *
-   * - wrench: completed when the measuredWrench reaches the given wrench, if
-   *   some values are NaN, this direction is ignored
-   *
-   */
-  std::function<bool(const mc_tasks::MetaTask & task, std::string &)> buildCompletionCriteria(
-      double dt,
-      const mc_rtc::Configuration & config) const override;
-
   void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
   void addToLogger(mc_rtc::Logger & logger) override;
   void removeFromLogger(mc_rtc::Logger & logger) override;

--- a/include/mc_tasks/SurfaceTransformTask.h
+++ b/include/mc_tasks/SurfaceTransformTask.h
@@ -78,6 +78,18 @@ public:
   /** Returns the pose of the surface in the inertial frame */
   const sva::PTransformd surfacePose() const;
 
+  /** Add support for the following criterias:
+   *
+   * - wrench: completed when the surface wrench reaches the given wrench, if
+   *   some values are NaN, this direction is ignored. Only valid if the surface
+   *   controlled by this task is attached to a force sensor, throws otherwise
+   *
+   * @throws If wrench is used but the surface is not attached to a force sensor
+   */
+  std::function<bool(const mc_tasks::MetaTask & task, std::string &)> buildCompletionCriteria(
+      double dt,
+      const mc_rtc::Configuration & config) const override;
+
   void addToLogger(mc_rtc::Logger & logger) override;
 
   void removeFromLogger(mc_rtc::Logger & logger) override;

--- a/src/mc_tasks/AdmittanceTask.cpp
+++ b/src/mc_tasks/AdmittanceTask.cpp
@@ -128,44 +128,6 @@ void AdmittanceTask::removeFromLogger(mc_rtc::Logger & logger)
   logger.removeLogEntry(name_ + "_target_wrench");
 }
 
-std::function<bool(const mc_tasks::MetaTask &, std::string &)> AdmittanceTask::buildCompletionCriteria(
-    double dt,
-    const mc_rtc::Configuration & config) const
-{
-  if(config.has("wrench"))
-  {
-    sva::ForceVecd target_w = config("wrench");
-    Eigen::Vector6d target = target_w.vector();
-    Eigen::Vector6d dof = Eigen::Vector6d::Ones();
-    for(int i = 0; i < 6; ++i)
-    {
-      if(std::isnan(target(i)))
-      {
-        dof(i) = 0.;
-        target(i) = 0.;
-      }
-      else if(target(i) < 0)
-      {
-        dof(i) = -1.;
-      }
-    }
-    return [dof, target](const mc_tasks::MetaTask & t, std::string & out) {
-      const auto & self = static_cast<const mc_tasks::force::AdmittanceTask &>(t);
-      Eigen::Vector6d w = self.measuredWrench().vector();
-      for(int i = 0; i < 6; ++i)
-      {
-        if(dof(i) * fabs(w(i)) < target(i))
-        {
-          return false;
-        }
-      }
-      out += "wrench";
-      return true;
-    };
-  }
-  return MetaTask::buildCompletionCriteria(dt, config);
-}
-
 void AdmittanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
 {
   gui.addElement({"Tasks", name_},

--- a/src/mc_tasks/SurfaceTransformTask.cpp
+++ b/src/mc_tasks/SurfaceTransformTask.cpp
@@ -153,6 +153,50 @@ void SurfaceTransformTask::removeFromLogger(mc_rtc::Logger & logger)
   logger.removeLogEntry(name_ + "_target_pose");
 }
 
+std::function<bool(const mc_tasks::MetaTask &, std::string &)> SurfaceTransformTask::buildCompletionCriteria(
+    double dt,
+    const mc_rtc::Configuration & config) const
+{
+  if(config.has("wrench"))
+  {
+    if(!robots.robot(rIndex).surfaceHasIndirectForceSensor(surfaceName))
+    {
+      mc_rtc::log::error_and_throw<std::invalid_argument>("[{}] Attempted to use \"wrench\" as completion criteria but "
+                                                          "surface \"{}\" is not attached to a force sensor",
+                                                          name(), surfaceName);
+    }
+    sva::ForceVecd target_w = config("wrench");
+    Eigen::Vector6d target = target_w.vector();
+    Eigen::Vector6d dof = Eigen::Vector6d::Ones();
+    for(int i = 0; i < 6; ++i)
+    {
+      if(std::isnan(target(i)))
+      {
+        dof(i) = 0.;
+        target(i) = 0.;
+      }
+      else if(target(i) < 0)
+      {
+        dof(i) = -1.;
+      }
+    }
+    return [dof, target](const mc_tasks::MetaTask & t, std::string & out) {
+      const auto & self = static_cast<const mc_tasks::SurfaceTransformTask &>(t);
+      Eigen::Vector6d w = self.robots.robot(self.rIndex).surfaceWrench(self.surface()).vector();
+      for(int i = 0; i < 6; ++i)
+      {
+        if(dof(i) * fabs(w(i)) < target(i))
+        {
+          return false;
+        }
+      }
+      out += "wrench";
+      return true;
+    };
+  }
+  return MetaTask::buildCompletionCriteria(dt, config);
+}
+
 void SurfaceTransformTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
 {
   TrajectoryTaskGeneric<tasks::qp::SurfaceTransformTask>::addToGUI(gui);


### PR DESCRIPTION
This PR adds support for `wrench` as a completion criteria in `SurfaceTransformTask`. This makes it easy to do things such as going towards a contact at constant velocity and stopping when a force threshold is reached.

Example:
```yaml
EstablishContactWithConstantVel:
  base: MetaTasks
  # Only allow motion along hand's z axis
  AddContacts:
    - r1: hrp4
      r2: tilted_board  
      r1Surface: RightHandPad
      r2Surface: AllGround
      dof: [1, 1, 1, 1, 1, 0]
  # Set a full contact after the force threshold is reached
  AddContactsAfter:
    - r1: hrp4
      r2: tilted_board  
      r1Surface: RightHandPad
      r2Surface: AllGround
      dof: [1, 1, 1, 1, 1, 1]
  tasks:
    RightHandConstantVelocity:
      type: surfaceTransform
      surface: RightHandPad
      refVel: [0,0,0,0,0,-0.05] # go towards target at 5cm per second
      stiffness: 1                    # we don't care about position
      damping: 300               # damping for velocity control
      completion:
        wrench:
          couple: [0, 0, 0]
          force: [0, 0, 10] # task is completed when the force sensor measures 10N
```

I'll merge when pipeline succeeds.