### PR TITLE
Improve general states configurability

### DIFF
--- a/doc/_data/json_categories.yml
+++ b/doc/_data/json_categories.yml
@@ -1,0 +1,20 @@
+- name: Eigen
+  desc: <p>Objects from the {% link Eigen %} library.</p><p>Data is always stored in row-major order.</p>
+- name: SpaceVecAlg
+  desc: <p>Objects from the {% link SpaceVecAlg %} library.</p>
+- name: RBDyn
+  desc: <p>Objects from the {% link RBDyn %} library.</p>
+- name: Tasks
+  desc: <p>Objects from the {% link Tasks %} library.</p>
+- name: GUI
+  desc: <p>Objects used in <a href="{{site.baseurl}}/tutorials/usage/gui.html">mc_rtc GUI description</a>.</p>
+- name: mc_rbdyn
+  desc: <p>Objects from mc_rbdyn. Used in various places in the framework.</p>
+- name: ConstraintSet
+  desc: "{% include schema_categories/ConstraintSet.html %}"
+- name: MetaTask
+  desc: "{% include schema_categories/MetaTask.html %}"
+- name: State
+  desc: <p>Base states available in mc_rtc.</p><p>This page shows which options are available for each of these states.</p>
+- name: Observers
+  desc: <p>Available observers in mc_rtc.</p><p>This page shows the available options for each observer implementation.</p><p>Please refer to the <a href="{{site.baseurl}}/tutorials/recipes/observers.html">State Observation Pipelines</a> tutorial for details on the observer pipeline configuration.</p>

--- a/doc/_data/links.yml
+++ b/doc/_data/links.yml
@@ -24,3 +24,5 @@ Choreonoid:
   url: https://choreonoid.org/en/
 mc_rtc_data:
   url: https://github.com/jrl-umi3218/mc_rtc_data
+Eigen:
+  url: https://eigen.tuxfamily.org

--- a/doc/_data/schemas/ConstraintSet/BoundedSpeedConstr.json
+++ b/doc/_data/schemas/ConstraintSet/BoundedSpeedConstr.json
@@ -16,10 +16,10 @@
         {
           "body": { "type": "string" },
           "bodyPoint": { "$ref": "/../../Eigen/Vector3d.json", "description": "Defaults to zero" },
-          "dof": { "$ref": "/../../Eigen/Matrix6d.json", "description": "Defaults to identity" },
-          "speed": { "$ref": "/../../Eigen/Vector3d.json" },
-          "lowerSpeed": { "$ref": "/../../Eigen/Vector3d.json", "description": "Ignored if speed is present" },
-          "upperSpeed": { "$ref": "/../../Eigen/Vector3d.json", "description": "Required if lowerSpeed is present and speed is absent" }
+          "dof": { "$ref": "/../../Eigen/Vector6d.json", "description": "Defaults to identity" },
+          "speed": { "$ref": "/../../Eigen/Vector6d.json" },
+          "lowerSpeed": { "$ref": "/../../Eigen/Vector6d.json", "description": "Ignored if speed is present" },
+          "upperSpeed": { "$ref": "/../../Eigen/Vector6d.json", "description": "Required if lowerSpeed is present and speed is absent" }
         },
         "required": ["body"]
       }

--- a/doc/_data/schemas/State/Posture.json
+++ b/doc/_data/schemas/State/Posture.json
@@ -1,17 +1,25 @@
 {
-  "title": "mc_control::fsm::PostureState",
-  "description": "Change configuration of the global posture task of a robot.",
-  "type": "object",
-  "properties":
-  {
-    "robot": { "type": "string", "default": "MainRobot", "description": "Name of the robot whose posture task is modified" },
-    "postureTask":
+  "allOf":
+  [
     {
+      "title": "mc_control::fsm::PostureState",
+      "description": "Change configuration of the global posture task of a robot.",
       "type": "object",
-      "title": "PostureTaskConfig",
-      "description": "Configuration for the gains and targets of the posture task",
-      "allOf":[ { "$ref": "/../../common/PostureTask_targets_properties.json" } ]
+      "properties":
+      {
+        "robot": { "type": "string", "default": "MainRobot", "description": "Name of the robot whose posture task is modified" },
+        "postureTask":
+        {
+          "type": "object",
+          "title": "PostureTaskConfig",
+          "description": "Configuration for the gains and targets of the posture task",
+          "allOf":[ { "$ref": "/../../common/PostureTask_targets_properties.json" } ]
+        },
+        "completion": { "$ref": "/../../common/completion_criteria.json" }
+      }
     },
-    "completion": { "$ref": "/../../common/completion_criteria.json" }
-  }
+    {
+      "$ref": "/../../common/State.json"
+    }
+  ]
 }

--- a/doc/_data/schemas/common/State.json
+++ b/doc/_data/schemas/common/State.json
@@ -25,8 +25,8 @@
       ]
     },
     "constraints": { "type": "object",
-                     "description": "Constraints that will be added when the state starts and removed when the state stops.<br/>Keys are used to identify the constraints in the description." },
+                     "description": "Constraints that will be added when the state starts and removed when the state stops.<br/>Keys are names for the constraints and values are <a href=\"{{site.baseurl}}/json.html#ConstraintSet\">ConstraintSet objects</a>." },
     "tasks": { "type": "object",
-               "description": "Tasks that will be added when the state starts and removed when the state stops.<br/>Keys are the name of the tasks and values are MetaTask objects." }
+               "description": "Tasks that will be added when the state starts and removed when the state stops.<br/>Keys are names for the tasks and values are <a href=\"{{site.baseurl}}/json.html#MetaTask\">MetaTask objects</a>." }
   }
 }

--- a/doc/_data/schemas/common/State.json
+++ b/doc/_data/schemas/common/State.json
@@ -18,7 +18,9 @@
     "RemoveCollisionsAfter": { "type": "array", "items": { "$ref": "/../../common/fsm_collision.json" },
                                "description": "Remove the specified collisions during the state's teardown" },
     "RemovePostureTask": { "type": "boolean", "default": false, "description": "If true, remove the main robot posture task at the state's start"},
-    "constraints": { "type": "array", "items": { "type": "object" },
-                     "description": "Constraints that will be added when the state starts and removed when the state stops" }
+    "constraints": { "type": "object",
+                     "description": "Constraints that will be added when the state starts and removed when the state stops.<br/>Keys are used to identify the constraints in the description." },
+    "tasks": { "type": "object",
+               "description": "Tasks that will be added when the state starts and removed when the state stops.<br/>Keys are the name of the tasks and values are MetaTask objects." }
   }
 }

--- a/doc/_data/schemas/common/State.json
+++ b/doc/_data/schemas/common/State.json
@@ -17,7 +17,13 @@
                             "description": "Add the specified collisions during the state's teardown" },
     "RemoveCollisionsAfter": { "type": "array", "items": { "$ref": "/../../common/fsm_collision.json" },
                                "description": "Remove the specified collisions during the state's teardown" },
-    "RemovePostureTask": { "type": "boolean", "default": false, "description": "If true, remove the main robot posture task at the state's start"},
+    "RemovePostureTask":
+    {
+      "oneOf": [
+        { "type": "boolean", "default": false, "description": "If true, remove all posture tasks at the state's start." },
+        { "type": "object", "description": "Keys are robots' names, value is a boolean indicating whether the posture taks is removed." }
+      ]
+    },
     "constraints": { "type": "object",
                      "description": "Constraints that will be added when the state starts and removed when the state stops.<br/>Keys are used to identify the constraints in the description." },
     "tasks": { "type": "object",

--- a/doc/_data/schemas/common/State.json
+++ b/doc/_data/schemas/common/State.json
@@ -17,6 +17,8 @@
                             "description": "Add the specified collisions during the state's teardown" },
     "RemoveCollisionsAfter": { "type": "array", "items": { "$ref": "/../../common/fsm_collision.json" },
                                "description": "Remove the specified collisions during the state's teardown" },
-    "RemovePostureTask": { "type": "boolean", "default": false, "description": "If true, remove the main robot posture task at the state's start"}
+    "RemovePostureTask": { "type": "boolean", "default": false, "description": "If true, remove the main robot posture task at the state's start"},
+    "constraints": { "type": "array", "items": { "type": "object" },
+                     "description": "Constraints that will be added when the state starts and removed when the state stops" }
   }
 }

--- a/doc/_data/schemas/common/State.json
+++ b/doc/_data/schemas/common/State.json
@@ -17,11 +17,11 @@
                             "description": "Add the specified collisions during the state's teardown" },
     "RemoveCollisionsAfter": { "type": "array", "items": { "$ref": "/../../common/fsm_collision.json" },
                                "description": "Remove the specified collisions during the state's teardown" },
-    "RemovePostureTask":
+    "DisablePostureTask":
     {
       "oneOf": [
-        { "type": "boolean", "default": false, "description": "If true, remove all posture tasks at the state's start." },
-        { "type": "object", "description": "Keys are robots' names, value is a boolean indicating whether the posture taks is removed." }
+        { "type": "boolean", "default": false, "description": "If true, disable all FSM posture tasks during this state execution." },
+        { "type": "array", "items": { "type": "string" }, "description": "Disable the posture tasks for the specified robots during this state execution." }
       ]
     },
     "constraints": { "type": "object",

--- a/doc/_data/schemas/mc_rbdyn/Collision.json
+++ b/doc/_data/schemas/mc_rbdyn/Collision.json
@@ -5,9 +5,9 @@
   {
     "body1": { "type": "string", "description": "First convex body used, wildcards can be used" },
     "body2": { "type": "string", "description": "Second convex body used, wildcards can be used" },
-    "iDist": { "type": "number", "description": "Interaction distance" },
-    "sDist": { "type": "number", "description": "Safety distance" },
-    "damping": { "type": "number", "description": "Damping, 0 enables automatic computation" }
+    "iDist": { "type": "number", "default": 0.05, "description": "Interaction distance" },
+    "sDist": { "type": "number", "default": 0.01, "description": "Safety distance" },
+    "damping": { "type": "number", "default": 0.0, "description": "Damping, 0 enables automatic computation" }
   },
   "required": ["body1", "body2", "iDist", "sDist", "damping"],
   "additionalProperties": false

--- a/doc/_includes/json_schema_category_description.html
+++ b/doc/_includes/json_schema_category_description.html
@@ -1,0 +1,11 @@
+{% capture collapseId %}collapse_{{include.id}}{% endcapture %}
+<div id="{{collapseId}}" class="collapse collapseSchema" style="position:sticky; top: 65px;">
+  <div class="card">
+    <div class="card-header">
+      <h6 class="text-primary font-weight-bold">{{include.id}}</h6>
+    </div>
+    <div class="card-body">
+      {{include.description | liquefy}}
+    </div>
+  </div>
+</div>

--- a/doc/_includes/json_schema_object_property.html
+++ b/doc/_includes/json_schema_object_property.html
@@ -13,17 +13,47 @@
     {% capture PROP_NAME %}<i>{{PROP_NAME}}</i>&nbsp;&nbsp;<small class="text-secondary">(pattern)</small>{% endcapture %}
   {% endif %}
   <td>{{PROP_NAME}}</td>
-  {% if include.has_description %}
-  <td>
-    {% include json_schema_item.html data=include.data id=include.id %}
-  </td>
-  <td>
-    <span class="text-secondary"><small>{{include.description | liquefy}}</small></span>
-  </td>
+  {% if include.data contains "oneOf" %}
+    {% assign oneOf = include.data.oneOf %}
+    {% for data in oneOf %}
+      {% capture id %}{{include.id}}{{forloop.index0}}{% endcapture %}
+      {% if data contains "description" %}
+        <td>
+          {% include json_schema_item.html data=data id=id %}
+        </td>
+        <td>
+          <span class="text-secondary"><small>{{data.description | liquefy}}</small></span>
+        </td>
+      {% else %}
+        <td colspan="2">
+          {% include json_schema_item.html data=data id=id %}
+        </td>
+      {% endif %}
+      {% if forloop.last == false %}
+        </tr>
+        <tr>
+          <td></td>
+          <td colspan="2">
+            <strong>OR</strong>
+          </td>
+        </tr>
+        <tr>
+          <td></td>
+      {% endif %}
+    {% endfor %}
   {% else %}
-  <td colspan="2">
-    {% include json_schema_item.html data=include.data id=include.id %}
-  </td>
+    {% if include.has_description %}
+    <td>
+      {% include json_schema_item.html data=include.data id=include.id %}
+    </td>
+    <td>
+      <span class="text-secondary"><small>{{include.description | liquefy}}</small></span>
+    </td>
+    {% else %}
+    <td colspan="2">
+      {% include json_schema_item.html data=include.data id=include.id %}
+    </td>
+    {% endif %}
   {% endif %}
 </tr>
 {% if INCLUDE_AFTER != "" %}

--- a/doc/_includes/schema_categories/ConstraintSet.html
+++ b/doc/_includes/schema_categories/ConstraintSet.html
@@ -1,0 +1,28 @@
+<p>These objects represent constraints that can be added to the solver.</p>
+
+<p>They can be loaded from C++ with the following code:</p>
+
+<div class="card bg-light card-source">
+  <div class="card-body">
+{% highlight cpp %}
+// Access the constraint set loader
+#include <mc_solver/ConstraintSetLoader.h>
+
+// Get the constraint from a JSON file
+auto constraint = mc_solver::ConstraintSetLoader::load(solver(), "/my/path/constraint.json");
+
+// Get the constraint from a YAML file
+auto constraint = mc_solver::ConstraintSetLoader::load(solver(), "/my/path/constraint.yaml");
+
+// Actually you can get the constraint from any mc_rtc::Configuration entry
+auto constraint = mc_solver::ConstraintSetLoader::load(solver(), config("constraint"));
+
+// In all the cases above, constraint is an std::shared_ptr<mc_solver::ConstraintSet>
+// but you can retrieve a more precise type, mc_rtc will check that the constraints
+// that was retrieved from disk is compatible with the constraint you requested
+auto constraint = mc_solver::ConstraintSetLoader::load<mc_solver::BoundedSpeedConstr>(solver(), config("constraint"));
+{% endhighlight %}
+  </div>
+</div>
+
+<p>This page shows what data is expected for each constraint available in mc_rtc.</p>

--- a/doc/_includes/schema_categories/MetaTask.html
+++ b/doc/_includes/schema_categories/MetaTask.html
@@ -1,0 +1,28 @@
+<p>These objects represent tasks that can be added to the solver.</p>
+
+<p>They can be loaded from C++ with the following code:</p>
+
+<div class="card bg-light card-source">
+  <div class="card-body">
+{% highlight cpp %}
+// Access the meta task loader
+#include <mc_tasks/MetaTaskLoader.h>
+
+// Get the task from a JSON file
+auto task = mc_tasks::MetaTaskLoader::load(solver(), "/my/path/task.json");
+
+// Get the task from a YAML file
+auto task = mc_tasks::MetaTaskLoader::load(solver(), "/my/path/task.yaml");
+
+// Actually you can get the task from any mc_rtc::Configuration entry
+auto task = mc_tasks::MetaTaskLoader::load(solver(), config("task"));
+
+// In all the cases above, task is an std::shared_ptr<mc_tasks::MetaTask>
+// but you can retrieve a more precise type, mc_rtc will check that the
+// task that was retrieved from disk is compatible with the task you requested
+auto task = mc_tasks::MetaTaskLoader::load<mc_tasks::EndEffectorTask>(solver(), config("task"));
+{% endhighlight %}
+  </div>
+</div>
+
+<p>This page shows what data is expected for each task available in mc_rtc.</p>

--- a/doc/_layouts/json.html
+++ b/doc/_layouts/json.html
@@ -8,12 +8,12 @@ use_mathjax: true
     <div class="list-group list-group-root well">
     {% for cat in page.menu %}
       {% assign category = cat[0] %}
-      <a id="{{category}}_link" href="#{{ cat[0] }}-objects" class="list-group-item list-group-item-category collapsed" data-toggle="collapse" role="button">
+      <a id="{{category}}_link" href="#{{ cat[0] }}-objects" class="list-group-item list-group-item-category collapsed" data-toggle="collapse" data-category="{{cat[0]}}" role="button">
         <span class="chevron-right">{% octicon chevron-right %}</span>
         <span class="chevron-down" style="display:none;">{% octicon chevron-down %}</span>
         {{ cat[0] }} objects
       </a>
-      <div class="collapse" id="{{ cat[0] }}-objects">
+      <div class="collapse collapseCategory" id="{{ cat[0] }}-objects">
         <div class="list-group">
           {% assign sorted_objects = cat[1] | sort %}
           {% for obj in sorted_objects %}
@@ -40,6 +40,9 @@ use_mathjax: true
         {% include json_schema_with_examples.html schema=schema example_sources=example id=id %}
       {% endfor %}
     {% endfor %}
+    {% for category in site.data.json_categories %}
+      {% include json_schema_category_description.html id=category.name description=category.desc %}
+    {% endfor %}
   </div>
   <div class="col-md-1 col-0"></div>
 </div>
@@ -54,24 +57,63 @@ $(document).ready(function()
   {
     var category = param.split('/')[0];
     var name = param.split('/')[1];
-    $('#collapse_' + category + '_' + name).collapse('show');
+    if(name && name.length)
+    {
+      $('#collapse_' + category + '_' + name).collapse('show');
+      $('#' + category + '_' + name + '_link').toggleClass('active', true);
+    }
+    else
+    {
+      $('#collapse_' + category).collapse('show');
+      $('#' + category + '_link').toggleClass('active', true);
+    }
     $('.chevron-down', $('#' + category + '_link')).toggle();
     $('.chevron-right', $('#' + category + '_link')).toggle();
-    $('#' + category + '_' + name + '_link').toggleClass('active', true);
     $('#' + category + '-objects').collapse();
   }
 
   $('.list-group-item-category').on('click', function() {
             var $this = $(this);
-            $('.chevron-down', this).toggle();
-            $('.chevron-right', this).toggle();
+            var was_active = !$this.hasClass('collapsed');
+            $('.collapseSchema').collapse('hide');
+            $('.collapseCategory').collapse('hide');
+            $('.chevron-down').toggle(false);
+            $('.chevron-right').toggle(true);
+            $('.chevron-down', this).toggle(!was_active);
+            $('.chevron-right', this).toggle(was_active);
+            var category = $this.data("category");
+            $('.list-group-item-category').toggleClass('active', false);
+            $('.list-group-item-schema').toggleClass('active', false);
+            if(!was_active)
+            {
+              $('#collapse_' + category).collapse('show');
+              $this.toggleClass('active', true);
+              window.location.hash = category;
+            }
+            else
+            {
+              $this.toggleClass('active', false);
+              window.location.hash = "";
+            }
+            $('.list-group-item-schema').toggleClass('active', false);
   });
 
   $('.list-group-item-schema').on('click', function() {
             var $this = $(this);
             $('.collapseSchema').collapse('hide');
+            var was_active = $this.hasClass('active');
+            $('.list-group-item-category').toggleClass('active', false);
             $('.list-group-item-schema').toggleClass('active', false);
-            $this.toggleClass('active', true);
+            if(was_active)
+            {
+              var category = $this.data("permalink").split("/")[0];
+              $('#collapse_' + category).collapse('show');
+              $(`#${category}_link`).toggleClass('active', true);
+            }
+            else
+            {
+              $this.toggleClass('active', true);
+            }
             window.location.hash = $this.data("permalink");
   });
 

--- a/include/mc_control/fsm/Controller.h
+++ b/include/mc_control/fsm/Controller.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #pragma once
@@ -257,7 +257,7 @@ private:
   /** Teardown the idle state */
   void teardownIdleState();
 
-private:
+protected:
   /** Map robots' names to index */
   std::map<std::string, size_t> robots_idx_;
 

--- a/include/mc_control/fsm/State.h
+++ b/include/mc_control/fsm/State.h
@@ -1,11 +1,14 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #pragma once
 
 #include <mc_control/fsm/api.h>
 #include <mc_control/fsm/states/api.h>
+
+#include <mc_solver/ConstraintSet.h>
+
 #include <mc_rtc/Configuration.h>
 
 namespace mc_control
@@ -143,11 +146,13 @@ protected:
   mc_rtc::Configuration remove_collisions_config_;
   mc_rtc::Configuration add_collisions_after_config_;
   mc_rtc::Configuration remove_collisions_after_config_;
+  mc_rtc::Configuration constraints_config_;
   bool remove_posture_task_ = false;
 
 private:
   std::string name_ = "";
   std::string output_ = "";
+  std::vector<mc_solver::ConstraintSetPtr> constraints_;
 };
 
 using StatePtr = std::shared_ptr<State>;

--- a/include/mc_control/fsm/State.h
+++ b/include/mc_control/fsm/State.h
@@ -9,6 +9,8 @@
 
 #include <mc_solver/ConstraintSet.h>
 
+#include <mc_tasks/MetaTask.h>
+
 #include <mc_rtc/Configuration.h>
 
 namespace mc_control
@@ -138,21 +140,37 @@ protected:
   virtual void teardown(Controller & ctl) = 0;
 
 protected:
+  /** AddContacts in the configuration */
   mc_rtc::Configuration add_contacts_config_;
+  /** RemoveContacts in the configuration */
   mc_rtc::Configuration remove_contacts_config_;
+  /** AddContactsAfter in the configuration */
   mc_rtc::Configuration add_contacts_after_config_;
+  /** RemoveContactsAfter in the configuration */
   mc_rtc::Configuration remove_contacts_after_config_;
+  /** AddCollisions in the configuration */
   mc_rtc::Configuration add_collisions_config_;
+  /** RemoveCollisions in the configuration */
   mc_rtc::Configuration remove_collisions_config_;
+  /** AddCollisionsAfter in the configuration */
   mc_rtc::Configuration add_collisions_after_config_;
+  /** RemoveCollisionsAfter in the configuration */
   mc_rtc::Configuration remove_collisions_after_config_;
+  /** constraints in the configuration */
   mc_rtc::Configuration constraints_config_;
+  /** tasks in the configuration */
+  mc_rtc::Configuration tasks_config_;
+  /** RemovePostureTask in the configuration */
   bool remove_posture_task_ = false;
+
+  /** Constraints managed by the state if any */
+  std::vector<mc_solver::ConstraintSetPtr> constraints_;
+  /** Tasks managed by the state if any */
+  std::vector<mc_tasks::MetaTaskPtr> tasks_;
 
 private:
   std::string name_ = "";
   std::string output_ = "";
-  std::vector<mc_solver::ConstraintSetPtr> constraints_;
 };
 
 using StatePtr = std::shared_ptr<State>;

--- a/include/mc_control/fsm/State.h
+++ b/include/mc_control/fsm/State.h
@@ -10,6 +10,7 @@
 #include <mc_solver/ConstraintSet.h>
 
 #include <mc_tasks/MetaTask.h>
+#include <mc_tasks/PostureTask.h>
 
 #include <mc_rtc/Configuration.h>
 
@@ -161,12 +162,14 @@ protected:
   /** tasks in the configuration */
   mc_rtc::Configuration tasks_config_;
   /** RemovePostureTask in the configuration */
-  bool remove_posture_task_ = false;
+  mc_rtc::Configuration remove_posture_task_;
 
   /** Constraints managed by the state if any */
   std::vector<mc_solver::ConstraintSetPtr> constraints_;
   /** Tasks managed by the state if any */
   std::vector<mc_tasks::MetaTaskPtr> tasks_;
+  /** Posture tasks that were removed by this state */
+  std::vector<mc_tasks::PostureTaskPtr> postures_;
 
 private:
   std::string name_ = "";

--- a/include/mc_control/fsm/states/MetaTasks.h
+++ b/include/mc_control/fsm/states/MetaTasks.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #pragma once
@@ -107,12 +107,8 @@ struct MC_CONTROL_FSM_STATE_DLLAPI MetaTasksState : State
   void teardown(Controller &) override;
 
 protected:
-  /** Configuration for each of the state's tasks */
-  std::map<std::string, mc_rtc::Configuration> tasks_configs_;
   /** Completion criterias used to generate the state's output */
   std::vector<std::string> outputCrit_;
-  /** Tasks managed by the state */
-  std::vector<mc_tasks::MetaTaskPtr> tasks_;
   /** Completion criteria and related infomation */
   struct TaskCriteria
   {

--- a/include/mc_tasks/PostureTask.h
+++ b/include/mc_tasks/PostureTask.h
@@ -120,4 +120,6 @@ private:
   Eigen::VectorXd speed_;
 };
 
+using PostureTaskPtr = std::shared_ptr<PostureTask>;
+
 } // namespace mc_tasks

--- a/src/mc_control/fsm/Controller.cpp
+++ b/src/mc_control/fsm/Controller.cpp
@@ -124,8 +124,12 @@ Controller::Controller(std::shared_ptr<mc_rbdyn::RobotModule> rm, double dt, con
   /** Load collision managers */
   {
     auto config_collisions = config("collisions", std::vector<mc_rtc::Configuration>{});
-    for(const auto & config_cc : config_collisions)
+    for(auto & config_cc : config_collisions)
     {
+      if(!config_cc.has("type"))
+      {
+        config_cc.add("type", "collision");
+      }
       auto cc = mc_solver::ConstraintSetLoader::load<mc_solver::CollisionsConstraint>(solver(), config_cc);
       auto & r1 = robots().robot(cc->r1Index);
       auto & r2 = robots().robot(cc->r2Index);

--- a/src/mc_control/fsm/State.cpp
+++ b/src/mc_control/fsm/State.cpp
@@ -115,11 +115,12 @@ void State::start_(Controller & ctl)
   {
     ctl.solver().removeTask(ctl.getPostureTask(ctl.robot().name()));
   }
-  if(constraints_config_.size())
+  if(!constraints_config_.empty())
   {
-    for(const auto & c : constraints_config_)
+    std::map<std::string, mc_rtc::Configuration> constraints = constraints_config_;
+    for(const auto & c : constraints)
     {
-      constraints_.push_back(mc_solver::ConstraintSetLoader::load(ctl.solver(), c));
+      constraints_.push_back(mc_solver::ConstraintSetLoader::load(ctl.solver(), c.second));
       ctl.solver().addConstraintSet(*constraints_.back());
     }
   }

--- a/src/mc_control/fsm/State.cpp
+++ b/src/mc_control/fsm/State.cpp
@@ -62,7 +62,13 @@ void State::configure_(const mc_rtc::Configuration & config)
   }
   if(config.has("RemovePostureTask"))
   {
+    mc_rtc::log::warning("[MC_RTC_DEPRECATED][{}] RemovePostureTask is deprecated, use DisablePostureTask instead",
+                         name());
     remove_posture_task_.load(config("RemovePostureTask"));
+  }
+  if(config.has("DisablePostureTask"))
+  {
+    remove_posture_task_.load(config("DisablePostureTask"));
   }
   configure(config);
 }
@@ -122,8 +128,7 @@ void State::start_(Controller & ctl)
   }
   if(!remove_posture_task_.empty())
   {
-    const auto & keys = remove_posture_task_.keys();
-    if(keys.empty())
+    if(!remove_posture_task_.size())
     {
       bool remove = remove_posture_task_;
       if(remove)
@@ -141,11 +146,11 @@ void State::start_(Controller & ctl)
     }
     else
     {
-      for(const auto & k : keys)
+      std::vector<std::string> robots = remove_posture_task_;
+      for(const auto & k : robots)
       {
-        bool remove = remove_posture_task_(k);
         auto pt = ctl.getPostureTask(k);
-        if(remove && pt)
+        if(pt)
         {
           ctl.solver().removeTask(pt);
           postures_.push_back(pt);

--- a/src/mc_control/fsm/states/MetaTasks.cpp
+++ b/src/mc_control/fsm/states/MetaTasks.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #include <mc_control/fsm/Controller.h>
@@ -16,35 +16,21 @@ namespace fsm
 
 void MetaTasksState::configure(const mc_rtc::Configuration & config)
 {
-  auto entries = config("tasks", std::map<std::string, mc_rtc::Configuration>{});
-  for(const auto & e : entries)
-  {
-    const auto & tName = e.first;
-    const auto & tConfig = e.second;
-    tasks_configs_[tName].load(tConfig);
-  }
   outputCrit_ = mc_rtc::fromVectorOrElement<std::string>(config, "outputs", outputCrit_);
 }
 
 void MetaTasksState::start(Controller & ctl)
 {
-  for(auto & tc : tasks_configs_)
+  for(size_t i = 0; i < tasks_.size(); ++i)
   {
-    const auto & tName = tc.first;
-    auto & tConfig = tc.second;
-    if(!tConfig.has("name"))
-    {
-      tConfig.add("name", tName);
-    }
-    tasks_.push_back(mc_tasks::MetaTaskLoader::load(ctl.solver(), tConfig));
-    auto & task = tasks_.back();
-    ctl.solver().addTask(task);
+    const auto & t = tasks_[i];
+    const auto & tConfig = tasks_config_(t->name());
     if(tConfig.has("completion"))
     {
       CompletionCriteria crit;
-      crit.configure(*task, ctl.solver().dt(), tConfig("completion"));
-      auto & tCrit = criterias_[tName];
-      tCrit.idx = tasks_.size() - 1;
+      crit.configure(*t, ctl.solver().dt(), tConfig("completion"));
+      auto & tCrit = criterias_[t->name()];
+      tCrit.idx = i;
       tCrit.criteria = crit;
       tCrit.use_output = false;
     }
@@ -52,7 +38,7 @@ void MetaTasksState::start(Controller & ctl)
   // Check validity of tasks output names
   for(const auto & tName : outputCrit_)
   {
-    if(!tasks_configs_.count(tName))
+    if(!tasks_config_.has(tName))
     {
       mc_rtc::log::error_and_throw<std::runtime_error>(
           "[{}] Invalid output task name {}: should be one of the following tasks: {}. Check your \"outputs\" "
@@ -107,13 +93,7 @@ bool MetaTasksState::run(Controller &)
   return false;
 }
 
-void MetaTasksState::teardown(Controller & ctl)
-{
-  for(auto & t : tasks_)
-  {
-    ctl.solver().removeTask(t);
-  }
-}
+void MetaTasksState::teardown(Controller &) {}
 
 } // namespace fsm
 

--- a/src/mc_rbdyn/configuration_io.cpp
+++ b/src/mc_rbdyn/configuration_io.cpp
@@ -140,7 +140,8 @@ mc_rtc::Configuration ConfigurationLoader<mc_rbdyn::BodySensor>::save(const mc_r
 
 mc_rbdyn::Collision ConfigurationLoader<mc_rbdyn::Collision>::load(const mc_rtc::Configuration & config)
 {
-  return mc_rbdyn::Collision(config("body1"), config("body2"), config("iDist"), config("sDist"), config("damping"));
+  return mc_rbdyn::Collision(config("body1"), config("body2"), config("iDist", 0.05), config("sDist", 0.01),
+                             config("damping", 0.0));
 }
 
 mc_rtc::Configuration ConfigurationLoader<mc_rbdyn::Collision>::save(const mc_rbdyn::Collision & c)

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -106,7 +106,7 @@ bool Configuration::empty() const
   {
     return value->ObjectEmpty();
   }
-  return true;
+  return value->IsNull();
 }
 
 size_t Configuration::Json::size() const

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -585,7 +585,7 @@ void Configuration::load(const mc_rtc::Configuration & config)
 
   if(target.IsNull())
   {
-    auto & docFrom = *std::static_pointer_cast<internal::RapidJSONDocument>(config.v.doc_);
+    auto & docFrom = *static_cast<internal::RapidJSONDocument *>(config.v.value_);
     target.CopyFrom(docFrom, doc.GetAllocator());
   }
   else
@@ -625,7 +625,7 @@ void Configuration::load(const mc_rtc::Configuration & config)
     }
     else
     {
-      auto & docFrom = *std::static_pointer_cast<internal::RapidJSONDocument>(config.v.doc_);
+      auto & docFrom = *static_cast<internal::RapidJSONDocument *>(config.v.value_);
       target.SetNull();
       target.CopyFrom(docFrom, doc.GetAllocator());
     }

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -720,9 +720,13 @@ bool Configuration::operator==(const char * rhs) const
 namespace
 {
 template<typename T>
-void add_impl(const std::string & key, T value, void * json_p, void * doc_p)
+void add_impl(const mc_rtc::Configuration & source, const std::string & key, T value, void * json_p, void * doc_p)
 {
   auto & json = *static_cast<internal::RapidJSONValue *>(json_p);
+  if(!json.IsObject())
+  {
+    throw Configuration::Exception("You cannot add entry into a non-object", source);
+  }
   auto & doc = *static_cast<internal::RapidJSONDocument *>(doc_p);
   auto & allocator = doc.GetAllocator();
   internal::RapidJSONValue value_ = mc_rtc::internal::toJSON(value, allocator);
@@ -755,6 +759,10 @@ void push_impl(const Configuration & source, T value, void * json_p, void * doc_
 
 void Configuration::add_null(const std::string & key)
 {
+  if(!v.isObject())
+  {
+    throw Exception("You cannot add entry into a non-object", v);
+  }
   auto & json = *static_cast<internal::RapidJSONValue *>(v.value_);
   auto & doc = *static_cast<internal::RapidJSONDocument *>(v.doc_.get());
   auto & allocator = doc.GetAllocator();
@@ -787,29 +795,33 @@ void Configuration::push_null()
 }
 
 // clang-format off
-void Configuration::add(const std::string & key, bool value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, int value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, unsigned int value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, int64_t value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, uint64_t value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, double value) { add_impl(key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, bool value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, int value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, unsigned int value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, int64_t value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, uint64_t value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, double value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
 void Configuration::add(const std::string & key, const char * value) { add(key, std::string(value)); }
-void Configuration::add(const std::string & key, const std::string & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const Eigen::Vector2d & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const Eigen::Vector3d & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const Eigen::Vector6d & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const Eigen::VectorXd & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const Eigen::Quaterniond & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const Eigen::Matrix3d & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const Eigen::Matrix6d & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const Eigen::MatrixXd & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const sva::PTransformd & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const sva::ForceVecd & value) { add_impl(key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, const sva::MotionVecd & value) { add_impl(key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const std::string & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const Eigen::Vector2d & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const Eigen::Vector3d & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const Eigen::Vector6d & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const Eigen::VectorXd & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const Eigen::Quaterniond & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const Eigen::Matrix3d & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const Eigen::Matrix6d & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const Eigen::MatrixXd & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const sva::PTransformd & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const sva::ForceVecd & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const sva::MotionVecd & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
 // clang-format on
 
 void Configuration::add(const std::string & key, const Configuration & value)
 {
+  if(!v.isObject())
+  {
+    throw Exception("You cannot add entry into a non-object", v);
+  }
   auto & doc = *static_cast<internal::RapidJSONDocument *>(v.doc_.get());
   auto & allocator = doc.GetAllocator();
   auto & json = *static_cast<internal::RapidJSONValue *>(v.value_);
@@ -824,6 +836,10 @@ void Configuration::add(const std::string & key, const Configuration & value)
 
 Configuration Configuration::add(const std::string & key)
 {
+  if(!v.isObject())
+  {
+    throw Exception("You cannot add entry into a non-object", v);
+  }
   auto & doc = *static_cast<internal::RapidJSONDocument *>(v.doc_.get());
   auto & allocator = doc.GetAllocator();
   auto & json = *static_cast<internal::RapidJSONValue *>(v.value_);

--- a/src/mc_solver/BoundedSpeedConstr.cpp
+++ b/src/mc_solver/BoundedSpeedConstr.cpp
@@ -98,7 +98,20 @@ static auto registered = mc_solver::ConstraintSetLoader::register_load_function(
         {
           std::string bName = c("body");
           Eigen::Vector3d bPoint = c("bodyPoint", Eigen::Vector3d::Zero().eval());
-          Eigen::Matrix6d dof = c("dof", Eigen::Matrix6d::Identity().eval());
+          Eigen::Matrix6d dof = Eigen::Matrix6d::Identity();
+          if(c.has("dof"))
+          {
+            const auto & c_dof = c("dof");
+            if(c_dof.size() == 6)
+            {
+              Eigen::Vector6d v = c_dof;
+              dof = v.asDiagonal();
+            }
+            else
+            {
+              dof = c_dof;
+            }
+          }
           if(c.has("speed"))
           {
             ret->addBoundedSpeed(solver, bName, bPoint, dof, c("speed"));

--- a/tests/controllers/CMakeLists.txt
+++ b/tests/controllers/CMakeLists.txt
@@ -70,12 +70,24 @@ endmacro()
 macro(controller_test_run NAME NRITER)
   controller_test_common(${NAME})
   if(CMAKE_CONFIGURATION_TYPES)
-    set(CONFIG_OUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/$<CONFIGURATION>/mc_rtc-${NAME}.conf")
+    set(CONFIG_OUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/$<CONFIG>/mc_rtc-${NAME}.conf")
     file(GENERATE
        OUTPUT ${CONFIG_OUT}
        INPUT ${CMAKE_CURRENT_BINARY_DIR}/${NAME}/mc_rtc-${NAME}.conf)
   else()
     set(CONFIG_OUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/mc_rtc-${NAME}.conf")
+  endif()
+  if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${NAME}.in.yaml")
+    configure_file(${NAME}.in.yaml "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/etc/${NAME}.cmake.yaml")
+    if(CMAKE_CONFIGURATION_TYPES)
+      file(GENERATE
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/$<CONFIG>/etc/${NAME}.yaml"
+        INPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/etc/${NAME}.cmake.yaml")
+    else()
+      file(GENERATE
+        OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/etc/${NAME}.yaml"
+        INPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/etc/${NAME}.cmake.yaml")
+    endif()
   endif()
   set_target_properties(${NAME} PROPERTIES FOLDER tests/controllers/run)
   if(ENABLE_FAST_TESTS)
@@ -159,6 +171,14 @@ controller_test_run(TestCoMTaskController 4001)
 controller_test_run(TestPositionTaskController 5000)
 controller_test_run(TestOrientationTaskController 6001)
 controller_test_run(TestEndEffectorTaskController 4001)
+
+# Test FSM generic state configuration option
+set(FSM_STATES_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/src/mc_control/fsm/states/")
+if(CMAKE_CONFIGURATION_TYPES)
+  set(FSM_STATES_INSTALL_PREFIX "${FSM_STATES_INSTALL_PREFIX}/$<CONFIGURATION>")
+endif()
+controller_test_run(TestFSMStateOptions 100)
+target_link_libraries(TestFSMStateOptions PUBLIC mc_control_fsm)
 
 set(ENABLED_OBSERVERS "\"Encoder\", \"BodySensor\", \"KinematicInertial\"")
 set(RUN_OBSERVERS "\"Encoder\", \"BodySensor\"")

--- a/tests/controllers/TestFSMStateOptions.cpp
+++ b/tests/controllers/TestFSMStateOptions.cpp
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#ifdef BOOST_TEST_MAIN
+#  undef BOOST_TEST_MAIN
+#endif
+
+#include <mc_control/fsm/Controller.h>
+
+#include <mc_control/mc_controller.h>
+
+#include <mc_rtc/logging.h>
+
+#include <boost/test/unit_test.hpp>
+
+namespace mc_control
+{
+
+struct MC_CONTROL_DLLAPI TestFSMStateOptionsController : public fsm::Controller
+{
+public:
+  TestFSMStateOptionsController(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & conf)
+  : fsm::Controller(rm, dt, conf)
+  {
+    // Check that the default constructor loads the robot + ground environment
+    BOOST_CHECK_EQUAL(robots().robots().size(), 2);
+    // Check that JVRC-1 was loaded
+    BOOST_CHECK_EQUAL(robot().name(), "jvrc1");
+    BOOST_REQUIRE(hasRobot("ground"));
+    mc_rtc::log::success("Created TestFSMStateOptionsController");
+  }
+
+  bool run() override
+  {
+    bool ret = fsm::Controller::run();
+    BOOST_REQUIRE(ret);
+    if(iter_ == 0) // TestContactsManipulation
+    {
+      // The AddContacts/RemoveContacts actions should have swapped the contacts
+      BOOST_REQUIRE(!hasContact("LeftFoot"));
+      BOOST_REQUIRE(!hasContact("RightFoot"));
+      BOOST_REQUIRE(hasContact("LeftFootCenter", 0.8));
+      Eigen::Vector6d dof = Eigen::Vector6d::Ones();
+      dof(2) = 0.0;
+      BOOST_REQUIRE(hasContact("RightFootCenter", 0.8, dof));
+    }
+    if(iter_ == 1) // TestRemovePostureTask
+    {
+      // AddContactsAfter/RemoveContactsAfter should have put the contacts back
+      BOOST_REQUIRE(hasContact("LeftFoot"));
+      BOOST_REQUIRE(hasContact("RightFoot"));
+      BOOST_REQUIRE(!hasContact("LeftFootCenter"));
+      BOOST_REQUIRE(!hasContact("RightFootCenter"));
+      // RemovePostureTask should have removed the posture task
+      BOOST_REQUIRE(!getPostureTask("jvrc1")->inSolver());
+    }
+    else
+    {
+      BOOST_REQUIRE(getPostureTask("jvrc1")->inSolver());
+    }
+    if(iter_ > 1) // TestConstraints
+    {
+      // There is now a constraint to set l_wrist speed to a constant
+      auto bIndex = robot().bodyIndexByName("l_wrist");
+      auto speed = robot().bodyVelW()[bIndex].vector();
+      Eigen::Vector6d ref = Eigen::Vector6d::Zero();
+      ref(5) = 0.001;
+      BOOST_REQUIRE((speed - ref).norm() < 5e-4);
+    }
+    iter_++;
+    return ret;
+  }
+
+  void reset(const ControllerResetData & reset_data) override
+  {
+    fsm::Controller::reset(reset_data);
+    BOOST_REQUIRE(hasContact("LeftFoot"));
+    BOOST_REQUIRE(hasContact("RightFoot"));
+  }
+
+  using fsm::Controller::hasContact;
+
+  const fsm::Contact & contact(const fsm::Contact & c)
+  {
+    assert(hasContact(c));
+    return *contacts().find(c);
+  }
+
+  bool hasContact(const std::string & s,
+                  double friction = mc_rbdyn::Contact::defaultFriction,
+                  const Eigen::Vector6d & dof = Eigen::Vector6d::Ones())
+  {
+    fsm::Contact c("jvrc1", "ground", s, "AllGround", friction, dof);
+    if(!hasContact(c))
+    {
+      return false;
+    }
+    const auto & ref = contact(c);
+    return ref.friction == c.friction && ref.dof == c.dof;
+  }
+
+private:
+  unsigned int iter_ = 0;
+};
+
+} // namespace mc_control
+
+CONTROLLER_CONSTRUCTOR("TestFSMStateOptions", mc_control::TestFSMStateOptionsController)

--- a/tests/controllers/TestFSMStateOptions.in.yaml
+++ b/tests/controllers/TestFSMStateOptions.in.yaml
@@ -19,8 +19,7 @@ contacts:
     r1Surface: RightFoot
     r2Surface: AllGround
 collisions:
-  - type: collision
-    useMinimal: true
+  - useMinimal: true
 states:
   TestContactsManipulation:
     base: HalfSitting

--- a/tests/controllers/TestFSMStateOptions.in.yaml
+++ b/tests/controllers/TestFSMStateOptions.in.yaml
@@ -18,10 +18,13 @@ contacts:
     r2: ground
     r1Surface: RightFoot
     r2Surface: AllGround
+collisions:
+  - type: collision
+    useMinimal: true
 states:
   TestContactsManipulation:
     base: HalfSitting
-    RemoveContacts:
+    RemoveContacts: &default-contacts
       - r1: jvrc1
         r2: ground
         r1Surface: LeftFoot
@@ -30,7 +33,7 @@ states:
         r2: ground
         r1Surface: RightFoot
         r2Surface: AllGround
-    AddContacts:
+    AddContacts: &special-contacts
       - r1: jvrc1
         r2: ground
         r1Surface: LeftFootCenter
@@ -42,27 +45,30 @@ states:
         r2Surface: AllGround
         friction: 0.8
         dof: [1, 1, 0, 1, 1, 1]
-    AddContactsAfter:
+    AddContactsAfter: *default-contacts
+    RemoveContactsAfter: *special-contacts
+  TestCollisionsManipulation:
+    base: HalfSitting
+    AddCollisions: &robot-ground-collisions
       - r1: jvrc1
         r2: ground
-        r1Surface: LeftFoot
-        r2Surface: AllGround
+        collisions:
+          - body1: L_WRIST_Y_S
+            body2: ground
+            iDist: 0.05
+            sDist: 0.01
+            damping: 0
+    RemoveCollisionsAfter: *robot-ground-collisions
+    RemoveCollisions: &robot-self-collisions
       - r1: jvrc1
-        r2: ground
-        r1Surface: RightFoot
-        r2Surface: AllGround
-    RemoveContactsAfter:
-      - r1: jvrc1
-        r2: ground
-        r1Surface: LeftFootCenter
-        r2Surface: AllGround
-        friction: 0.8
-      - r1: jvrc1
-        r2: ground
-        r1Surface: RightFootCenter
-        r2Surface: AllGround
-        friction: 0.8
-        dof: [1, 1, 0, 1, 1, 1]
+        r2: jvrc1
+        collisions:
+          - body1: R_WRIST_Y_S
+            body2: R_HIP_Y_S
+            iDist: 0.05
+            sDist: 0.025
+            damping: 0
+    AddCollisionsAfter: *robot-self-collisions
   TestRemovePostureTask:
     base: HalfSitting
     RemovePostureTask: true
@@ -76,5 +82,6 @@ states:
             dof: [1, 1, 1, 1, 1, 1]
             speed: [0, 0, 0, 0, 0, 0.001]
 transitions:
-  - [TestContactsManipulation, OK, TestRemovePostureTask, Auto]
+  - [TestContactsManipulation, OK, TestCollisionsManipulation, Auto]
+  - [TestCollisionsManipulation, OK, TestRemovePostureTask, Auto]
   - [TestRemovePostureTask, OK, TestConstraints, Auto]

--- a/tests/controllers/TestFSMStateOptions.in.yaml
+++ b/tests/controllers/TestFSMStateOptions.in.yaml
@@ -71,7 +71,7 @@ states:
   TestRemovePostureTask:
     base: HalfSitting
     RemovePostureTask: true
-  TestConstraints:
+  TestConstraintsAndTasks:
     base: HalfSitting
     constraints:
       boundedSpeed:
@@ -81,7 +81,10 @@ states:
           - body: l_wrist
             dof: [1, 1, 1, 1, 1, 1]
             speed: [0, 0, 0, 0, 0, 0.001]
+    tasks:
+      CoM:
+        type: com
 transitions:
   - [TestContactsManipulation, OK, TestCollisionsManipulation, Auto]
   - [TestCollisionsManipulation, OK, TestRemovePostureTask, Auto]
-  - [TestRemovePostureTask, OK, TestConstraints, Auto]
+  - [TestRemovePostureTask, OK, TestConstraintsAndTasks, Auto]

--- a/tests/controllers/TestFSMStateOptions.in.yaml
+++ b/tests/controllers/TestFSMStateOptions.in.yaml
@@ -1,0 +1,80 @@
+StatesLibraries: ["@FSM_STATES_INSTALL_PREFIX@"]
+StepByStep: false
+Managed: false
+IdleKeepState: true
+robots:
+  ground:
+    module: env/ground
+constraints:
+  - type: dynamics
+    damper: [0.1, 0.01, 0.5]
+  - type: contact
+contacts:
+  - r1: jvrc1
+    r2: ground
+    r1Surface: LeftFoot
+    r2Surface: AllGround
+  - r1: jvrc1
+    r2: ground
+    r1Surface: RightFoot
+    r2Surface: AllGround
+states:
+  TestContactsManipulation:
+    base: HalfSitting
+    RemoveContacts:
+      - r1: jvrc1
+        r2: ground
+        r1Surface: LeftFoot
+        r2Surface: AllGround
+      - r1: jvrc1
+        r2: ground
+        r1Surface: RightFoot
+        r2Surface: AllGround
+    AddContacts:
+      - r1: jvrc1
+        r2: ground
+        r1Surface: LeftFootCenter
+        r2Surface: AllGround
+        friction: 0.8
+      - r1: jvrc1
+        r2: ground
+        r1Surface: RightFootCenter
+        r2Surface: AllGround
+        friction: 0.8
+        dof: [1, 1, 0, 1, 1, 1]
+    AddContactsAfter:
+      - r1: jvrc1
+        r2: ground
+        r1Surface: LeftFoot
+        r2Surface: AllGround
+      - r1: jvrc1
+        r2: ground
+        r1Surface: RightFoot
+        r2Surface: AllGround
+    RemoveContactsAfter:
+      - r1: jvrc1
+        r2: ground
+        r1Surface: LeftFootCenter
+        r2Surface: AllGround
+        friction: 0.8
+      - r1: jvrc1
+        r2: ground
+        r1Surface: RightFootCenter
+        r2Surface: AllGround
+        friction: 0.8
+        dof: [1, 1, 0, 1, 1, 1]
+  TestRemovePostureTask:
+    base: HalfSitting
+    RemovePostureTask: true
+  TestConstraints:
+    base: HalfSitting
+    constraints:
+      - type: boundedSpeed
+        robot: jvrc1
+        constraints:
+          - body: l_wrist
+            dof: [1, 1, 1, 1, 1, 1]
+            speed: [0, 0, 0, 0, 0, 0.001]
+transitions:
+  - [TestContactsManipulation, OK, TestRemovePostureTask, Auto]
+  - [TestRemovePostureTask, OK, TestConstraints, Auto]

--- a/tests/controllers/TestFSMStateOptions.in.yaml
+++ b/tests/controllers/TestFSMStateOptions.in.yaml
@@ -74,7 +74,8 @@ states:
   TestConstraints:
     base: HalfSitting
     constraints:
-      - type: boundedSpeed
+      boundedSpeed:
+        type: boundedSpeed
         robot: jvrc1
         constraints:
           - body: l_wrist

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -960,6 +960,36 @@ BOOST_AUTO_TEST_CASE(TestLoadConfigurationInConfiguration)
   BOOST_REQUIRE(c1("o")("o") == ref_v);
 }
 
+BOOST_AUTO_TEST_CASE(TestNestedLoading)
+{
+  mc_rtc::Configuration c1;
+  c1.add("a", std::vector<int>{0, 1, 2, 3});
+  c1.add("i", 42);
+  {
+    auto nested = c1.add("in");
+    nested.add("value", 42.42);
+  }
+  mc_rtc::Configuration c2;
+  {
+    auto nested = c2.add("nested");
+    nested.add("b", true);
+  }
+  c1("in").load(c2("nested"));
+  BOOST_REQUIRE(c1("in").has("b"));
+  BOOST_REQUIRE(c1("in")("b") == true);
+  c1("in").load(c2("nested")("b"));
+  BOOST_REQUIRE(c1("in").keys().size() == 0);
+  BOOST_REQUIRE(c1("in").size() == 0);
+  BOOST_REQUIRE(c1("in") == true);
+  mc_rtc::Configuration c3;
+  c3.load(c2("nested")("b"));
+  BOOST_REQUIRE(c3 == true);
+  BOOST_CHECK_THROW(c3.add("nested"), mc_rtc::Configuration::Exception);
+  c1.load(c2("nested")("b"));
+  BOOST_REQUIRE(c1 == true);
+  BOOST_CHECK_THROW(c1.add("nested"), mc_rtc::Configuration::Exception);
+}
+
 BOOST_AUTO_TEST_CASE(TestConfigurartionRemove)
 {
   auto config = mc_rtc::Configuration::fromData(sampleConfig(false, true));


### PR DESCRIPTION
- Allow to specify a set of constraints that are added by the state and removed at completion
- Allow to specify a set of tasks that are added by the state and removed at completion
- ^^ `MetaTasks` now uses the capability above and simply load the completion criteria
- RemovePostureTask now removes all active FSM posture tasks or can be specified to remove some of the active posture tasks

Along the way:
- add a test to check that all common state options work correctly
- introduce `oneOf` support for properties in schema doc generation, I will look into supporting this better for some tasks specifications (for now it won't affect the panel)
- fix `mc_rtc::Configuration::empty()` to return false if the configuration holds a non-null value
- fix a long standing bug where loading a nested configuration into another configuration would load the entire document under some circumstances