### PR TITLE
Add autocompletion feature to build_and_install script

### DIFF
--- a/utils/autocompletion.bash
+++ b/utils/autocompletion.bash
@@ -1,0 +1,12 @@
+this_dir=`cd $(dirname $0); pwd`
+mc_rtc_dir=`cd $this_dir/..; pwd`
+
+_build_and_install_completion()
+{
+  _script_commands=$($mc_rtc_dir/utils/build_and_install.sh --inputlist)
+  local cur
+  COMPREPLY=()
+  cur="${COMP_WORDS[COMP_CWORD]}"
+  COMPREPLY=( $(compgen -W "${_script_commands}" -- ${cur}) )
+}
+complete -o nospace -F _build_and_install_completion build_and_install.sh

--- a/utils/autocompletion.zsh
+++ b/utils/autocompletion.zsh
@@ -1,4 +1,5 @@
 autoload -U +X compinit && compinit
 autoload -U +X bashcompinit && bashcompinit
 
-source ./autocompletion.bash
+this_dir=`cd $(dirname $0); pwd`
+source $this_dir/autocompletion.bash

--- a/utils/autocompletion.zsh
+++ b/utils/autocompletion.zsh
@@ -1,0 +1,4 @@
+autoload -U +X compinit && compinit
+autoload -U +X bashcompinit && bashcompinit
+
+source ./autocompletion.bash

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -6,6 +6,17 @@
 
 shopt -s expand_aliases
 
+# display the list of parameters for autocompletion
+if [[ $1 == --inputlist ]];
+then
+        echo -h --help -i --install-prefix -s --source-dir --with-ros-support --with-python-support \
+              --python-user-install --python-force-python2 --python-force-python3 --python-build-2-and-3 \
+              --with-lssol --with-hrp2 --with-hrp4 --with-hrp4j --with-hrp5 --with-mc_udp --with-mc_openrtm \
+              --build-type --build-testing --build-benchmarks --install-system-dependencies \
+              --install-system-dependencies --clone-only --skip-update --skip-dirty-update --user-input \
+              -j --build-core --ros-distro --allow-root
+        exit
+fi
 
 ##########################
 #  --  Configuration --  #
@@ -1301,3 +1312,7 @@ else
     echo_log "If you are running zsh, replace setup.bash with setup.zsh in that last line"
   fi
 fi
+
+echo_log "source $this_dir/autocompletion.bash"
+echo_log "If you want autocompletion on the scripts add also the following to your .bashrc/.zshrc"
+echo_log "If you are running zsh, replace autocompletion.bash with autocompletion.zsh in that last line"


### PR DESCRIPTION
That requires to source a new file in bashrc / zshrc. 

Tested with zsh and bash.