### PR TITLE
Add Robot to GUI elements

### DIFF
--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -94,6 +94,21 @@ struct MC_CONTROL_CLIENT_DLLAPI ControllerClient
   /** Get the current timeout */
   double timeout();
 
+  /** Check if there is an available message from the server and process it
+   *
+   * This is the synchronous pendant to \ref start()
+   *
+   * \param buffer Buffer to receive data from the server, if it is too small,
+   * the buffer is resized and the message is discarded
+   *
+   * \param t_last_received Time when the last message was received, it is
+   * updated if the client receives a message. If a message has not been
+   * received since \ref timeout() then act as if we received an empty message
+   * (server offline).
+   *
+   */
+  void run(std::vector<char> & buffer, std::chrono::system_clock::time_point & t_last_received);
+
 protected:
   /** Should be called when the client is ready to receive data */
   void start();

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #pragma once
@@ -354,6 +354,13 @@ protected:
 
   /** Called to close a table identified by \p id */
   virtual void table_end(const ElementId & /*id*/) {}
+
+  virtual void robot(const ElementId & id,
+                     const std::vector<std::string> & /*parameters*/,
+                     const std::vector<std::vector<double>> & /*q*/)
+  {
+    default_impl("Robot", id);
+  }
 
   /** Should display a form to send schema-based request to the server
    *

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -372,7 +372,8 @@ protected:
 
   virtual void robot(const ElementId & id,
                      const std::vector<std::string> & /*parameters*/,
-                     const std::vector<std::vector<double>> & /*q*/)
+                     const std::vector<std::vector<double>> & /*q*/,
+                     const sva::PTransformd & /*posW*/)
   {
     default_impl("Robot", id);
   }

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -603,7 +603,7 @@ protected:
 
 private:
   /** Default implementations for widgets' creations display a warning message to the user */
-  void default_impl(const std::string & type, const ElementId & id);
+  virtual void default_impl(const std::string & type, const ElementId & id);
 
   /** Handle details of Point3D elements */
   void handle_point3d(const ElementId & id, const mc_rtc::Configuration & data);

--- a/include/mc_rtc/gui.h
+++ b/include/mc_rtc/gui.h
@@ -23,6 +23,7 @@
 #include <mc_rtc/gui/NumberSlider.h>
 #include <mc_rtc/gui/Point3D.h>
 #include <mc_rtc/gui/Polygon.h>
+#include <mc_rtc/gui/Robot.h>
 #include <mc_rtc/gui/Rotation.h>
 #include <mc_rtc/gui/Schema.h>
 #include <mc_rtc/gui/StringInput.h>

--- a/include/mc_rtc/gui/Robot.h
+++ b/include/mc_rtc/gui/Robot.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_rtc/gui/details/traits.h>
+#include <mc_rtc/gui/elements.h>
+#include <mc_rtc/gui/types.h>
+
+#include <mc_rbdyn/Robot.h>
+
+namespace mc_rtc
+{
+
+namespace gui
+{
+
+namespace details
+{
+
+/** Robot should display a robot model in the environment
+ *
+ * The element provides the following data to the client:
+ * - the parameters passed to RobotLoader to get the RobotModule (vector<string>)
+ * - the current robot configuration (vector<vector<double>>)
+ *
+ * \tparam GetT Should return an mc_rbdyn::Robot
+ */
+template<typename GetT>
+struct RobotImpl : public Element
+{
+  static constexpr auto type = Elements::Robot;
+
+  RobotImpl(const std::string & name, GetT get_fn) : Element(name), get_fn_(get_fn)
+  {
+    static_assert(CheckReturnType<GetT, mc_rbdyn::Robot>::value, "Robot element must return an mc_rbdyn::Robot");
+  }
+
+  static constexpr size_t write_size()
+  {
+    return Element::write_size() + 2;
+  }
+
+  void write(mc_rtc::MessagePackBuilder & builder)
+  {
+    const mc_rbdyn::Robot & robot = get_fn_();
+    Element::write(builder);
+    builder.write(robot.module().parameters());
+    builder.write(robot.mbc().q);
+  }
+
+private:
+  GetT get_fn_;
+};
+
+} // namespace details
+
+/** Helper function to create a RobotImpl */
+template<typename GetT>
+details::RobotImpl<GetT> Robot(const std::string & name, GetT get_fn)
+{
+  return details::RobotImpl<GetT>(name, get_fn);
+}
+
+} // namespace gui
+
+} // namespace mc_rtc

--- a/include/mc_rtc/gui/Robot.h
+++ b/include/mc_rtc/gui/Robot.h
@@ -39,7 +39,7 @@ struct RobotImpl : public Element
 
   static constexpr size_t write_size()
   {
-    return Element::write_size() + 2;
+    return Element::write_size() + 3;
   }
 
   void write(mc_rtc::MessagePackBuilder & builder)
@@ -48,6 +48,7 @@ struct RobotImpl : public Element
     Element::write(builder);
     builder.write(robot.module().parameters());
     builder.write(robot.mbc().q);
+    builder.write(robot.posW());
   }
 
 private:

--- a/include/mc_rtc/gui/elements.h
+++ b/include/mc_rtc/gui/elements.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #pragma once
@@ -40,7 +40,8 @@ enum class Elements
   Force,
   Arrow,
   XYTheta,
-  Table
+  Table,
+  Robot
 };
 
 /** Element is the common class for every element's type available in the

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -327,7 +327,7 @@ void ControllerClient::handle_widget(const ElementId & id, const mc_rtc::Configu
                      data.at(4, std::vector<mc_rtc::Configuration>{}));
         break;
       case Elements::Robot:
-        robot(id, data[3], data[4]);
+        robot(id, data[3], data[4], data[5]);
         break;
       default:
         mc_rtc::log::error("Type {} is not handlded by this ControllerClient", static_cast<int>(type));

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #include <mc_control/ControllerClient.h>
@@ -309,6 +309,9 @@ void ControllerClient::handle_widget(const ElementId & id, const mc_rtc::Configu
       case Elements::Table:
         handle_table(id, data.at(3, std::vector<std::string>{}), data.at(5, std::vector<std::string>{}),
                      data.at(4, std::vector<mc_rtc::Configuration>{}));
+        break;
+      case Elements::Robot:
+        robot(id, data[3], data[4]);
         break;
       default:
         mc_rtc::log::error("Type {} is not handlded by this ControllerClient", static_cast<int>(type));

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -100,6 +100,44 @@ void ControllerClient::reconnect(const std::string & sub_conn_uri, const std::st
   start();
 }
 
+void ControllerClient::run(std::vector<char> & buff, std::chrono::system_clock::time_point & t_last_received)
+{
+  memset(buff.data(), 0, buff.size() * sizeof(char));
+  auto recv = nn_recv(sub_socket_, buff.data(), buff.size(), NN_DONTWAIT);
+  auto now = std::chrono::system_clock::now();
+  if(recv < 0)
+  {
+    if(timeout_ > 0 && now - t_last_received > std::chrono::duration<double>(timeout_))
+    {
+      t_last_received = now;
+      if(run_)
+      {
+        handle_gui_state(mc_rtc::Configuration{});
+      }
+    }
+    auto err = nn_errno();
+    if(err != EAGAIN)
+    {
+      mc_rtc::log::error("ControllerClient failed to receive with errno: {}", err);
+    }
+  }
+  else if(recv > 0)
+  {
+    if(recv > static_cast<int>(buff.size()))
+    {
+      mc_rtc::log::warning(
+          "Receive buffer was too small to receive the latest state message, will resize for next time");
+      buff.resize(2 * buff.size());
+      return;
+    }
+    t_last_received = now;
+    if(run_)
+    {
+      handle_gui_state(mc_rtc::Configuration::fromMessagePack(buff.data(), static_cast<size_t>(recv)));
+    }
+  }
+}
+
 void ControllerClient::start()
 {
   run_ = true;
@@ -108,40 +146,7 @@ void ControllerClient::start()
     auto t_last_received = std::chrono::system_clock::now();
     while(run_)
     {
-      memset(buff.data(), 0, buff.size() * sizeof(char));
-      auto recv = nn_recv(sub_socket_, buff.data(), buff.size(), NN_DONTWAIT);
-      auto now = std::chrono::system_clock::now();
-      if(recv < 0)
-      {
-        if(timeout_ > 0 && now - t_last_received > std::chrono::duration<double>(timeout_))
-        {
-          t_last_received = now;
-          if(run_)
-          {
-            handle_gui_state(mc_rtc::Configuration{});
-          }
-        }
-        auto err = nn_errno();
-        if(err != EAGAIN)
-        {
-          mc_rtc::log::error("ControllerClient failed to receive with errno: {}", err);
-        }
-      }
-      else if(recv > 0)
-      {
-        if(recv > static_cast<int>(buff.size()))
-        {
-          mc_rtc::log::warning(
-              "Receive buffer was too small to receive the latest state message, will resize for next time");
-          buff.resize(2 * buff.size());
-          continue;
-        }
-        t_last_received = now;
-        if(run_)
-        {
-          handle_gui_state(mc_rtc::Configuration::fromMessagePack(buff.data(), static_cast<size_t>(recv)));
-        }
-      }
+      run(buff, t_last_received);
       std::this_thread::sleep_for(std::chrono::microseconds(500));
     }
   });

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -394,8 +394,17 @@ void ControllerClient::handle_trajectory(const ElementId & id, const mc_rtc::Con
       catch(mc_rtc::Configuration::Exception & exc)
       {
         exc.silence();
-        Eigen::Vector3d p = data;
-        trajectory(id, p, config);
+        try
+        {
+          Eigen::Vector3d p = data;
+          trajectory(id, p, config);
+        }
+        catch(mc_rtc::Configuration::Exception & exc)
+        {
+          exc.silence();
+          sva::PTransformd pos = data;
+          trajectory(id, pos, config);
+        }
       }
     }
   }

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -129,6 +129,13 @@ mc_rbdyn::Robot & MCController::loadRobot(mc_rbdyn::RobotModulePtr rm,
   if(updateNrVars)
   {
     solver().updateNrVars();
+    if(gui())
+    {
+      size_t i = robots.size();
+      gui()->addElement({"Robots"}, mc_rtc::gui::Robot(r.name(), [i, this]() -> const mc_rbdyn::Robot & {
+                          return this->robots().robots()[i];
+                        }));
+    }
   }
   return r;
 }

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -125,17 +125,14 @@ mc_rbdyn::Robot & MCController::loadRobot(mc_rbdyn::RobotModulePtr rm,
       bs.push(b.name());
     }
     data("surfaces").add(r.name(), r.availableSurfaces());
+    auto name = r.name();
+    gui()->addElement({"Robots"}, mc_rtc::gui::Robot(r.name(), [name, this]() -> const mc_rbdyn::Robot & {
+                        return this->robot(name);
+                      }));
   }
   if(updateNrVars)
   {
     solver().updateNrVars();
-    if(gui())
-    {
-      size_t i = robots.size() - 1;
-      gui()->addElement({"Robots"}, mc_rtc::gui::Robot(r.name(), [i, this]() -> const mc_rbdyn::Robot & {
-                          return this->robots().robots()[i];
-                        }));
-    }
   }
   return r;
 }

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -131,7 +131,7 @@ mc_rbdyn::Robot & MCController::loadRobot(mc_rbdyn::RobotModulePtr rm,
     solver().updateNrVars();
     if(gui())
     {
-      size_t i = robots.size();
+      size_t i = robots.size() - 1;
       gui()->addElement({"Robots"}, mc_rtc::gui::Robot(r.name(), [i, this]() -> const mc_rbdyn::Robot & {
                           return this->robots().robots()[i];
                         }));

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -677,13 +677,6 @@ bool MCGlobalController::run()
     bool r = controller_->run();
     auto end_controller_run_t = clock::now();
 
-    if(server_)
-    {
-      auto start_gui_t = clock::now();
-      server_->handle_requests(*controller_->gui_);
-      server_->publish(*controller_->gui_);
-      gui_dt = clock::now() - start_gui_t;
-    }
     pre_gripper_mbcs_ = controller_->robots().mbcs();
     for(size_t i = 0; i < controller_->robots().size(); ++i)
     {
@@ -704,6 +697,13 @@ bool MCGlobalController::run()
       auto start_log_t = clock::now();
       controller_->logger().log();
       log_dt = clock::now() - start_log_t;
+    }
+    if(server_)
+    {
+      auto start_gui_t = clock::now();
+      server_->handle_requests(*controller_->gui_);
+      server_->publish(*controller_->gui_);
+      gui_dt = clock::now() - start_gui_t;
     }
     controller_run_dt = end_controller_run_t - start_controller_run_t;
     solver_build_and_solve_t = boost_ms(boost_ns(controller_->solver().solveAndBuildTime().wall)).count();

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -366,9 +366,28 @@ Configuration::operator Eigen::VectorXd() const
 
 Configuration::operator Eigen::Quaterniond() const
 {
-  if(v.isArray() && v.size() == 4 && v[0].isNumeric())
+  if(v.isArray() && v[0].isNumeric())
   {
-    return Eigen::Quaterniond(v[0].asDouble(), v[1].asDouble(), v[2].asDouble(), v[3].asDouble()).normalized();
+    if(v.size() == 4)
+    {
+      return Eigen::Quaterniond(v[0].asDouble(), v[1].asDouble(), v[2].asDouble(), v[3].asDouble()).normalized();
+    }
+    else if(v.size() == 9)
+    {
+      Eigen::Matrix3d m;
+      for(size_t i = 0; i < 3; ++i)
+      {
+        for(size_t j = 0; j < 3; ++j)
+        {
+          m(static_cast<int>(i), static_cast<int>(j)) = v[3 * i + j].asDouble();
+        }
+      }
+      return Eigen::Quaterniond(m).normalized();
+    }
+    else if(v.size() == 3)
+    {
+      return Eigen::Quaterniond(mc_rbdyn::rpyToMat(v[0].asDouble(), v[1].asDouble(), v[2].asDouble())).normalized();
+    }
   }
   throw Exception("Stored Json value is not a Quaterniond", v);
 }

--- a/src/mc_solver/QPSolver.cpp
+++ b/src/mc_solver/QPSolver.cpp
@@ -10,6 +10,7 @@
 #include <mc_tasks/MetaTask.h>
 
 #include <mc_rtc/gui/Button.h>
+#include <mc_rtc/gui/Force.h>
 #include <mc_rtc/gui/Form.h>
 
 #include <Tasks/Bounds.h>
@@ -183,6 +184,17 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
       logger_->removeLogEntry("contact_" + r1 + "::" + r1S + "_" + r2 + "::" + r2S);
     }
   }
+  if(gui_)
+  {
+    for(const auto & contact : contacts_)
+    {
+      const std::string & r1 = robots().robot(contact.r1Index()).name();
+      const std::string & r1S = contact.r1Surface()->name();
+      const std::string & r2 = robots().robot(contact.r2Index()).name();
+      const std::string & r2S = contact.r2Surface()->name();
+      gui_->removeElement({"Contacts"}, fmt::format("{}::{}/{}::{}", r1, r1S, r2, r2S));
+    }
+  }
   contacts_ = contacts;
   if(logger_)
   {
@@ -194,6 +206,22 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
       const std::string & r2S = contact.r2Surface()->name();
       logger_->addLogEntry("contact_" + r1 + "::" + r1S + "_" + r2 + "::" + r2S,
                            [this, &contact]() { return desiredContactForce(contact); });
+    }
+  }
+  if(gui_)
+  {
+    for(const auto & contact : contacts_)
+    {
+      const std::string & r1 = robots().robot(contact.r1Index()).name();
+      const std::string & r1S = contact.r1Surface()->name();
+      const std::string & r2 = robots().robot(contact.r2Index()).name();
+      const std::string & r2S = contact.r2Surface()->name();
+      gui_->addElement({"Contacts"}, mc_rtc::gui::Force(fmt::format("{}::{}/{}::{}", r1, r1S, r2, r2S),
+                                                        [this, &contact]() { return desiredContactForce(contact); },
+                                                        [this, &contact]() {
+                                                          return robots().robots()[contact.r1Index()].surfacePose(
+                                                              contact.r1Surface()->name());
+                                                        }));
     }
   }
   uniContacts.clear();

--- a/utils/mc_log_gui/mc_log_ui/mc_log_ui.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_ui.py
@@ -203,7 +203,7 @@ class LineStyleDialog(CommonStyleDialog):
     super(LineStyleDialog, self).apply()
     self.style.label = self.labelInput.text()
     self.set_style(self.name, self.style)
-    self.setWindowTitle('Edit {} style'.format(style.label))
+    self.setWindowTitle('Edit {} style'.format(self.style.label))
     self.canvas.draw()
 
 class ColorButtonRightClick(QtWidgets.QPushButton):


### PR DESCRIPTION
The main goal of this PR is to add a new GUI element: Robot

This allows GUI implementations to display the robot

Also included in this PR, some minor changes:
- [3rd-party] Bump embedded Qhull version
- [mc_rtc] Accept 3D matrix and rpy representation to read Quaternions from a configuration
- [mc_control] Add computed contact forces to the GUI
- [ControllerClient] Fix an issue with trajectory de-serialization
- [ControllerClient] Always read the latest message from the publisher
- [ControllerClient] Make the default widget implementation virtual
- [ControllerClient] Add a synchronous run method
- [tests] Add more elements to the dummy GUI server