### PR TITLE
[lipm_stabilizer::Contact] fix bug in [x|y]min, [x|y]max

### DIFF
--- a/include/mc_tasks/lipm_stabilizer/Contact.h
+++ b/include/mc_tasks/lipm_stabilizer/Contact.h
@@ -181,7 +181,7 @@ struct MC_TASKS_DLLAPI Contact
    */
   double xmin() const
   {
-    return contactPolygon_[0].x();
+    return xyMin_.x();
   }
 
   /**
@@ -190,7 +190,7 @@ struct MC_TASKS_DLLAPI Contact
    */
   double xmax() const
   {
-    return contactPolygon_[1].x();
+    return xyMax_.x();
   }
 
   /**
@@ -199,7 +199,7 @@ struct MC_TASKS_DLLAPI Contact
    */
   double ymin() const
   {
-    return contactPolygon_[3].y();
+    return xyMin_.y();
   }
 
   /**
@@ -208,7 +208,7 @@ struct MC_TASKS_DLLAPI Contact
    */
   double ymax() const
   {
-    return contactPolygon_[0].y();
+    return xyMax_.y();
   }
 
 private:
@@ -231,6 +231,9 @@ private:
 
   std::vector<Eigen::Vector3d>
       contactPolygon_; /**< Polygon of the surface boundaries along the sagital/lateral plane */
+
+  Eigen::Vector2d xyMin_ = Eigen::Vector2d::Zero(); /**< Minimum position in support polygon */
+  Eigen::Vector2d xyMax_ = Eigen::Vector2d::Zero(); /**< Maximum position in support polygon */
 };
 
 } // namespace internal

--- a/src/mc_tasks/lipm_stabilizer/Contact.cpp
+++ b/src/mc_tasks/lipm_stabilizer/Contact.cpp
@@ -110,6 +110,15 @@ void Contact::findSurfaceBoundaries(const mc_rbdyn::Surface & surface)
                             + surfacePose_.rotation().inverse() * Eigen::Vector3d{maxSagital, minLateral, 0.});
   contactPolygon_.push_back(surfacePose_.translation()
                             + surfacePose_.rotation().inverse() * Eigen::Vector3d{minSagital, minLateral, 0.});
+
+  const auto & xMinMax =
+      std::minmax_element(contactPolygon_.begin(), contactPolygon_.end(),
+                          [](const Eigen::Vector3d & v1, const Eigen::Vector3d & v2) { return v1.x() < v2.x(); });
+  const auto & yMinMax =
+      std::minmax_element(contactPolygon_.begin(), contactPolygon_.end(),
+                          [](const Eigen::Vector3d & v1, const Eigen::Vector3d & v2) { return v1.y() < v2.y(); });
+  xyMin_ << xMinMax.first->x(), yMinMax.first->y();
+  xyMax_ << xMinMax.second->x(), yMinMax.second->y();
 }
 
 HrepXd Contact::hrep(const Eigen::Vector3d & vertical) const


### PR DESCRIPTION
`lipm_stabilizer::Contact::[x|y][min|max]` methods have bug. They returns incorrect value when foot rotates around vertical axis.

These values are used only for visualization (plot and log) and do not affect the robot behavior.

### example
Send the same footstep with/without this pull request. See the max position of support in the last step. It is incorrect before PR (ZMP goes outside of incorrect support range) and becomes correct after PR.

#### before PR
![before](https://user-images.githubusercontent.com/6636600/104160609-c0866d80-5434-11eb-93f6-b46df4165d52.png)

#### after PR
![after](https://user-images.githubusercontent.com/6636600/104160632-c8dea880-5434-11eb-9f0e-7d195221d595.png)
