### PR TITLE
Ignore the build directory in the corresponding repos

### DIFF
--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -1004,6 +1004,11 @@ build_git_dependency_configure_and_build()
   git_dependency_parsing $1
   echo "--> Compiling $git_dep (branch $git_dep_branch)"
   mkdir -p "$SOURCE_DIR/$git_dep/$BUILD_SUBDIR"
+  # Add the build subdirecory to the ignored files list if it is not ignored already
+  if ! grep -Fxq "/$BUILD_SUBDIR/" $SOURCE_DIR/$git_dep/.git/info/exclude ;   
+  then     
+    echo "/$BUILD_SUBDIR/" >> $SOURCE_DIR/$git_dep/.git/info/exclude ;   
+  fi
   cd "$SOURCE_DIR/$git_dep/$BUILD_SUBDIR"
   if [[ $OS == "Windows" ]]
   then
@@ -1145,6 +1150,11 @@ then
   exit_if_error "-- [ERROR] Failed to update submodules"
 fi
 mkdir -p $BUILD_SUBDIR
+# Add the build subdirecory to the ignored files list if it is not ignored already
+if ! grep -Fxq "/$BUILD_SUBDIR/" .git/info/exclude ;   
+then     
+  echo "/$BUILD_SUBDIR/" >> .git/info/exclude ;   
+fi
 cd $BUILD_SUBDIR
 if $BUILD_TESTING
 then

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -1019,7 +1019,7 @@ build_git_dependency_configure_and_build()
   then
     custom_install_prefix="$2"
   fi
-  exec_log cmake .. -DCMAKE_INSTALL_PREFIX:STRING="$custom_install_prefix" \
+    exec_log cmake $SOURCE_DIR/$git_dep -DCMAKE_INSTALL_PREFIX:STRING="$custom_install_prefix" \
                     -DPYTHON_BINDING:BOOL=${WITH_PYTHON_SUPPORT} \
                     -DPYTHON_BINDING_USER_INSTALL:BOOL=${PYTHON_USER_INSTALL} \
                     -DPYTHON_BINDING_FORCE_PYTHON2:BOOL=${PYTHON_FORCE_PYTHON2} \
@@ -1172,7 +1172,7 @@ if ! $WITH_ROS_SUPPORT
 then
   CMAKE_ADDITIONAL_OPTIONS="${CMAKE_ADDITIONAL_OPTIONS} -DDISABLE_ROS=ON"
 fi
-exec_log cmake ../ -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" \
+exec_log cmake $mc_rtc_dir -DCMAKE_BUILD_TYPE:STRING="$BUILD_TYPE" \
                    -DCMAKE_INSTALL_PREFIX:STRING="$INSTALL_PREFIX" \
                    -DBUILD_TESTING:BOOL=${BUILD_TESTING_OPTION} \
                    -DBUILD_BENCHMARKS:BOOL=${BUILD_BENCHMARKS_OPTION} \


### PR DESCRIPTION
This is a followup to PR #82

It allows one to automatically ignore build directories, so the repos will be clean after the installation.

(Why am I not able to create draft PRs?)
