### PR TITLE
Give custom build directories.

### DIFF
--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -1003,8 +1003,8 @@ build_git_dependency_configure_and_build()
 {
   git_dependency_parsing $1
   echo "--> Compiling $git_dep (branch $git_dep_branch)"
-  mkdir -p "$SOURCE_DIR/$git_dep/build"
-  cd "$SOURCE_DIR/$git_dep/build"
+  mkdir -p "$SOURCE_DIR/$git_dep/$BUILD_SUBDIR"
+  cd "$SOURCE_DIR/$git_dep/$BUILD_SUBDIR"
   if [[ $OS == "Windows" ]]
   then
     hide_sh
@@ -1144,8 +1144,8 @@ then
   git submodule update --init
   exit_if_error "-- [ERROR] Failed to update submodules"
 fi
-mkdir -p build
-cd build
+mkdir -p $BUILD_SUBDIR
+cd $BUILD_SUBDIR
 if $BUILD_TESTING
 then
   BUILD_TESTING_OPTION=ON

--- a/utils/build_and_install_default_config.sh
+++ b/utils/build_and_install_default_config.sh
@@ -1,5 +1,6 @@
 #default settings
 export SOURCE_DIR=`cd $(dirname $0)/../../; pwd`
+export BUILD_SUBDIR=build
 export INSTALL_PREFIX="/usr/local"
 export WITH_ROS_SUPPORT="true"
 export WITH_PYTHON_SUPPORT="true"


### PR DESCRIPTION
This is useful in case you want to have a separate build directory for each different CMake option, especially BUILD_TYPE, in order to avoid recompiling everything.

I did not add it as an option for the config sample file but I think the name is self-explanatory and easy to find in the defaults.

I am testing it and it is working. I hope I did not forget a place where it should be. 
