### PR TITLE
[doc] Fix tutorial's source code inclusion

### DIFF
--- a/doc/_includes/tutorials/introduction/first-controller/controller.cpp
+++ b/doc/_includes/tutorials/introduction/first-controller/controller.cpp
@@ -3,6 +3,8 @@
 MyFirstController::MyFirstController(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & config)
 : mc_control::MCController(rm, dt)
 {
+  jointIndex = robot().jointIndexByName(jointName);
+
   config_.load(config);
   solver().addConstraintSet(contactConstraint);
   solver().addConstraintSet(kinematicsConstraint);
@@ -30,11 +32,11 @@ void MyFirstController::switch_target()
 {
   if(goingLeft)
   {
-    postureTask->target({{"NECK_Y", robot().qu()[jointIndex]}});
+    postureTask->target({{jointName, robot().qu()[jointIndex]}});
   }
   else
   {
-    postureTask->target({{"NECK_Y", robot().ql()[jointIndex]}});
+    postureTask->target({{jointName, robot().ql()[jointIndex]}});
   }
   goingLeft = !goingLeft;
 }

--- a/doc/_includes/tutorials/introduction/first-controller/controller.h
+++ b/doc/_includes/tutorials/introduction/first-controller/controller.h
@@ -15,6 +15,7 @@ struct MyFirstController_DLLAPI MyFirstController : public mc_control::MCControl
     void switch_target();
 private:
     mc_rtc::Configuration config_;
+    std::string jointName = "NECK_Y";
     int jointIndex = 0;
     bool goingLeft = true;
 };

--- a/doc/_includes/tutorials/introduction/first-controller/controller.py
+++ b/doc/_includes/tutorials/introduction/first-controller/controller.py
@@ -8,7 +8,8 @@ class MyFirstController(mc_control.MCPythonController):
         self.qpsolver.addConstraintSet(self.contactConstraint)
         self.qpsolver.addTask(self.postureTask)
         self.qpsolver.setContacts([])
-        self.jointIndex = self.robot().jointIndexByName("NECK_Y")
+        self.jointName = "NECK_Y"
+        self.jointIndex = self.robot().jointIndexByName(self.jointName)
         self.goingLeft = True
     def run_callback(self):
         if abs(self.postureTask.posture()[self.jointIndex][0] - self.robot().mbc.q[self.jointIndex][0]) < 0.05:
@@ -18,9 +19,9 @@ class MyFirstController(mc_control.MCPythonController):
         pass
     def switch_target(self):
         if self.goingLeft:
-            self.postureTask.target({"NECK_Y": self.robot().qu[self.jointIndex]})
+            self.postureTask.target({self.jointName: self.robot().qu[self.jointIndex]})
         else:
-            self.postureTask.target({"NECK_Y": self.robot().ql[self.jointIndex]})
+            self.postureTask.target({self.jointName: self.robot().ql[self.jointIndex]})
         self.goingLeft = not self.goingLeft
     @staticmethod
     def create(robot, dt):

--- a/doc/_plugins/include_raw.rb
+++ b/doc/_plugins/include_raw.rb
@@ -1,0 +1,12 @@
+module Jekyll
+  module Tags
+    class RawIncludeTag < IncludeTag
+      def read_file(file, context)
+        # Wrap the entire file in a `raw` liquid tag, suppressing liquid processing.
+        "{% raw %}" + super + "{% endraw %}"
+      end
+    end
+  end
+end
+
+Liquid::Template.register_tag("include_raw", Jekyll::Tags::RawIncludeTag)

--- a/doc/tutorials/introduction/sources/com-controller.html
+++ b/doc/tutorials/introduction/sources/com-controller.html
@@ -16,9 +16,9 @@ layout: tutorials
       <div class="card-body">
         <p><em>Note: <code>api.h</code>, <code>CMakeLists.txt</code> and <code>src/CMakeLists.txt</code> are the same as in the previous example</em></p>
         <h3><code>MyFirstController.h</code></h3>
-        {% highlight c++ linenos %}{% include tutorials/introduction/com-controller/controller.h %}{% endhighlight %}
+        {% highlight c++ linenos %}{% include_raw tutorials/introduction/com-controller/controller.h %}{% endhighlight %}
         <h3><code>MyFirstController.cpp</code></h3>
-        {% highlight c++ linenos %}{% include tutorials/introduction/com-controller/controller.cpp %}{% endhighlight %}
+        {% highlight c++ linenos %}{% include_raw tutorials/introduction/com-controller/controller.cpp %}{% endhighlight %}
       </div>
     </div>
   </div>
@@ -26,9 +26,9 @@ layout: tutorials
     <div class="card bg-light">
       <div class="card-body">
         <h3><code>my_first_controller.py</code></h3>
-        {% highlight python linenos %}{% include tutorials/introduction/com-controller/controller.py %}{% endhighlight %}
+        {% highlight python linenos %}{% include_raw tutorials/introduction/com-controller/controller.py %}{% endhighlight %}
         <h3><code>__init__.py</code></h3>
-        {% highlight python linenos %}{% include tutorials/introduction/com-controller/__init__.py %}{% endhighlight %}
+        {% highlight python linenos %}{% include_raw tutorials/introduction/com-controller/__init__.py %}{% endhighlight %}
       </div>
     </div>
   </div>

--- a/doc/tutorials/introduction/sources/first-controller.html
+++ b/doc/tutorials/introduction/sources/first-controller.html
@@ -15,15 +15,15 @@ layout: tutorials
     <div class="card bg-light">
       <div class="card-body">
         <h3><code>MyFirstController.h</code></h3>
-        {% highlight c++ linenos %}{% include tutorials/introduction/first-controller/controller.h %}{% endhighlight %}
+        {% highlight c++ linenos %}{% include_raw tutorials/introduction/first-controller/controller.h %}{% endhighlight %}
         <h3><code>MyFirstController.cpp</code></h3>
-        {% highlight c++ linenos %}{% include tutorials/introduction/first-controller/controller.cpp %}{% endhighlight %}
+        {% highlight c++ linenos %}{% include_raw tutorials/introduction/first-controller/controller.cpp %}{% endhighlight %}
         <h3><code>api.h</code></h3>
-        {% highlight c++ linenos %}{% include tutorials/introduction/first-controller/api.h %}{% endhighlight %}
+        {% highlight c++ linenos %}{% include_raw tutorials/introduction/first-controller/api.h %}{% endhighlight %}
         <h3><code>CMakeLists.txt</code></h3>
-        {% highlight cmake linenos %}{% include tutorials/introduction/first-controller/CMakeLists.txt %}{% endhighlight %}
+        {% highlight cmake linenos %}{% include_raw tutorials/introduction/first-controller/CMakeLists.txt %}{% endhighlight %}
         <h3><code>src/CMakeLists.txt</code></h3>
-        {% highlight cmake linenos %}{% include tutorials/introduction/first-controller/src_CMakeLists.txt %}{% endhighlight %}
+        {% highlight cmake linenos %}{% include_raw tutorials/introduction/first-controller/src_CMakeLists.txt %}{% endhighlight %}
       </div>
     </div>
   </div>
@@ -31,9 +31,9 @@ layout: tutorials
     <div class="card bg-light">
       <div class="card-body">
         <h3><code>my_first_controller.py</code></h3>
-        {% highlight python linenos %}{% include tutorials/introduction/first-controller/controller.py %}{% endhighlight %}
+        {% highlight python linenos %}{% include_raw tutorials/introduction/first-controller/controller.py %}{% endhighlight %}
         <h3><code>__init__.py</code></h3>
-        {% highlight python linenos %}{% include tutorials/introduction/first-controller/__init__.py %}{% endhighlight %}
+        {% highlight python linenos %}{% include_raw tutorials/introduction/first-controller/__init__.py %}{% endhighlight %}
       </div>
     </div>
   </div>

--- a/doc/tutorials/introduction/sources/multi-robot-controller.html
+++ b/doc/tutorials/introduction/sources/multi-robot-controller.html
@@ -16,9 +16,9 @@ layout: tutorials
       <div class="card-body">
         <p><em>Note: <code>api.h</code>, <code>CMakeLists.txt</code> and <code>src/CMakeLists.txt</code> are the same as in the previous example</em></p>
         <h3><code>MyFirstController.h</code></h3>
-        {% highlight c++ linenos %}{% include tutorials/introduction/multi-robot-controller/controller.h %}{% endhighlight %}
+        {% highlight c++ linenos %}{% include_raw tutorials/introduction/multi-robot-controller/controller.h %}{% endhighlight %}
         <h3><code>MyFirstController.cpp</code></h3>
-        {% highlight c++ linenos %}{% include tutorials/introduction/multi-robot-controller/controller.cpp %}{% endhighlight %}
+        {% highlight c++ linenos %}{% include_raw tutorials/introduction/multi-robot-controller/controller.cpp %}{% endhighlight %}
       </div>
     </div>
   </div>
@@ -26,9 +26,9 @@ layout: tutorials
     <div class="card bg-light">
       <div class="card-body">
         <h3><code>my_first_controller.py</code></h3>
-        {% highlight python linenos %}{% include tutorials/introduction/multi-robot-controller/controller.py %}{% endhighlight %}
+        {% highlight python linenos %}{% include_raw tutorials/introduction/multi-robot-controller/controller.py %}{% endhighlight %}
         <h3><code>__init__.py</code></h3>
-        {% highlight python linenos %}{% include tutorials/introduction/multi-robot-controller/__init__.py %}{% endhighlight %}
+        {% highlight python linenos %}{% include_raw tutorials/introduction/multi-robot-controller/__init__.py %}{% endhighlight %}
       </div>
     </div>
   </div>


### PR DESCRIPTION
- Fix inclusion of full source code in tutorials (protects against parsing of liquid tags): Fixes #66 #73 
- Fix source code of first tutorial as suggested in #73 