### PR TITLE
Add simplified stabilizer task constructor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Added
+
+- [mc_tasks] Add a simple constructor for StabilizerTask
+
 ### Fixes
 
 - [mc_observers] Fix configuration reading for anchor frame configuration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Fixes
+
+- [mc_observers] Fix configuration reading for anchor frame configuration
+
 ## [1.5.1] - 2020-09-14
 
 ### Added

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -72,6 +72,25 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
                  double dt);
 
   /**
+   * @brief Creates a stabilizer meta task
+   *
+   * This constructor uses the stabilizer configuration in the robot module associated to the controlled robot. The
+   * stabilizer is started with two feet contacts.
+   *
+   * @param robots Robots on which the task acts
+   *
+   * @param realRobots Corresponding real robots instance
+   *
+   * @param robotIndex Index of the robot
+   *
+   * @param dt Controller's timestep
+   */
+  StabilizerTask(const mc_rbdyn::Robots & robots,
+                 const mc_rbdyn::Robots & realRobots,
+                 unsigned int robotIndex,
+                 double dt);
+
+  /**
    * @brief Resets the stabilizer tasks and parameters to their default configuration.
    *
    * Resets all tasks and errors/integrator/derivators to their initial

--- a/src/mc_observers/KinematicInertialPoseObserver.cpp
+++ b/src/mc_observers/KinematicInertialPoseObserver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
  *
  * This file is  inspired by Stephane's Caron implementation as part of
  * lipm_walking_controller <https://github.com/stephane-caron/lipm_walking_controller>
@@ -23,8 +23,9 @@ void KinematicInertialPoseObserver::configure(const mc_control::MCController & c
   anchorFrameFunction_ = "KinematicAnchorFrame::" + ctl.robot(robot_).name();
   if(config.has("anchorFrame"))
   {
-    config("datastoreFunction", anchorFrameFunction_);
-    config("maxAnchorFrameDiscontinuity", maxAnchorFrameDiscontinuity_);
+    auto afConfig = config("anchorFrame");
+    afConfig("datastoreFunction", anchorFrameFunction_);
+    afConfig("maxAnchorFrameDiscontinuity", maxAnchorFrameDiscontinuity_);
   }
   if(config.has("gui"))
   {

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -61,6 +61,23 @@ StabilizerTask::StabilizerTask(const mc_rbdyn::Robots & robots,
   torsoTask->name(n + "_torso");
 }
 
+StabilizerTask::StabilizerTask(const mc_rbdyn::Robots & robots,
+                               const mc_rbdyn::Robots & realRobots,
+                               unsigned int robotIndex,
+                               double dt)
+: StabilizerTask(robots,
+                 realRobots,
+                 robotIndex,
+                 robots.robot(robotIndex).module().defaultLIPMStabilizerConfiguration().leftFootSurface,
+                 robots.robot(robotIndex).module().defaultLIPMStabilizerConfiguration().rightFootSurface,
+                 robots.robot(robotIndex).module().defaultLIPMStabilizerConfiguration().torsoBodyName,
+                 dt)
+{
+  reset();
+  configure(robots.robot(robotIndex).module().defaultLIPMStabilizerConfiguration());
+  setContacts({ContactState::Left, ContactState::Right});
+}
+
 void StabilizerTask::reset()
 {
   t_ = 0;


### PR DESCRIPTION
This PR adds a simple StabilizerTask constructor that used the configuration stored in the robot module and performs a reasonable default initialization

Also fixes a configuration bug introduced in #61 