### PR TITLE
[loader] Allow loading libraries from symbolic links

### DIFF
--- a/src/mc_rtc/loader.in.cpp
+++ b/src/mc_rtc/loader.in.cpp
@@ -201,7 +201,7 @@ void Loader::load_libraries(const std::string & class_name,
     for(const auto & p : drange)
     {
       /* Attempt to load all dynamics libraries in the directory */
-      if((!bfs::is_directory(p)) && (!bfs::is_symlink(p)) && bfs::extension(p) == "@CMAKE_SHARED_LIBRARY_SUFFIX@")
+      if((!bfs::is_directory(p)) && bfs::extension(p) == "@CMAKE_SHARED_LIBRARY_SUFFIX@")
       {
         auto handle = std::make_shared<LTDLHandle>(class_name, p.string(), rpath, verbose);
         for(const auto & cn : handle->classes())


### PR DESCRIPTION
@orikuma uses `catkin build`, which has a slightly different build process from what we are used to with `catkin_make`:

> It puts products into hidden directories, and then symbolically links them into the devel space (by default).

That is `${CATKIN_DEVEL_PREFIX}` is set `devel/.private` and `catkin build` will create libraries in `devel/.private` and create a symbolic link in devel directory. Right now, we are explicitly disallowing loading of libraries from symbolic links, which prevents setting `ControllerModulePaths` to the `devel` directory.

@gergondet Any particular reason why you initially chose to disallow loading libraries from symbolic links?


PS: I'll work on a separate PR regarding [migrating](https://catkin-tools.readthedocs.io/en/latest/migration.html) from `catkin_make` to the now recommended `catkin build` tools.