### PR TITLE
[doc] Indicate the contact wrench ref. frame in EqualityConstraintForce

### DIFF
--- a/include/mc_solver/EqualityConstraint.h
+++ b/include/mc_solver/EqualityConstraint.h
@@ -127,6 +127,9 @@ struct EqualityConstraintLambda : public utils::EqualityConstraint<utils::Update
  * Helper class to write an equality constraint for Tasks. This constraint
  * applies to the wrench associated with a given contact.
  *
+ * The wrench \f$ \mathbf{f}_{cI} \f$ is expressed in the first robot (`cid.r1Index`)
+ * contact surface frame.
+ *
  * This implements \f$ A * \mathbf{f}_{cI} = b \f$
  *
  * Where \f$cI\f$ is the contact id you provide at construction.

--- a/include/mc_solver/GenInequalityConstraint.h
+++ b/include/mc_solver/GenInequalityConstraint.h
@@ -135,6 +135,9 @@ struct GenInequalityConstraintLambda : public utils::GenInequalityConstraint<uti
  * Helper class to write a general inequality constraint for Tasks. This constraint
  * applies to the wrench associated with a given contact.
  *
+ * The wrench \f$ \mathbf{f}_{cI} \f$ is expressed in the first robot (`cid.r1Index`)
+ * contact surface frame.
+ *
  * This implements \f$ L \le A * \mathbf{f}_{cI} \le U \f$
  *
  * Where \f$cI\f$ is the contact id you provide at construction.

--- a/include/mc_solver/InequalityConstraint.h
+++ b/include/mc_solver/InequalityConstraint.h
@@ -128,6 +128,9 @@ struct InequalityConstraintLambda : public utils::InequalityConstraint<utils::Up
  * Helper class to write an inequality constraint for Tasks. This constraint
  * applies to the wrench associated with a given contact.
  *
+ * The wrench \f$ \mathbf{f}_{cI} \f$ is expressed in the first robot (`cid.r1Index`)
+ * contact surface frame.
+ *
  * This implements \f$ A * \mathbf{f}_{cI} \le b \f$
  *
  * Where \f$cI\f$ is the contact id you provide at construction.


### PR DESCRIPTION
This PR adds a note to the `EqualityConstraintForce` documentation about the reference frame in which the contact wrench is expressed (contact surface frame of the first robot `r1Index` involved in the contact).