### PR TITLE
[mc_rtcMacros.cmake] Fix argument name in add_controller when overwriting LIBRARY_OUTPUT_DIRECTORY

### DIFF
--- a/src/mc_rtcMacros.cmake
+++ b/src/mc_rtcMacros.cmake
@@ -12,7 +12,7 @@ macro(add_controller controller_name controller_SRC controller_HDR)
 
   set_target_properties(${controller_name} PROPERTIES PREFIX "")
   if(DEFINED CATKIN_DEVEL_PREFIX)
-    set_target_properties(${state_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CATKIN_DEVEL_PREFIX}/lib/mc_controller")
+    set_target_properties(${controller_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY "${CATKIN_DEVEL_PREFIX}/lib/mc_controller")
   endif()
 
   target_link_libraries(${controller_name} PUBLIC mc_rtc::mc_control)


### PR DESCRIPTION
This PR fixes wrong argument name in add_controller function