### PR TITLE
[mc_rtc] Add a way to keep track of the source of a log entryTopic/simplified logging

### DIFF
--- a/doc/tutorials/usage/logging.md
+++ b/doc/tutorials/usage/logging.md
@@ -42,6 +42,67 @@ Normally, an `addLogEntry` call should have a corresponding `removeLogEntry` cal
 logger().removeLogEntry("entry_name");
 ```
 
+#### With a logging source
+
+You can specify a logging source:
+
+```cpp
+// In this example, "this" is the source
+logger().addLogEntry("entry_A", this, [this]() { return a; });
+logger().addLogEntry("entry_B", this, [this]() { return b; });
+logger().addLogEntry("entry_C", this, [this]() { return c; });
+
+// You can also group calls with the same source
+logger().addLogEntries(this,
+                       "entry_A", [this]() { return a; },
+                       "entry_B", [this]() { return b; },
+                       "entry_C", [this]() { return c; });
+```
+
+Then all the entries can be removed at once:
+
+```cpp
+logger().removeLogEntries(this);
+
+// This would yield the same result but you would need to keep the addLogEntry and removeLogEntry call in sync
+logger().removeLogEntry("entry_A");
+logger().removeLogEntry("entry_B");
+logger().removeLogEntry("entry_C");
+```
+
+#### Logging members or method
+
+As seen above, a common pattern is to load a member or method called on `this` instance, this can be done in a simple way. The main benefit of this approach is to avoid the performance caveat highlighted below.
+
+```cpp
+struct MyObject
+{
+  Eigen::Vector3d data_;
+  sva::PTransformd something_;
+
+  Eigen::Vector6d computeVector();
+
+  const sva::PTransformd & referenceBody();
+  void referenceBody(const std::string &);
+
+  void addToLogger(mc_rtc::Logger & logger)
+  {
+    // This is the actual syntax required in C++11
+    logger.addLogEntry<decltype(&MyObject::data_), &MyObject::data_>("data", this);
+    // We have the following macro helper
+    MC_RTC_LOG_HELPER("something", something_);
+    // Also works with methods
+    MC_RTC_LOG_HELPER("computeVector", computeVector);
+    // But for overloaded methods we must use another macro to work-around ambiguity issues
+    MC_RTC_LOG_GETTER("referenceBody", referenceBody);
+  }
+};
+```
+
+The `MC_RTC_LOG_HELPER` and `MC_RTC_LOG_GETTER` make the following two assumptions:
+- `this` is the logging source
+- `logger` is the logger instance you are adding the data to
+
 #### Python interface
 
 The Python interface is very similar:

--- a/include/mc_observers/BodySensorObserver.h
+++ b/include/mc_observers/BodySensorObserver.h
@@ -76,7 +76,6 @@ struct MC_OBSERVER_DLLAPI BodySensorObserver : public Observer
 
 protected:
   void addToLogger(const mc_control::MCController &, mc_rtc::Logger &, const std::string & category) override;
-  void removeFromLogger(mc_rtc::Logger &, const std::string & category) override;
   void addToGUI(const mc_control::MCController &,
                 mc_rtc::gui::StateBuilder &,
                 const std::vector<std::string> & category) override;

--- a/include/mc_observers/EncoderObserver.h
+++ b/include/mc_observers/EncoderObserver.h
@@ -59,7 +59,6 @@ struct MC_OBSERVER_DLLAPI EncoderObserver : public Observer
 
 protected:
   void addToLogger(const mc_control::MCController &, mc_rtc::Logger &, const std::string &) override;
-  void removeFromLogger(mc_rtc::Logger &, const std::string &) override;
 
 protected:
   /*! Position update type */

--- a/include/mc_observers/KinematicInertialObserver.h
+++ b/include/mc_observers/KinematicInertialObserver.h
@@ -55,7 +55,6 @@ struct MC_OBSERVER_DLLAPI KinematicInertialObserver : public KinematicInertialPo
 
 protected:
   void addToLogger(const mc_control::MCController & ctl, mc_rtc::Logger &, const std::string & category) override;
-  void removeFromLogger(mc_rtc::Logger &, const std::string & category) override;
   void addToGUI(const mc_control::MCController &,
                 mc_rtc::gui::StateBuilder &,
                 const std::vector<std::string> & category) override;

--- a/include/mc_observers/KinematicInertialPoseObserver.h
+++ b/include/mc_observers/KinematicInertialPoseObserver.h
@@ -77,7 +77,6 @@ struct MC_OBSERVER_DLLAPI KinematicInertialPoseObserver : public Observer
 
 protected:
   void addToLogger(const mc_control::MCController & ctl, mc_rtc::Logger &, const std::string & category) override;
-  void removeFromLogger(mc_rtc::Logger &, const std::string & category) override;
   void addToGUI(const mc_control::MCController &,
                 mc_rtc::gui::StateBuilder &,
                 const std::vector<std::string> & category) override;

--- a/include/mc_observers/Observer.h
+++ b/include/mc_observers/Observer.h
@@ -115,7 +115,7 @@ struct MC_OBSERVERS_DLLAPI Observer
   }
 
   /*! \brief Remove observer from logger. */
-  void removeFromLogger_(mc_rtc::Logger & logger, std::string category = "")
+  void removeFromLogger_(mc_rtc::Logger & logger, const std::string & category = "")
   {
     removeFromLogger(logger, category + "_" + name_);
   }
@@ -183,12 +183,11 @@ protected:
 
   /*! \brief Remove observer from logger
    *
-   * Default implementation does nothing, each observer implementation is
-   * responsible for removing all logs entry that it added.
+   * The default implementation removes the entry that were registered by this
    *
    * @param category Category in which this observer entries are logged
    */
-  virtual void removeFromLogger(mc_rtc::Logger &, const std::string & /* category */) {}
+  virtual void removeFromLogger(mc_rtc::Logger &, const std::string & /* category */);
 
   /*! \brief Add observer information the GUI.
    *

--- a/include/mc_rtc/log/Logger.h
+++ b/include/mc_rtc/log/Logger.h
@@ -177,6 +177,9 @@ public:
    */
   const std::string & path() const;
 
+  /** Flush the log data to disk (only implemented in the synchronous method) */
+  void flush();
+
 private:
   /** Hold information about a log entry stored in this instance */
   struct LogEntry

--- a/include/mc_rtc/log/Logger.h
+++ b/include/mc_rtc/log/Logger.h
@@ -171,6 +171,12 @@ public:
   /** Return the time elapsed since the controller start */
   double t() const;
 
+  /** Access the file opened by this Logger
+   *
+   * \note This is empty before \ref start has been called
+   */
+  const std::string & path() const;
+
 private:
   /** Hold information about a log entry stored in this instance */
   struct LogEntry

--- a/include/mc_rtc/log/Logger.h
+++ b/include/mc_rtc/log/Logger.h
@@ -133,25 +133,6 @@ public:
                           }};
   }
 
-  /** Add a log entry from a source and a pointer to member
-   *
-   * This is an helper above the source + callback version
-   *
-   * \param name Name of the log entry
-   *
-   * \param source Source of the log entry
-   *
-   * \param member Member pointer for the source data
-   *
-   */
-  template<typename SourceT,
-           typename MemberT,
-           typename std::enable_if<mc_rtc::log::is_serializable_member<MemberT SourceT::*>::value, int>::type = 0>
-  void addLogEntry(const std::string & name, const SourceT * source, MemberT SourceT::*member)
-  {
-    addLogEntry(name, source, [source, member]() -> const MemberT & { return source->*member; });
-  }
-
   /** Add a log entry from a source and a compile-time pointer to member
    *
    * This is slightly more efficient than the source + pointer to member version at the cost of annoying syntax,
@@ -173,25 +154,6 @@ public:
   {
     using MemberT = decltype(source->*member);
     addLogEntry(name, source, [source]() -> const MemberT & { return source->*member; });
-  }
-
-  /** Add a log entry from a source and a pointer to method
-   *
-   * This is an helper above the source + callback version
-   *
-   * \param name Name of the log entry
-   *
-   * \param source Source of the log entry
-   *
-   * \param method Method pointer for the source data
-   */
-  template<
-      typename SourceT,
-      typename MethodT,
-      typename std::enable_if<mc_rtc::log::is_serializable_getter<MethodT (SourceT::*)() const>::value, int>::type = 0>
-  void addLogEntry(const std::string & name, const SourceT * source, MethodT (SourceT::*method)() const)
-  {
-    addLogEntry(name, source, [source, method]() -> MethodT { return (source->*method)(); });
   }
 
   /** Add a log entry from a source and a compile-time pointer to method

--- a/include/mc_rtc/log/utils.h
+++ b/include/mc_rtc/log/utils.h
@@ -110,6 +110,31 @@ struct is_serializable
 template<typename...>
 using void_t = void;
 
+/** True for member pointer that are serializable */
+template<typename T>
+struct is_serializable_member
+{
+  static constexpr bool value = false;
+};
+
+template<typename T, typename MemberT>
+struct is_serializable_member<MemberT T::*>
+{
+  static constexpr bool value = is_serializable<typename std::decay<MemberT>::type>::value;
+};
+
+template<typename T>
+struct is_serializable_getter
+{
+  static constexpr bool value = false;
+};
+
+template<typename T, typename MethodRetT>
+struct is_serializable_getter<MethodRetT (T::*)() const>
+{
+  static constexpr bool value = is_serializable<typename std::decay<MethodRetT>::type>::value;
+};
+
 /** Type-traits for callables that returns a serializable type
  *
  *  value is true if T() return type (after decaying) is serializable

--- a/include/mc_rtc/log/utils.h
+++ b/include/mc_rtc/log/utils.h
@@ -107,13 +107,22 @@ struct is_serializable
   static constexpr bool value = GetLogType<T>::type != mc_rtc::log::LogType::None;
 };
 
+template<typename...>
+using void_t = void;
+
 /** Type-traits for callables that returns a serializable type
  *
  *  value is true if T() return type (after decaying) is serializable
  *
  */
-template<typename T>
+template<typename T, typename = void>
 struct callback_is_serializable
+{
+  static constexpr bool value = false;
+};
+
+template<typename T>
+struct callback_is_serializable<T, void_t<typename std::result_of<T()>::type>>
 {
   using ret_type = typename std::result_of<T()>::type;
   using base_type = typename std::decay<ret_type>::type;

--- a/include/mc_tasks/AddRemoveContactTask.h
+++ b/include/mc_tasks/AddRemoveContactTask.h
@@ -122,13 +122,13 @@ public:
    * \returns Velocity error of the LinVelocity task */
   Eigen::Vector3d velError();
 
-  virtual void dimWeight(const Eigen::VectorXd & dimW) override;
+  void dimWeight(const Eigen::VectorXd & dimW) override;
 
-  virtual Eigen::VectorXd dimWeight() const override;
+  Eigen::VectorXd dimWeight() const override;
 
-  virtual Eigen::VectorXd eval() const override;
+  Eigen::VectorXd eval() const override;
 
-  virtual Eigen::VectorXd speed() const override;
+  Eigen::VectorXd speed() const override;
 
 public:
   mc_rbdyn::Robots & robots;
@@ -169,14 +169,14 @@ private:
   {
   }
 
-  virtual void resetJointsSelector(mc_solver::QPSolver &) override {}
+  void resetJointsSelector(mc_solver::QPSolver &) override {}
 
-  virtual void reset() override {}
+  void reset() override {}
 
 private:
-  virtual void addToSolver(mc_solver::QPSolver & solver) override;
+  void addToSolver(mc_solver::QPSolver & solver) override;
 
-  virtual void removeFromSolver(mc_solver::QPSolver & solver) override;
+  void removeFromSolver(mc_solver::QPSolver & solver) override;
 
   void update(mc_solver::QPSolver &) override;
 

--- a/include/mc_tasks/AdmittanceTask.h
+++ b/include/mc_tasks/AdmittanceTask.h
@@ -252,7 +252,6 @@ protected:
 
   void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
   void addToLogger(mc_rtc::Logger & logger) override;
-  void removeFromLogger(mc_rtc::Logger & logger) override;
 
   /** Surface transform's refVelB() becomes internal to the task.
    *

--- a/include/mc_tasks/CoMTask.h
+++ b/include/mc_tasks/CoMTask.h
@@ -32,7 +32,7 @@ public:
    */
   CoMTask(const mc_rbdyn::Robots & robots, unsigned int robotIndex, double stiffness = 5.0, double weight = 100.);
 
-  virtual void reset() override;
+  void reset() override;
 
   /*! \brief Change the CoM target by a given amount
    *
@@ -66,7 +66,6 @@ public:
 protected:
   void addToGUI(mc_rtc::gui::StateBuilder &) override;
   void addToLogger(mc_rtc::Logger & logger) override;
-  void removeFromLogger(mc_rtc::Logger & logger) override;
 
 private:
   unsigned int robot_index_;

--- a/include/mc_tasks/CoPTask.h
+++ b/include/mc_tasks/CoPTask.h
@@ -164,7 +164,6 @@ public:
 
 protected:
   void addToLogger(mc_rtc::Logger & logger) override;
-  void removeFromLogger(mc_rtc::Logger & logger) override;
   void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
 
 private:

--- a/include/mc_tasks/EndEffectorTask.h
+++ b/include/mc_tasks/EndEffectorTask.h
@@ -56,7 +56,7 @@ public:
    *
    * Set the task objective to the current end-effector position
    */
-  virtual void reset() override;
+  void reset() override;
 
   /*! \brief Increment the target position
    *
@@ -79,25 +79,23 @@ public:
    */
   virtual sva::PTransformd get_ef_pose();
 
-  virtual void dimWeight(const Eigen::VectorXd & dimW) override;
+  void dimWeight(const Eigen::VectorXd & dimW) override;
 
-  virtual Eigen::VectorXd dimWeight() const override;
+  Eigen::VectorXd dimWeight() const override;
 
-  virtual void selectActiveJoints(
-      mc_solver::QPSolver & solver,
-      const std::vector<std::string> & activeJointsName,
-      const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {}) override;
+  void selectActiveJoints(mc_solver::QPSolver & solver,
+                          const std::vector<std::string> & activeJointsName,
+                          const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {}) override;
 
-  virtual void selectUnactiveJoints(
-      mc_solver::QPSolver & solver,
-      const std::vector<std::string> & unactiveJointsName,
-      const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {}) override;
+  void selectUnactiveJoints(mc_solver::QPSolver & solver,
+                            const std::vector<std::string> & unactiveJointsName,
+                            const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {}) override;
 
-  virtual void resetJointsSelector(mc_solver::QPSolver & solver) override;
+  void resetJointsSelector(mc_solver::QPSolver & solver) override;
 
-  virtual Eigen::VectorXd eval() const override;
+  Eigen::VectorXd eval() const override;
 
-  virtual Eigen::VectorXd speed() const override;
+  Eigen::VectorXd speed() const override;
 
   void load(mc_solver::QPSolver & solver, const mc_rtc::Configuration & config) override;
 
@@ -113,14 +111,15 @@ public:
   sva::PTransformd curTransform;
 
 protected:
-  virtual void removeFromSolver(mc_solver::QPSolver & solver) override;
+  void removeFromSolver(mc_solver::QPSolver & solver) override;
 
-  virtual void addToSolver(mc_solver::QPSolver & solver) override;
+  void addToSolver(mc_solver::QPSolver & solver) override;
 
   void update(mc_solver::QPSolver &) override;
 
-  virtual void addToLogger(mc_rtc::Logger & logger) override;
-  virtual void removeFromLogger(mc_rtc::Logger & logger) override;
+  void addToLogger(mc_rtc::Logger & logger) override;
+
+  void removeFromLogger(mc_rtc::Logger & logger) override;
 
   void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
 };

--- a/include/mc_tasks/GazeTask.h
+++ b/include/mc_tasks/GazeTask.h
@@ -78,7 +78,7 @@ public:
    *
    * Set the task objective to the current body orientation
    */
-  virtual void reset() override;
+  void reset() override;
 
   /*! \brief Set the current error
    *

--- a/include/mc_tasks/ImpedanceTask.h
+++ b/include/mc_tasks/ImpedanceTask.h
@@ -185,7 +185,7 @@ public:
   }
 
   /*! \brief Get the cutoff period for the low-pass filter of measured wrench. */
-  double cutoffPeriod()
+  double cutoffPeriod() const
   {
     return lowPass_.cutoffPeriod();
   }
@@ -237,7 +237,6 @@ protected:
   void addToSolver(mc_solver::QPSolver & solver) override;
   void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
   void addToLogger(mc_rtc::Logger & logger) override;
-  void removeFromLogger(mc_rtc::Logger & logger) override;
 
 private:
   /** Targets of SurfaceTransformTask should not be set by the user.

--- a/include/mc_tasks/LookAtTask.h
+++ b/include/mc_tasks/LookAtTask.h
@@ -60,7 +60,6 @@ struct MC_TASKS_DLLAPI LookAtTask : public VectorOrientationTask
 
 private:
   void addToLogger(mc_rtc::Logger & logger) override;
-  void removeFromLogger(mc_rtc::Logger & logger) override;
   void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
 
 private:

--- a/include/mc_tasks/MetaTask.h
+++ b/include/mc_tasks/MetaTask.h
@@ -203,9 +203,10 @@ protected:
    *
    * This will be called by the solver when the task is removed.
    *
-   * The default implementation removes nothing from the log.
+   * The default implementation removes everything registered with the MetaTask instance as a source, it is likely good
+   * enough
    */
-  virtual void removeFromLogger(mc_rtc::Logger &) {}
+  virtual void removeFromLogger(mc_rtc::Logger &);
 
   /*! Helper function to remove a task from the logger when using another MetaTask
    * inside a MetaTask */

--- a/include/mc_tasks/MomentumTask.h
+++ b/include/mc_tasks/MomentumTask.h
@@ -37,7 +37,7 @@ public:
    * Set the task target to the current momentum and reset desired velocity and acceleration to zero.
    *
    */
-  virtual void reset() override;
+  void reset() override;
 
   /*! \brief Get the current target momentum */
   sva::ForceVecd momentum() const;
@@ -50,8 +50,6 @@ public:
   void momentum(const sva::ForceVecd & mom);
 
   void addToLogger(mc_rtc::Logger & logger) override;
-
-  void removeFromLogger(mc_rtc::Logger & logger) override;
 
   /*! \brief Load parameters from a Configuration object */
   void load(mc_solver::QPSolver & solver, const mc_rtc::Configuration & config) override;

--- a/include/mc_tasks/OrientationTask.h
+++ b/include/mc_tasks/OrientationTask.h
@@ -42,7 +42,7 @@ public:
    *
    * Set the task objective to the current body orientation
    */
-  virtual void reset() override;
+  void reset() override;
 
   /*! \brief Set the body orientation target
    *
@@ -65,7 +65,6 @@ public:
   std::string bodyName;
   unsigned int bIndex;
   void addToLogger(mc_rtc::Logger & logger) override;
-  void removeFromLogger(mc_rtc::Logger & logger) override;
 };
 
 } // namespace mc_tasks

--- a/include/mc_tasks/PositionBasedVisServoTask.h
+++ b/include/mc_tasks/PositionBasedVisServoTask.h
@@ -66,7 +66,7 @@ public:
    *
    * Set the task objective to the current body orientation
    */
-  virtual void reset() override;
+  void reset() override;
 
   /*! \brief Set the current error
    *
@@ -76,7 +76,6 @@ public:
   void error(const sva::PTransformd & X_t_s);
 
   void addToLogger(mc_rtc::Logger & logger) override;
-  void removeFromLogger(mc_rtc::Logger & logger) override;
 
 private:
   sva::PTransformd X_t_s_;

--- a/include/mc_tasks/PositionTask.h
+++ b/include/mc_tasks/PositionTask.h
@@ -58,7 +58,7 @@ public:
    *
    * Set the task objective to the current body position
    */
-  virtual void reset() override;
+  void reset() override;
 
   /*! \brief Get the body position target */
   Eigen::Vector3d position();
@@ -87,7 +87,6 @@ protected:
   std::string bodyName;
   unsigned int bIndex;
   void addToLogger(mc_rtc::Logger & logger) override;
-  void removeFromLogger(mc_rtc::Logger & logger) override;
 };
 
 } // namespace mc_tasks

--- a/include/mc_tasks/PostureTask.h
+++ b/include/mc_tasks/PostureTask.h
@@ -98,8 +98,6 @@ protected:
 
   void addToLogger(mc_rtc::Logger & logger) override;
 
-  void removeFromLogger(mc_rtc::Logger & logger) override;
-
 private:
   /** True if added to solver */
   bool inSolver_ = false;

--- a/include/mc_tasks/RelativeEndEffectorTask.h
+++ b/include/mc_tasks/RelativeEndEffectorTask.h
@@ -57,13 +57,13 @@ public:
                           double stiffness = 10.0,
                           double weight = 1000.0);
 
-  virtual void reset() override;
+  void reset() override;
 
-  virtual void add_ef_pose(const sva::PTransformd & dtr) override;
+  void add_ef_pose(const sva::PTransformd & dtr) override;
 
-  virtual void set_ef_pose(const sva::PTransformd & tf) override;
+  void set_ef_pose(const sva::PTransformd & tf) override;
 
-  virtual sva::PTransformd get_ef_pose() override;
+  sva::PTransformd get_ef_pose() override;
 
 protected:
   void addToGUI(mc_rtc::gui::StateBuilder & gui) override;

--- a/include/mc_tasks/SplineTrajectoryTask.h
+++ b/include/mc_tasks/SplineTrajectoryTask.h
@@ -365,8 +365,6 @@ protected:
    */
   void addToLogger(mc_rtc::Logger & logger) override;
 
-  void removeFromLogger(mc_rtc::Logger & logger) override;
-
   /*! \brief Update trajectory target */
   void update(mc_solver::QPSolver &) override;
 

--- a/include/mc_tasks/SplineTrajectoryTask.hpp
+++ b/include/mc_tasks/SplineTrajectoryTask.hpp
@@ -391,19 +391,9 @@ void SplineTrajectoryTask<Derived>::addToLogger(mc_rtc::Logger & logger)
     const auto & robot = this->robots.robot(rIndex_);
     return robot.surfacePose(surfaceName_);
   });
-  logger.addLogEntry(name_ + "_targetPose", [this]() { return this->target(); });
-  logger.addLogEntry(name_ + "_refPose", [this]() { return this->refPose(); });
-  logger.addLogEntry(name_ + "_speed", [this]() -> const Eigen::VectorXd { return this->speed(); });
-}
-
-template<typename Derived>
-void SplineTrajectoryTask<Derived>::removeFromLogger(mc_rtc::Logger & logger)
-{
-  TrajectoryBase::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_surfacePose");
-  logger.removeLogEntry(name_ + "_targetPose");
-  logger.removeLogEntry(name_ + "_refPose");
-  logger.removeLogEntry(name_ + "_speed");
+  logger.addLogEntry(name_ + "_targetPose", this, [this]() { return target(); });
+  logger.addLogEntry(name_ + "_refPose", this, [this]() { return refPose(); });
+  MC_RTC_LOG_HELPER(logger, name_ + "_speed", this, &SplineTrajectoryBase::speed);
 }
 
 template<typename Derived>

--- a/include/mc_tasks/SplineTrajectoryTask.hpp
+++ b/include/mc_tasks/SplineTrajectoryTask.hpp
@@ -391,9 +391,9 @@ void SplineTrajectoryTask<Derived>::addToLogger(mc_rtc::Logger & logger)
     const auto & robot = this->robots.robot(rIndex_);
     return robot.surfacePose(surfaceName_);
   });
-  logger.addLogEntry(name_ + "_targetPose", this, [this]() { return target(); });
-  logger.addLogEntry(name_ + "_refPose", this, [this]() { return refPose(); });
-  MC_RTC_LOG_HELPER(logger, name_ + "_speed", this, &SplineTrajectoryBase::speed);
+  MC_RTC_LOG_GETTER(name_ + "_targetPose", target);
+  MC_RTC_LOG_GETTER(name_ + "_refPose", refPose);
+  MC_RTC_LOG_HELPER(name_ + "_speed", speed);
 }
 
 template<typename Derived>

--- a/include/mc_tasks/SurfaceTransformTask.h
+++ b/include/mc_tasks/SurfaceTransformTask.h
@@ -44,7 +44,7 @@ public:
    * and acceleration to zero.
    *
    */
-  virtual void reset() override;
+  void reset() override;
 
   /*! \brief Get the body Surface target */
   sva::PTransformd target() const;
@@ -91,8 +91,6 @@ public:
       const mc_rtc::Configuration & config) const override;
 
   void addToLogger(mc_rtc::Logger & logger) override;
-
-  void removeFromLogger(mc_rtc::Logger & logger) override;
 
   using TrajectoryTaskGeneric<tasks::qp::SurfaceTransformTask>::stiffness;
   using TrajectoryTaskGeneric<tasks::qp::SurfaceTransformTask>::damping;

--- a/include/mc_tasks/TrajectoryTaskGeneric.h
+++ b/include/mc_tasks/TrajectoryTaskGeneric.h
@@ -47,7 +47,7 @@ struct TrajectoryTaskGeneric : public MetaTask
   /*! \brief Reset task target velocity and acceleration to zero
    *
    */
-  virtual void reset() override;
+  void reset() override;
 
   /*! \brief Set the trajectory reference velocity
    *
@@ -151,9 +151,9 @@ struct TrajectoryTaskGeneric : public MetaTask
   /*! \brief Returns the task weight */
   double weight() const;
 
-  virtual void dimWeight(const Eigen::VectorXd & dimW) override;
+  void dimWeight(const Eigen::VectorXd & dimW) override;
 
-  virtual Eigen::VectorXd dimWeight() const override;
+  Eigen::VectorXd dimWeight() const override;
 
   /** \brief Create an active joints selector
    *
@@ -168,9 +168,9 @@ struct TrajectoryTaskGeneric : public MetaTask
    * \throws If checkJoints is true and a joint name in activeJointsName is not
    * part of the robot
    */
-  virtual void selectActiveJoints(const std::vector<std::string> & activeJointsName,
-                                  const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {},
-                                  bool checkJoints = true);
+  void selectActiveJoints(const std::vector<std::string> & activeJointsName,
+                          const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {},
+                          bool checkJoints = true);
 
   /** \brief Create an active joints selector
    *
@@ -184,10 +184,9 @@ struct TrajectoryTaskGeneric : public MetaTask
    * \param activeDofs Allow to select only part of the dofs of a joint
    * \throws If a joint name in activeJointsName is not part of the robot
    */
-  virtual void selectActiveJoints(
-      mc_solver::QPSolver & solver,
-      const std::vector<std::string> & activeJointsName,
-      const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {}) override;
+  void selectActiveJoints(mc_solver::QPSolver & solver,
+                          const std::vector<std::string> & activeJointsName,
+                          const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {}) override;
 
   /** \brief Create an unactive joints selector
    *
@@ -202,9 +201,9 @@ struct TrajectoryTaskGeneric : public MetaTask
    * \throws If checkJoints is true and a joint name in unactiveJointsName is not
    * part of the robot
    */
-  virtual void selectUnactiveJoints(const std::vector<std::string> & unactiveJointsName,
-                                    const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {},
-                                    bool checkJoints = true);
+  void selectUnactiveJoints(const std::vector<std::string> & unactiveJointsName,
+                            const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {},
+                            bool checkJoints = true);
 
   /** \brief Create an unactive joints selector
    *
@@ -218,18 +217,17 @@ struct TrajectoryTaskGeneric : public MetaTask
    * \param unactiveDofs Allow to select only part of the dofs of a joint
    * \throws If a joint name in unactiveJointsName is not part of the robot
    */
-  virtual void selectUnactiveJoints(
-      mc_solver::QPSolver & solver,
-      const std::vector<std::string> & unactiveJointsName,
-      const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {}) override;
+  void selectUnactiveJoints(mc_solver::QPSolver & solver,
+                            const std::vector<std::string> & unactiveJointsName,
+                            const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {}) override;
 
   virtual void resetJointsSelector();
 
-  virtual void resetJointsSelector(mc_solver::QPSolver & solver) override;
+  void resetJointsSelector(mc_solver::QPSolver & solver) override;
 
-  virtual Eigen::VectorXd eval() const override;
+  Eigen::VectorXd eval() const override;
 
-  virtual Eigen::VectorXd speed() const override;
+  Eigen::VectorXd speed() const override;
 
   const Eigen::VectorXd & normalAcc() const;
 
@@ -247,8 +245,6 @@ protected:
 
   void addToLogger(mc_rtc::Logger & logger) override;
 
-  void removeFromLogger(mc_rtc::Logger & logger) override;
-
   std::function<bool(const mc_tasks::MetaTask & task, std::string &)> buildCompletionCriteria(
       double dt,
       const mc_rtc::Configuration & config) const override;
@@ -263,7 +259,7 @@ protected:
   std::shared_ptr<tasks::qp::TrajectoryTask> trajectoryT_ = nullptr;
 
 protected:
-  virtual void addToSolver(mc_solver::QPSolver & solver) override;
+  void addToSolver(mc_solver::QPSolver & solver) override;
 
 private:
   Eigen::VectorXd stiffness_;
@@ -271,7 +267,7 @@ private:
   double weight_;
   std::shared_ptr<tasks::qp::JointsSelector> selectorT_ = nullptr;
 
-  virtual void removeFromSolver(mc_solver::QPSolver & solver) override;
+  void removeFromSolver(mc_solver::QPSolver & solver) override;
 
   void update(mc_solver::QPSolver &) override;
 };

--- a/include/mc_tasks/TrajectoryTaskGeneric.hpp
+++ b/include/mc_tasks/TrajectoryTaskGeneric.hpp
@@ -425,25 +425,13 @@ void TrajectoryTaskGeneric<T>::addToGUI(mc_rtc::gui::StateBuilder & gui)
 template<typename T>
 void TrajectoryTaskGeneric<T>::addToLogger(mc_rtc::Logger & logger)
 {
-  logger.addLogEntry(name_ + "_damping", [this]() { return damping_(0); });
-  logger.addLogEntry(name_ + "_stiffness", [this]() { return stiffness_(0); });
-  logger.addLogEntry(name_ + "_dimWeight", [this]() -> const Eigen::VectorXd { return dimWeight(); });
-  logger.addLogEntry(name_ + "_dimDamping", [this]() -> const Eigen::VectorXd & { return damping_; });
-  logger.addLogEntry(name_ + "_dimStiffness", [this]() -> const Eigen::VectorXd & { return stiffness_; });
-  logger.addLogEntry(name_ + "_refVel", [this]() { return refVel_; });
-  logger.addLogEntry(name_ + "_refAccel", [this]() { return refAccel_; });
-}
-
-template<typename T>
-void TrajectoryTaskGeneric<T>::removeFromLogger(mc_rtc::Logger & logger)
-{
-  logger.removeLogEntry(name_ + "_damping");
-  logger.removeLogEntry(name_ + "_stiffness");
-  logger.removeLogEntry(name_ + "_dimWeight");
-  logger.removeLogEntry(name_ + "_dimDamping");
-  logger.removeLogEntry(name_ + "_dimStiffness");
-  logger.removeLogEntry(name_ + "_refVel");
-  logger.removeLogEntry(name_ + "_refAccel");
+  logger.addLogEntry(name_ + "_damping", this, [this]() { return damping_(0); });
+  logger.addLogEntry(name_ + "_stiffness", this, [this]() { return stiffness_(0); });
+  logger.addLogEntry(name_ + "_dimWeight", this, [this]() { return dimWeight(); });
+  MC_RTC_LOG_HELPER(logger, name_ + "_dimDamping", this, &TrajectoryBase::damping_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_dimStiffness", this, &TrajectoryBase::stiffness_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_refVel", this, &TrajectoryBase::refVel_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_refAccel", this, &TrajectoryBase::refAccel_);
 }
 
 template<typename T>

--- a/include/mc_tasks/TrajectoryTaskGeneric.hpp
+++ b/include/mc_tasks/TrajectoryTaskGeneric.hpp
@@ -425,13 +425,16 @@ void TrajectoryTaskGeneric<T>::addToGUI(mc_rtc::gui::StateBuilder & gui)
 template<typename T>
 void TrajectoryTaskGeneric<T>::addToLogger(mc_rtc::Logger & logger)
 {
-  logger.addLogEntry(name_ + "_damping", this, [this]() { return damping_(0); });
-  logger.addLogEntry(name_ + "_stiffness", this, [this]() { return stiffness_(0); });
-  logger.addLogEntry(name_ + "_dimWeight", this, [this]() { return dimWeight(); });
-  MC_RTC_LOG_HELPER(logger, name_ + "_dimDamping", this, &TrajectoryBase::damping_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_dimStiffness", this, &TrajectoryBase::stiffness_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_refVel", this, &TrajectoryBase::refVel_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_refAccel", this, &TrajectoryBase::refAccel_);
+  // clang-format off
+  logger.addLogEntries(this,
+                       name_ + "_damping", [this]() { return damping_(0); },
+                       name_ + "_stiffness", [this]() { return stiffness_(0); });
+  // clang-format on
+  MC_RTC_LOG_GETTER(name_ + "_dimWeight", dimWeight);
+  MC_RTC_LOG_HELPER(name_ + "_dimDamping", damping_);
+  MC_RTC_LOG_HELPER(name_ + "_dimStiffness", stiffness_);
+  MC_RTC_LOG_HELPER(name_ + "_refVel", refVel_);
+  MC_RTC_LOG_HELPER(name_ + "_refAccel", refAccel_);
 }
 
 template<typename T>

--- a/include/mc_tasks/VectorOrientationTask.h
+++ b/include/mc_tasks/VectorOrientationTask.h
@@ -55,7 +55,7 @@ struct MC_TASKS_DLLAPI VectorOrientationTask : public TrajectoryTaskGeneric<task
    * Set the task objective (i.e. target vector in the world frame) to the
    * current body vector
    */
-  virtual void reset() override;
+  void reset() override;
 
   /*! \brief Set the body vector to be controlled
    *
@@ -101,7 +101,6 @@ struct MC_TASKS_DLLAPI VectorOrientationTask : public TrajectoryTaskGeneric<task
 protected:
   void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
   void addToLogger(mc_rtc::Logger & logger) override;
-  void removeFromLogger(mc_rtc::Logger & logger) override;
 
 protected:
   std::string bodyName;

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -538,10 +538,9 @@ private:
                           const std::vector<std::string> & activeJointsName,
                           const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {}) override;
 
-  virtual void selectUnactiveJoints(
-      mc_solver::QPSolver & solver,
-      const std::vector<std::string> & unactiveJointsName,
-      const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {}) override;
+  void selectUnactiveJoints(mc_solver::QPSolver & solver,
+                            const std::vector<std::string> & unactiveJointsName,
+                            const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {}) override;
 
   void resetJointsSelector(mc_solver::QPSolver & solver) override;
 

--- a/src/mc_control/fsm/Executor.cpp
+++ b/src/mc_control/fsm/Executor.cpp
@@ -72,13 +72,14 @@ void Executor::init(Controller & ctl,
   {
     log_entry += "_Main";
   }
-  ctl.logger().addLogEntry(log_entry, [this]() { return curr_state_; });
-  ctl.logger().addLogEntry("perf_" + log_entry, [this]() {
+  ctl.logger().addLogEntry(log_entry, this, [this]() { return curr_state_; });
+  log_entry = "perf_" + log_entry;
+  ctl.logger().addLogEntry(log_entry, this, [this]() {
     return state_create_dt_.count() + state_run_dt_.count() + state_teardown_dt_.count();
   });
-  ctl.logger().addLogEntry("perf_" + log_entry + "_create", [this]() { return state_create_dt_.count(); });
-  ctl.logger().addLogEntry("perf_" + log_entry + "_run", [this]() { return state_run_dt_.count(); });
-  ctl.logger().addLogEntry("perf_" + log_entry + "_teardown", [this]() { return state_teardown_dt_.count(); });
+  ctl.logger().addLogEntry(log_entry + "_create", this, [this]() { return state_create_dt_.count(); });
+  ctl.logger().addLogEntry(log_entry + "_run", this, [this]() { return state_run_dt_.count(); });
+  ctl.logger().addLogEntry(log_entry + "_teardown", this, [this]() { return state_teardown_dt_.count(); });
 }
 
 bool Executor::run(Controller & ctl, bool keep_state)
@@ -161,20 +162,7 @@ void Executor::teardown(Controller & ctl)
   {
     ctl.gui()->removeCategory(category_);
   }
-  std::string log_entry = "Executor";
-  if(name_.size())
-  {
-    log_entry += "_" + name_;
-  }
-  else
-  {
-    log_entry += "_Main";
-  }
-  ctl.logger().removeLogEntry(log_entry);
-  ctl.logger().removeLogEntry("perf_" + log_entry);
-  ctl.logger().removeLogEntry("perf_" + log_entry + "_create");
-  ctl.logger().removeLogEntry("perf_" + log_entry + "_run");
-  ctl.logger().removeLogEntry("perf_" + log_entry + "_teardown");
+  ctl.logger().removeLogEntries(this);
 }
 
 bool Executor::complete(Controller & ctl, bool keep_state)

--- a/src/mc_control/fsm/states/SlidingFootContact.cpp
+++ b/src/mc_control/fsm/states/SlidingFootContact.cpp
@@ -82,10 +82,11 @@ void SlidingFootContactState::start(Controller & ctl)
   ctl.contactConstraint().contactConstr->resetDofContacts();
   setHandDofContact(ctl);
   slidingContactId_ = getContactId(ctl, slidingSurface_);
-  ctl.logger().addLogEntry("Sliding_" + slidingSurface_ + "_com_targetIn",
-                           [this]() -> const Eigen::Vector3d & { return com_target0; });
-  ctl.logger().addLogEntry("Sliding_" + slidingSurface_ + "_com_sensor",
-                           [this]() -> const Eigen::Vector3d & { return com_sensor; });
+#define LOG_MEMBER(NAME, MEMBER) \
+  MC_RTC_LOG_HELPER(ctl.logger(), "Sliding_" + slidingSurface_ + NAME, this, &SlidingFootContactState::MEMBER)
+  LOG_MEMBER("_com_targetIn", com_target0);
+  LOG_MEMBER("_com_sensor", com_sensor);
+#undef LOG_MEMBER
   if(wait_for_slide_trigger_)
   {
     auto gui = ctl.gui();
@@ -262,8 +263,7 @@ bool SlidingFootContactState::run(Controller & ctl)
 
 void SlidingFootContactState::teardown(Controller & ctl)
 {
-  ctl.logger().removeLogEntry("Sliding_" + slidingSurface_ + "_com_targetIn");
-  ctl.logger().removeLogEntry("Sliding_" + slidingSurface_ + "_com_sensor");
+  ctl.logger().removeLogEntries(this);
   if(wait_for_slide_trigger_)
   {
     auto gui = ctl.gui();

--- a/src/mc_control/fsm/states/SlidingFootContact.cpp
+++ b/src/mc_control/fsm/states/SlidingFootContact.cpp
@@ -82,8 +82,8 @@ void SlidingFootContactState::start(Controller & ctl)
   ctl.contactConstraint().contactConstr->resetDofContacts();
   setHandDofContact(ctl);
   slidingContactId_ = getContactId(ctl, slidingSurface_);
-#define LOG_MEMBER(NAME, MEMBER) \
-  MC_RTC_LOG_HELPER(ctl.logger(), "Sliding_" + slidingSurface_ + NAME, this, &SlidingFootContactState::MEMBER)
+#define LOG_MEMBER(NAME, MEMBER) MC_RTC_LOG_HELPER("Sliding_" + slidingSurface_ + NAME, MEMBER)
+  auto & logger = ctl.logger();
   LOG_MEMBER("_com_targetIn", com_target0);
   LOG_MEMBER("_com_sensor", com_sensor);
 #undef LOG_MEMBER

--- a/src/mc_control/fsm/states/StabilizerStandingState.cpp
+++ b/src/mc_control/fsm/states/StabilizerStandingState.cpp
@@ -148,7 +148,8 @@ void StabilizerStandingState::start(Controller & ctl)
                                  D_ = 2 * std::sqrt(K_);
                                }));
 
-#define LOG_MEMBER(NAME, MEMBER) MC_RTC_LOG_HELPER(ctl.logger(), name() + NAME, this, &StabilizerStandingState::MEMBER)
+#define LOG_MEMBER(NAME, MEMBER) MC_RTC_LOG_HELPER(name() + NAME, MEMBER)
+  auto & logger = ctl.logger();
   LOG_MEMBER("_stiffness", K_);
   LOG_MEMBER("_damping", D_);
   LOG_MEMBER("_targetCoM", comTarget_);

--- a/src/mc_control/fsm/states/StabilizerStandingState.cpp
+++ b/src/mc_control/fsm/states/StabilizerStandingState.cpp
@@ -148,10 +148,12 @@ void StabilizerStandingState::start(Controller & ctl)
                                  D_ = 2 * std::sqrt(K_);
                                }));
 
-  ctl.logger().addLogEntry(name() + "_stiffness", [this]() { return K_; });
-  ctl.logger().addLogEntry(name() + "_damping", [this]() { return D_; });
-  ctl.logger().addLogEntry(name() + "_targetCoM", [this]() -> const Eigen::Vector3d & { return comTarget_; });
-  ctl.logger().addLogEntry(name() + "_targetCoP", [this]() -> const Eigen::Vector3d & { return copTarget_; });
+#define LOG_MEMBER(NAME, MEMBER) MC_RTC_LOG_HELPER(ctl.logger(), name() + NAME, this, &StabilizerStandingState::MEMBER)
+  LOG_MEMBER("_stiffness", K_);
+  LOG_MEMBER("_damping", D_);
+  LOG_MEMBER("_targetCoM", comTarget_);
+  LOG_MEMBER("_targetCoP", copTarget_);
+#undef LOG_MEMBER
 
   // Provide accessor callbacks on the datastore
   ctl.datastore().make_call("StabilizerStandingState::getCoMTarget",
@@ -243,10 +245,7 @@ void StabilizerStandingState::teardown(Controller & ctl)
 {
   ctl.solver().removeTask(stabilizerTask_);
   ctl.gui()->removeCategory({"FSM", name()});
-  ctl.logger().removeLogEntry(name() + "_stiffness");
-  ctl.logger().removeLogEntry(name() + "_damping");
-  ctl.logger().removeLogEntry(name() + "_targetCoM");
-  ctl.logger().removeLogEntry(name() + "_targetCoP");
+  ctl.logger().removeLogEntries(this);
 
   ctl.datastore().remove("StabilizerStandingState::getCoMTarget");
   ctl.datastore().remove("StabilizerStandingState::setCoMTarget");

--- a/src/mc_observers/BodySensorObserver.cpp
+++ b/src/mc_observers/BodySensorObserver.cpp
@@ -147,26 +147,20 @@ void BodySensorObserver::addToLogger(const mc_control::MCController &,
                                      const std::string & category)
 {
   auto cat = category + "_" + fbSensorName_;
+#define LOG_MEMBER(NAME, MEMBER) MC_RTC_LOG_HELPER(logger, cat + NAME, this, &BodySensorObserver::MEMBER)
   if(logPos_)
   {
-    logger.addLogEntry(cat + "_posW", [this]() { return posW_; });
+    LOG_MEMBER("_posW", posW_);
   }
   if(logVel_)
   {
-    logger.addLogEntry(cat + "_velW", [this]() { return velW_; });
+    LOG_MEMBER("_velW", velW_);
   }
   if(logAcc_)
   {
-    logger.addLogEntry(cat + "_accW", [this]() { return accW_; });
+    LOG_MEMBER("_accW", accW_);
   }
-}
-
-void BodySensorObserver::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)
-{
-  auto cat = category + "_" + fbSensorName_;
-  logger.removeLogEntry(cat + "_posW");
-  logger.removeLogEntry(cat + "_velW");
-  logger.removeLogEntry(cat + "_accW");
+#undef LOG_MEMBER
 }
 
 void BodySensorObserver::addToGUI(const mc_control::MCController & ctl,

--- a/src/mc_observers/BodySensorObserver.cpp
+++ b/src/mc_observers/BodySensorObserver.cpp
@@ -147,20 +147,18 @@ void BodySensorObserver::addToLogger(const mc_control::MCController &,
                                      const std::string & category)
 {
   auto cat = category + "_" + fbSensorName_;
-#define LOG_MEMBER(NAME, MEMBER) MC_RTC_LOG_HELPER(logger, cat + NAME, this, &BodySensorObserver::MEMBER)
   if(logPos_)
   {
-    LOG_MEMBER("_posW", posW_);
+    MC_RTC_LOG_HELPER(cat + "_posW", posW_);
   }
   if(logVel_)
   {
-    LOG_MEMBER("_velW", velW_);
+    MC_RTC_LOG_HELPER(cat + "_velW", velW_);
   }
   if(logAcc_)
   {
-    LOG_MEMBER("_accW", accW_);
+    MC_RTC_LOG_HELPER(cat + "_accW", accW_);
   }
-#undef LOG_MEMBER
 }
 
 void BodySensorObserver::addToGUI(const mc_control::MCController & ctl,

--- a/src/mc_observers/EncoderObserver.cpp
+++ b/src/mc_observers/EncoderObserver.cpp
@@ -209,7 +209,7 @@ void EncoderObserver::addToLogger(const mc_control::MCController & ctl,
   {
     if(velUpdate_ == VelUpdate::EncoderFiniteDifferences)
     {
-      MC_RTC_LOG_HELPER(logger, category + "_encoderFiniteDifferences", this, &EncoderObserver::encodersVelocity_);
+      MC_RTC_LOG_HELPER(category + "_encoderFiniteDifferences", encodersVelocity_);
     }
     else if(velUpdate_ == VelUpdate::EncoderVelocities)
     {

--- a/src/mc_observers/EncoderObserver.cpp
+++ b/src/mc_observers/EncoderObserver.cpp
@@ -184,22 +184,24 @@ void EncoderObserver::addToLogger(const mc_control::MCController & ctl,
   {
     if(posUpdate_ == PosUpdate::EncoderValues)
     {
-      logger.addLogEntry(category + "_encoderValues", [this, &ctl]() { return ctl.robot(robot_).encoderValues(); });
+      logger.addLogEntry(category + "_encoderValues", this,
+                         [this, &ctl]() -> const std::vector<double> & { return ctl.robot(robot_).encoderValues(); });
     }
-    else if(velUpdate_ == VelUpdate::Control)
+    else if(posUpdate_ == PosUpdate::Control)
     {
       std::vector<double> qOut(ctl.robot(robot_).refJointOrder().size(), 0);
-      logger.addLogEntry(category + "_controlValues", [this, &ctl, qOut]() mutable -> const std::vector<double> & {
-        for(size_t i = 0; i < qOut.size(); ++i)
-        {
-          auto jIdx = ctl.robot(robot_).jointIndexInMBC(i);
-          if(jIdx != -1)
-          {
-            qOut[i] = ctl.robot(robot_).mbc().alpha[static_cast<size_t>(jIdx)][0];
-          }
-        }
-        return qOut;
-      });
+      logger.addLogEntry(category + "_controlValues", this,
+                         [this, &ctl, qOut]() mutable -> const std::vector<double> & {
+                           for(size_t i = 0; i < qOut.size(); ++i)
+                           {
+                             auto jIdx = ctl.robot(robot_).jointIndexInMBC(i);
+                             if(jIdx != -1)
+                             {
+                               qOut[i] = ctl.robot(robot_).mbc().alpha[static_cast<size_t>(jIdx)][0];
+                             }
+                           }
+                           return qOut;
+                         });
     }
   }
 
@@ -207,37 +209,31 @@ void EncoderObserver::addToLogger(const mc_control::MCController & ctl,
   {
     if(velUpdate_ == VelUpdate::EncoderFiniteDifferences)
     {
-      logger.addLogEntry(category + "_encoderFiniteDifferences", [this]() { return encodersVelocity_; });
+      MC_RTC_LOG_HELPER(logger, category + "_encoderFiniteDifferences", this, &EncoderObserver::encodersVelocity_);
     }
     else if(velUpdate_ == VelUpdate::EncoderVelocities)
     {
-      logger.addLogEntry(category + "_encoderVelocities",
-                         [this, &ctl]() { return ctl.robot(robot_).encoderVelocities(); });
+      logger.addLogEntry(category + "_encoderVelocities", this, [this, &ctl]() -> const std::vector<double> & {
+        return ctl.robot(robot_).encoderVelocities();
+      });
     }
     else if(velUpdate_ == VelUpdate::Control)
     {
       std::vector<double> alpha(ctl.robot(robot_).refJointOrder().size(), 0);
-      logger.addLogEntry(category + "_controlVelocities", [this, &ctl, alpha]() mutable -> const std::vector<double> & {
-        for(size_t i = 0; i < alpha.size(); ++i)
-        {
-          auto jIdx = ctl.robot(robot_).jointIndexInMBC(i);
-          if(jIdx != -1)
-          {
-            alpha[i] = ctl.robot(robot_).mbc().alpha[static_cast<size_t>(jIdx)][0];
-          }
-        }
-        return alpha;
-      });
+      logger.addLogEntry(category + "_controlVelocities", this,
+                         [this, &ctl, alpha]() mutable -> const std::vector<double> & {
+                           for(size_t i = 0; i < alpha.size(); ++i)
+                           {
+                             auto jIdx = ctl.robot(robot_).jointIndexInMBC(i);
+                             if(jIdx != -1)
+                             {
+                               alpha[i] = ctl.robot(robot_).mbc().alpha[static_cast<size_t>(jIdx)][0];
+                             }
+                           }
+                           return alpha;
+                         });
     }
   }
-}
-void EncoderObserver::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)
-{
-  logger.removeLogEntry(category + "_" + name() + "encoderValues");
-  logger.removeLogEntry(category + "_" + name() + "controlValues");
-  logger.removeLogEntry(category + "_" + name() + "encoderFiniteDifferences");
-  logger.removeLogEntry(category + "_" + name() + "encoderVelocities");
-  logger.removeLogEntry(category + "_" + name() + "controlVelocities");
 }
 
 } // namespace mc_observers

--- a/src/mc_observers/KinematicInertialObserver.cpp
+++ b/src/mc_observers/KinematicInertialObserver.cpp
@@ -79,16 +79,9 @@ void KinematicInertialObserver::addToLogger(const mc_control::MCController & ctl
   KinematicInertialPoseObserver::addToLogger(ctl, logger, category);
   if(logVelocity_)
   {
-    logger.addLogEntry(category + "_velW", [this]() -> const sva::MotionVecd & { return velW_; });
-    logger.addLogEntry(category + "_filter_cutoffPeriod", [this]() { return velFilter_.cutoffPeriod(); });
+    logger.addLogEntry(category + "_velW", this, [this]() -> const sva::MotionVecd & { return velW_; });
+    logger.addLogEntry(category + "_filter_cutoffPeriod", this, [this]() { return velFilter_.cutoffPeriod(); });
   }
-}
-
-void KinematicInertialObserver::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)
-{
-  KinematicInertialPoseObserver::removeFromLogger(logger, category);
-  logger.removeLogEntry(category + "_velW");
-  logger.removeLogEntry(category + "_filter_cutoffPeriod");
 }
 
 void KinematicInertialObserver::addToGUI(const mc_control::MCController & ctl,

--- a/src/mc_observers/KinematicInertialPoseObserver.cpp
+++ b/src/mc_observers/KinematicInertialPoseObserver.cpp
@@ -138,18 +138,15 @@ void KinematicInertialPoseObserver::addToLogger(const mc_control::MCController &
                                                 mc_rtc::Logger & logger,
                                                 const std::string & category)
 {
-#define LOG_MEMBER(NAME, MEMBER) \
-  MC_RTC_LOG_HELPER(logger, category + NAME, this, &KinematicInertialPoseObserver::MEMBER)
   if(logPose_)
   {
-    LOG_MEMBER("_posW", pose_);
+    MC_RTC_LOG_HELPER(category + "_posW", pose_);
   }
   if(logAnchorFrame_)
   {
-    LOG_MEMBER("_anchorFrame", X_0_anchorFrame_);
-    LOG_MEMBER("_anchorFrameReal", X_0_anchorFrameReal_);
+    MC_RTC_LOG_HELPER(category + "_anchorFrame", X_0_anchorFrame_);
+    MC_RTC_LOG_HELPER(category + "_anchorFrameReal", X_0_anchorFrameReal_);
   }
-#undef LOG_MEMBER
 }
 
 void KinematicInertialPoseObserver::addToGUI(const mc_control::MCController & ctl,

--- a/src/mc_observers/KinematicInertialPoseObserver.cpp
+++ b/src/mc_observers/KinematicInertialPoseObserver.cpp
@@ -138,23 +138,18 @@ void KinematicInertialPoseObserver::addToLogger(const mc_control::MCController &
                                                 mc_rtc::Logger & logger,
                                                 const std::string & category)
 {
+#define LOG_MEMBER(NAME, MEMBER) \
+  MC_RTC_LOG_HELPER(logger, category + NAME, this, &KinematicInertialPoseObserver::MEMBER)
   if(logPose_)
   {
-    logger.addLogEntry(category + "_posW", [this]() -> const sva::PTransformd & { return pose_; });
+    LOG_MEMBER("_posW", pose_);
   }
   if(logAnchorFrame_)
   {
-    logger.addLogEntry(category + "_anchorFrame", [this]() -> const sva::PTransformd & { return X_0_anchorFrame_; });
-    logger.addLogEntry(category + "_anchorFrameReal",
-                       [this]() -> const sva::PTransformd & { return X_0_anchorFrameReal_; });
+    LOG_MEMBER("_anchorFrame", X_0_anchorFrame_);
+    LOG_MEMBER("_anchorFrameReal", X_0_anchorFrameReal_);
   }
-}
-
-void KinematicInertialPoseObserver::removeFromLogger(mc_rtc::Logger & logger, const std::string & category)
-{
-  logger.removeLogEntry(category + "_posW");
-  logger.removeLogEntry(category + "_anchorFrame");
-  logger.removeLogEntry(category + "_anchorFrameReal");
+#undef LOG_MEMBER
 }
 
 void KinematicInertialPoseObserver::addToGUI(const mc_control::MCController & ctl,

--- a/src/mc_observers/Observer.cpp
+++ b/src/mc_observers/Observer.cpp
@@ -12,4 +12,9 @@ void Observer::removeFromGUI(mc_rtc::gui::StateBuilder & gui, const std::vector<
   gui.removeCategory(category);
 }
 
+void Observer::removeFromLogger(mc_rtc::Logger & logger, const std::string &)
+{
+  logger.removeLogEntries(this);
+}
+
 } // namespace mc_observers

--- a/src/mc_rtc/Logger.cpp
+++ b/src/mc_rtc/Logger.cpp
@@ -286,6 +286,7 @@ void Logger::removeLogEntries(const void * source)
   {
     if(it->second.source == source)
     {
+      log_entries_changed_ = true;
       it = log_entries_.erase(it);
     }
     else

--- a/src/mc_rtc/Logger.cpp
+++ b/src/mc_rtc/Logger.cpp
@@ -36,6 +36,7 @@ struct LoggerImpl
   std::string tmpl;
   double log_iter_ = 0;
   bool valid_ = true;
+  std::string path_ = "";
   std::ofstream log_;
 
 protected:
@@ -48,6 +49,7 @@ protected:
   // Open file and write magic number to it right away
   void open(const std::string & path)
   {
+    path_ = path;
     log_.open(path, std::ofstream::binary);
     log_.write((const char *)&Logger::magic, sizeof(Logger::magic));
   }
@@ -288,4 +290,10 @@ double Logger::t() const
 {
   return impl_->log_iter_;
 }
+
+const std::string & Logger::path() const
+{
+  return impl_->path_;
+}
+
 } // namespace mc_rtc

--- a/src/mc_rtc/Logger.cpp
+++ b/src/mc_rtc/Logger.cpp
@@ -211,7 +211,7 @@ void Logger::start(const std::string & ctl_name, double timestep, bool resume)
   {
     if(!log_entries_.count("t"))
     {
-      addLogEntry("t", [this, timestep]() {
+      addLogEntry("t", this, [this, timestep]() {
         impl_->log_iter_ += timestep;
         return impl_->log_iter_ - timestep;
       });
@@ -252,7 +252,7 @@ void Logger::log()
   builder.start_array(2 * log_entries_.size());
   for(auto & e : log_entries_)
   {
-    e.second(builder);
+    e.second.log_cb(builder);
   }
   builder.finish_array();
   builder.finish_array();
@@ -266,6 +266,21 @@ void Logger::removeLogEntry(const std::string & name)
   {
     log_entries_changed_ = true;
     log_entries_.erase(name);
+  }
+}
+
+void Logger::removeLogEntries(const void * source)
+{
+  for(auto it = log_entries_.begin(); it != log_entries_.end();)
+  {
+    if(it->second.source == source)
+    {
+      it = log_entries_.erase(it);
+    }
+    else
+    {
+      ++it;
+    }
   }
 }
 

--- a/src/mc_tasks/AdmittanceTask.cpp
+++ b/src/mc_tasks/AdmittanceTask.cpp
@@ -111,11 +111,11 @@ void AdmittanceTask::load(mc_solver::QPSolver & solver, const mc_rtc::Configurat
 void AdmittanceTask::addToLogger(mc_rtc::Logger & logger)
 {
   SurfaceTransformTask::addToLogger(logger);
-  MC_RTC_LOG_HELPER(logger, name_ + "_admittance", this, &AdmittanceTask::admittance_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_measured_wrench", this, &AdmittanceTask::measuredWrench);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target_body_vel", this, &AdmittanceTask::feedforwardVelB_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target_wrench", this, &AdmittanceTask::targetWrench_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_vel_filter_gain", this, &AdmittanceTask::velFilterGain_);
+  MC_RTC_LOG_HELPER(name_ + "_admittance", admittance_);
+  MC_RTC_LOG_HELPER(name_ + "_measured_wrench", measuredWrench);
+  MC_RTC_LOG_HELPER(name_ + "_target_body_vel", feedforwardVelB_);
+  MC_RTC_LOG_HELPER(name_ + "_target_wrench", targetWrench_);
+  MC_RTC_LOG_HELPER(name_ + "_vel_filter_gain", velFilterGain_);
 }
 
 void AdmittanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/AdmittanceTask.cpp
+++ b/src/mc_tasks/AdmittanceTask.cpp
@@ -111,21 +111,11 @@ void AdmittanceTask::load(mc_solver::QPSolver & solver, const mc_rtc::Configurat
 void AdmittanceTask::addToLogger(mc_rtc::Logger & logger)
 {
   SurfaceTransformTask::addToLogger(logger);
-  logger.addLogEntry(name_ + "_admittance", [this]() -> const sva::ForceVecd & { return admittance_; });
-  logger.addLogEntry(name_ + "_measured_wrench", [this]() -> sva::ForceVecd { return measuredWrench(); });
-  logger.addLogEntry(name_ + "_target_body_vel", [this]() -> const sva::MotionVecd & { return feedforwardVelB_; });
-  logger.addLogEntry(name_ + "_target_wrench", [this]() -> const sva::ForceVecd & { return targetWrench_; });
-  logger.addLogEntry(name_ + "_vel_filter_gain", [this]() { return velFilterGain_; });
-}
-
-void AdmittanceTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  SurfaceTransformTask::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_admittance");
-  logger.removeLogEntry(name_ + "_measured_wrench");
-  logger.removeLogEntry(name_ + "_target_body_vel");
-  logger.removeLogEntry(name_ + "_target_wrench");
-  logger.removeLogEntry(name_ + "_vel_filter_gain");
+  MC_RTC_LOG_HELPER(logger, name_ + "_admittance", this, &AdmittanceTask::admittance_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_measured_wrench", this, &AdmittanceTask::measuredWrench);
+  MC_RTC_LOG_HELPER(logger, name_ + "_target_body_vel", this, &AdmittanceTask::feedforwardVelB_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_target_wrench", this, &AdmittanceTask::targetWrench_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_vel_filter_gain", this, &AdmittanceTask::velFilterGain_);
 }
 
 void AdmittanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/CoMTask.cpp
+++ b/src/mc_tasks/CoMTask.cpp
@@ -90,15 +90,8 @@ const Eigen::Vector3d & CoMTask::actual() const
 void CoMTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  logger.addLogEntry(name_ + "_pos", [this]() -> const Eigen::Vector3d & { return actual(); });
-  logger.addLogEntry(name_ + "_target", [this]() -> const Eigen::Vector3d & { return cur_com_; });
-}
-
-void CoMTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  TrajectoryBase::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_pos");
-  logger.removeLogEntry(name_ + "_target");
+  MC_RTC_LOG_HELPER(logger, name_ + "_pos", this, &CoMTask::actual);
+  MC_RTC_LOG_HELPER(logger, name_ + "_target", this, &CoMTask::cur_com_);
 }
 
 void CoMTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/CoMTask.cpp
+++ b/src/mc_tasks/CoMTask.cpp
@@ -90,8 +90,8 @@ const Eigen::Vector3d & CoMTask::actual() const
 void CoMTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  MC_RTC_LOG_HELPER(logger, name_ + "_pos", this, &CoMTask::actual);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target", this, &CoMTask::cur_com_);
+  MC_RTC_LOG_HELPER(name_ + "_pos", actual);
+  MC_RTC_LOG_HELPER(name_ + "_target", cur_com_);
 }
 
 void CoMTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/CoPTask.cpp
+++ b/src/mc_tasks/CoPTask.cpp
@@ -45,17 +45,8 @@ void CoPTask::update(mc_solver::QPSolver & solver)
 void CoPTask::addToLogger(mc_rtc::Logger & logger)
 {
   DampingTask::addToLogger(logger);
-  logger.addLogEntry(name_ + "_measured_cop", [this]() -> Eigen::Vector2d { return measuredCoP(); });
-  logger.addLogEntry(name_ + "_target_cop", [this]() -> const Eigen::Vector2d & { return targetCoP_; });
-}
-
-void CoPTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  DampingTask::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_measured_cop");
-  logger.removeLogEntry(name_ + "_measured_copW");
-  logger.removeLogEntry(name_ + "_target_cop");
-  logger.removeLogEntry(name_ + "_target_copW");
+  MC_RTC_LOG_HELPER(logger, name_ + "_measured_cop", this, &CoPTask::measuredCoP);
+  MC_RTC_LOG_HELPER(logger, name_ + "_target_cop", this, &CoPTask::targetCoP_);
 }
 
 void CoPTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/CoPTask.cpp
+++ b/src/mc_tasks/CoPTask.cpp
@@ -45,8 +45,8 @@ void CoPTask::update(mc_solver::QPSolver & solver)
 void CoPTask::addToLogger(mc_rtc::Logger & logger)
 {
   DampingTask::addToLogger(logger);
-  MC_RTC_LOG_HELPER(logger, name_ + "_measured_cop", this, &CoPTask::measuredCoP);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target_cop", this, &CoPTask::targetCoP_);
+  MC_RTC_LOG_HELPER(name_ + "_measured_cop", measuredCoP);
+  MC_RTC_LOG_HELPER(name_ + "_target_cop", targetCoP_);
 }
 
 void CoPTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/EndEffectorTask.cpp
+++ b/src/mc_tasks/EndEffectorTask.cpp
@@ -195,7 +195,7 @@ void EndEffectorTask::addToLogger(mc_rtc::Logger & logger)
 {
   positionTask->addToLogger(logger);
   orientationTask->addToLogger(logger);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target", this, &EndEffectorTask::curTransform);
+  MC_RTC_LOG_HELPER(name_ + "_target", curTransform);
   logger.addLogEntry(
       name_, this, [this]() -> const sva::PTransformd & { return robots.robot(robotIndex).mbc().bodyPosW[bodyIndex]; });
 }

--- a/src/mc_tasks/EndEffectorTask.cpp
+++ b/src/mc_tasks/EndEffectorTask.cpp
@@ -195,17 +195,16 @@ void EndEffectorTask::addToLogger(mc_rtc::Logger & logger)
 {
   positionTask->addToLogger(logger);
   orientationTask->addToLogger(logger);
-  logger.addLogEntry(name_ + "_target", [this]() -> const sva::PTransformd & { return curTransform; });
+  MC_RTC_LOG_HELPER(logger, name_ + "_target", this, &EndEffectorTask::curTransform);
   logger.addLogEntry(
-      name_, [this]() -> const sva::PTransformd & { return robots.robot(robotIndex).mbc().bodyPosW[bodyIndex]; });
+      name_, this, [this]() -> const sva::PTransformd & { return robots.robot(robotIndex).mbc().bodyPosW[bodyIndex]; });
 }
 
 void EndEffectorTask::removeFromLogger(mc_rtc::Logger & logger)
 {
+  MetaTask::removeFromLogger(logger);
   positionTask->removeFromLogger(logger);
   orientationTask->removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_target");
-  logger.removeLogEntry(name_);
 }
 
 void EndEffectorTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/ImpedanceTask.cpp
+++ b/src/mc_tasks/ImpedanceTask.cpp
@@ -190,48 +190,20 @@ void ImpedanceTask::addToLogger(mc_rtc::Logger & logger)
                      [this]() -> const sva::ImpedanceVecd & { return gains().wrench().vec(); });
 
   // compliance values
-  logger.addLogEntry(name_ + "_deltaCompliancePose", [this]() -> const sva::PTransformd & { return deltaCompPoseW_; });
-  logger.addLogEntry(name_ + "_deltaComplianceVel", [this]() -> const sva::MotionVecd & { return deltaCompVelW_; });
-  logger.addLogEntry(name_ + "_deltaComplianceAccel", [this]() -> const sva::MotionVecd & { return deltaCompAccelW_; });
+  MC_RTC_LOG_HELPER(logger, name_ + "_deltaCompliancePose", this, &ImpedanceTask::deltaCompPoseW_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_deltaComplianceVel", this, &ImpedanceTask::deltaCompVelW_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_deltaComplianceAccel", this, &ImpedanceTask::deltaCompAccelW_);
 
   // target values
-  logger.addLogEntry(name_ + "_targetPose", [this]() -> const sva::PTransformd & { return targetPoseW_; });
-  logger.addLogEntry(name_ + "_targetVel", [this]() -> const sva::MotionVecd & { return targetVelW_; });
-  logger.addLogEntry(name_ + "_targetAccel", [this]() -> const sva::MotionVecd & { return targetAccelW_; });
+  MC_RTC_LOG_HELPER(logger, name_ + "_targetPose", this, &ImpedanceTask::targetPoseW_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_targetVel", this, &ImpedanceTask::targetVelW_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_targetAccel", this, &ImpedanceTask::targetAccelW_);
 
   // wrench
-  logger.addLogEntry(name_ + "_targetWrench", [this]() -> const sva::ForceVecd & { return targetWrench_; });
-  logger.addLogEntry(name_ + "_measuredWrench", [this]() -> const sva::ForceVecd & { return measuredWrench_; });
-  logger.addLogEntry(name_ + "_filteredMeasuredWrench",
-                     [this]() -> const sva::ForceVecd & { return filteredMeasuredWrench_; });
-  logger.addLogEntry(name_ + "_cutoffPeriod", [this]() { return cutoffPeriod(); });
-}
-
-void ImpedanceTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  SurfaceTransformTask::removeFromLogger(logger);
-
-  // impedance parameters
-  logger.removeLogEntry(name_ + "_gains_M");
-  logger.removeLogEntry(name_ + "_gains_D");
-  logger.removeLogEntry(name_ + "_gains_K");
-  logger.removeLogEntry(name_ + "_gains_wrench");
-
-  // compliance values
-  logger.removeLogEntry(name_ + "_deltaCompliancePose");
-  logger.removeLogEntry(name_ + "_deltaComplianceVel");
-  logger.removeLogEntry(name_ + "_deltaComplianceAccel");
-
-  // target values
-  logger.removeLogEntry(name_ + "_targetPose");
-  logger.removeLogEntry(name_ + "_targetVel");
-  logger.removeLogEntry(name_ + "_targetAccel");
-
-  // wrench
-  logger.removeLogEntry(name_ + "_targetWrench");
-  logger.removeLogEntry(name_ + "_measuredWrench");
-  logger.removeLogEntry(name_ + "_filteredMeasuredWrench");
-  logger.removeLogEntry(name_ + "_cutoffPeriod");
+  MC_RTC_LOG_HELPER(logger, name_ + "_targetWrench", this, &ImpedanceTask::targetWrench_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_measuredWrench", this, &ImpedanceTask::measuredWrench_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_filteredMeasuredWrench", this, &ImpedanceTask::filteredMeasuredWrench_);
+  logger.addLogEntry(name_ + "_cutoffPeriod", this, [this]() { return cutoffPeriod(); });
 }
 
 void ImpedanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/ImpedanceTask.cpp
+++ b/src/mc_tasks/ImpedanceTask.cpp
@@ -190,19 +190,19 @@ void ImpedanceTask::addToLogger(mc_rtc::Logger & logger)
                      [this]() -> const sva::ImpedanceVecd & { return gains().wrench().vec(); });
 
   // compliance values
-  MC_RTC_LOG_HELPER(logger, name_ + "_deltaCompliancePose", this, &ImpedanceTask::deltaCompPoseW_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_deltaComplianceVel", this, &ImpedanceTask::deltaCompVelW_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_deltaComplianceAccel", this, &ImpedanceTask::deltaCompAccelW_);
+  MC_RTC_LOG_HELPER(name_ + "_deltaCompliancePose", deltaCompPoseW_);
+  MC_RTC_LOG_HELPER(name_ + "_deltaComplianceVel", deltaCompVelW_);
+  MC_RTC_LOG_HELPER(name_ + "_deltaComplianceAccel", deltaCompAccelW_);
 
   // target values
-  MC_RTC_LOG_HELPER(logger, name_ + "_targetPose", this, &ImpedanceTask::targetPoseW_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_targetVel", this, &ImpedanceTask::targetVelW_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_targetAccel", this, &ImpedanceTask::targetAccelW_);
+  MC_RTC_LOG_HELPER(name_ + "_targetPose", targetPoseW_);
+  MC_RTC_LOG_HELPER(name_ + "_targetVel", targetVelW_);
+  MC_RTC_LOG_HELPER(name_ + "_targetAccel", targetAccelW_);
 
   // wrench
-  MC_RTC_LOG_HELPER(logger, name_ + "_targetWrench", this, &ImpedanceTask::targetWrench_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_measuredWrench", this, &ImpedanceTask::measuredWrench_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_filteredMeasuredWrench", this, &ImpedanceTask::filteredMeasuredWrench_);
+  MC_RTC_LOG_HELPER(name_ + "_targetWrench", targetWrench_);
+  MC_RTC_LOG_HELPER(name_ + "_measuredWrench", measuredWrench_);
+  MC_RTC_LOG_HELPER(name_ + "_filteredMeasuredWrench", filteredMeasuredWrench_);
   logger.addLogEntry(name_ + "_cutoffPeriod", this, [this]() { return cutoffPeriod(); });
 }
 

--- a/src/mc_tasks/ImpedanceTask.cpp
+++ b/src/mc_tasks/ImpedanceTask.cpp
@@ -183,10 +183,10 @@ void ImpedanceTask::addToLogger(mc_rtc::Logger & logger)
   SurfaceTransformTask::addToLogger(logger);
 
   // impedance parameters
-  logger.addLogEntry(name_ + "_gains_M", [this]() -> const sva::ImpedanceVecd & { return gains().M().vec(); });
-  logger.addLogEntry(name_ + "_gains_D", [this]() -> const sva::ImpedanceVecd & { return gains().D().vec(); });
-  logger.addLogEntry(name_ + "_gains_K", [this]() -> const sva::ImpedanceVecd & { return gains().K().vec(); });
-  logger.addLogEntry(name_ + "_gains_wrench",
+  logger.addLogEntry(name_ + "_gains_M", this, [this]() -> const sva::ImpedanceVecd & { return gains().M().vec(); });
+  logger.addLogEntry(name_ + "_gains_D", this, [this]() -> const sva::ImpedanceVecd & { return gains().D().vec(); });
+  logger.addLogEntry(name_ + "_gains_K", this, [this]() -> const sva::ImpedanceVecd & { return gains().K().vec(); });
+  logger.addLogEntry(name_ + "_gains_wrench", this,
                      [this]() -> const sva::ImpedanceVecd & { return gains().wrench().vec(); });
 
   // compliance values

--- a/src/mc_tasks/LookAtTask.cpp
+++ b/src/mc_tasks/LookAtTask.cpp
@@ -59,18 +59,10 @@ Eigen::Vector3d LookAtTask::target() const
 void LookAtTask::addToLogger(mc_rtc::Logger & logger)
 {
   VectorOrientationTask::addToLogger(logger);
-  logger.addLogEntry(name_ + "_target_pos", [this]() -> const Eigen::Vector3d { return target(); });
-  logger.addLogEntry(name_ + "_current_pos", [this]() -> const Eigen::Vector3d & {
+  logger.addLogEntry(name_ + "_target_pos", this, [this]() -> const Eigen::Vector3d { return target(); });
+  logger.addLogEntry(name_ + "_current_pos", this, [this]() -> const Eigen::Vector3d & {
     return robots.robot(rIndex).mbc().bodyPosW[bIndex].translation();
-    ;
   });
-}
-
-void LookAtTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  VectorOrientationTask::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_target_pos");
-  logger.removeLogEntry(name_ + "_current_pos");
 }
 
 void LookAtTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/MetaTask.cpp
+++ b/src/mc_tasks/MetaTask.cpp
@@ -64,6 +64,11 @@ void MetaTask::removeFromGUI(mc_rtc::gui::StateBuilder & gui)
   gui.removeCategory({"Tasks", name_});
 }
 
+void MetaTask::removeFromLogger(mc_rtc::Logger & logger)
+{
+  logger.removeLogEntries(this);
+}
+
 std::function<bool(const mc_tasks::MetaTask & task, std::string &)> MetaTask::buildCompletionCriteria(
     double,
     const mc_rtc::Configuration &) const

--- a/src/mc_tasks/MomentumTask.cpp
+++ b/src/mc_tasks/MomentumTask.cpp
@@ -53,16 +53,10 @@ void MomentumTask::momentum(const sva::ForceVecd & m)
 void MomentumTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  logger.addLogEntry(name_ + "_target_momentum", [this]() { return momentum(); });
+  logger.addLogEntry(name_ + "_target_momentum", this, [this]() { return momentum(); });
   // FIXME Not correct with dimWeight
-  logger.addLogEntry(name_ + "_momentum", [this]() { return sva::ForceVecd(momentum().vector() - errorT->eval()); });
-}
-
-void MomentumTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  TrajectoryBase::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_momentum");
-  logger.removeLogEntry(name_ + "_target_momentum");
+  logger.addLogEntry(name_ + "_momentum", this,
+                     [this]() { return sva::ForceVecd(momentum().vector() - errorT->eval()); });
 }
 
 void MomentumTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/OrientationTask.cpp
+++ b/src/mc_tasks/OrientationTask.cpp
@@ -74,16 +74,9 @@ void OrientationTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
 void OrientationTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  logger.addLogEntry(name_ + "_target", [this]() { return Eigen::Quaterniond(orientation()); });
-  logger.addLogEntry(name_,
+  logger.addLogEntry(name_ + "_target", this, [this]() { return Eigen::Quaterniond(orientation()); });
+  logger.addLogEntry(name_, this,
                      [this]() { return Eigen::Quaterniond(robots.robot(rIndex).mbc().bodyPosW[bIndex].rotation()); });
-}
-
-void OrientationTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  TrajectoryBase::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_target");
-  logger.removeLogEntry(name_);
 }
 
 } // namespace mc_tasks

--- a/src/mc_tasks/PositionBasedVisServoTask.cpp
+++ b/src/mc_tasks/PositionBasedVisServoTask.cpp
@@ -57,8 +57,8 @@ void PositionBasedVisServoTask::error(const sva::PTransformd & X_t_s)
 void PositionBasedVisServoTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  logger.addLogEntry(name_ + "_error", [this]() -> const sva::PTransformd & { return X_t_s_; });
-  logger.addLogEntry(name_ + "_eval", [this]() -> sva::PTransformd {
+  MC_RTC_LOG_HELPER(logger, name_ + "_error", this, &PositionBasedVisServoTask::X_t_s_);
+  logger.addLogEntry(name_ + "_eval", this, [this]() -> sva::PTransformd {
     Eigen::Vector6d eval = errorT->eval();
     Eigen::Vector3d angleAxis = eval.head(3);
     Eigen::Vector3d axis = angleAxis / angleAxis.norm();
@@ -66,13 +66,6 @@ void PositionBasedVisServoTask::addToLogger(mc_rtc::Logger & logger)
     Eigen::Quaterniond quat(Eigen::AngleAxisd(angle, axis));
     return sva::PTransformd(quat, eval.tail(3));
   });
-}
-
-void PositionBasedVisServoTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  TrajectoryBase::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_error");
-  logger.removeLogEntry(name_ + "_eval");
 }
 
 } // namespace mc_tasks

--- a/src/mc_tasks/PositionBasedVisServoTask.cpp
+++ b/src/mc_tasks/PositionBasedVisServoTask.cpp
@@ -57,7 +57,7 @@ void PositionBasedVisServoTask::error(const sva::PTransformd & X_t_s)
 void PositionBasedVisServoTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  MC_RTC_LOG_HELPER(logger, name_ + "_error", this, &PositionBasedVisServoTask::X_t_s_);
+  MC_RTC_LOG_HELPER(name_ + "_error", X_t_s_);
   logger.addLogEntry(name_ + "_eval", this, [this]() -> sva::PTransformd {
     Eigen::Vector6d eval = errorT->eval();
     Eigen::Vector3d angleAxis = eval.head(3);

--- a/src/mc_tasks/PositionTask.cpp
+++ b/src/mc_tasks/PositionTask.cpp
@@ -76,19 +76,11 @@ void PositionTask::bodyPoint(const Eigen::Vector3d & bodyPoint)
 void PositionTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  logger.addLogEntry(name_ + "_target", [this]() { return position(); });
-  logger.addLogEntry(name_ + "_curPos", [this]() -> const Eigen::Vector3d & {
+  logger.addLogEntry(name_ + "_target", this, [this]() { return position(); });
+  logger.addLogEntry(name_ + "_curPos", this, [this]() -> const Eigen::Vector3d & {
     return robots.robot(rIndex).mbc().bodyPosW[bIndex].translation();
   });
-  logger.addLogEntry(name_ + "_curVel", [this]() -> const Eigen::VectorXd & { return errorT->speed(); });
-}
-
-void PositionTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  TrajectoryBase::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_target");
-  logger.removeLogEntry(name_ + "_curPos");
-  logger.removeLogEntry(name_ + "_curVel");
+  logger.addLogEntry(name_ + "_curVel", this, [this]() -> const Eigen::VectorXd & { return errorT->speed(); });
 }
 
 void PositionTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/PostureTask.cpp
+++ b/src/mc_tasks/PostureTask.cpp
@@ -212,14 +212,8 @@ void PostureTask::target(const std::map<std::string, std::vector<double>> & join
 
 void PostureTask::addToLogger(mc_rtc::Logger & logger)
 {
-  logger.addLogEntry(name_ + "_eval", [this]() -> const Eigen::VectorXd & { return pt_.eval(); });
-  logger.addLogEntry(name_ + "_speed", [this]() -> const Eigen::VectorXd & { return speed_; });
-}
-
-void PostureTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  logger.removeLogEntry(name_ + "_eval");
-  logger.removeLogEntry(name_ + "_speed");
+  logger.addLogEntry(name_ + "_eval", this, [this]() -> const Eigen::VectorXd & { return pt_.eval(); });
+  logger.addLogEntry(name_ + "_speed", this, [this]() -> const Eigen::VectorXd & { return speed_; });
 }
 
 void PostureTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/SurfaceTransformTask.cpp
+++ b/src/mc_tasks/SurfaceTransformTask.cpp
@@ -139,18 +139,11 @@ void SurfaceTransformTask::targetSurface(unsigned int robotIndex,
 void SurfaceTransformTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  logger.addLogEntry(name_ + "_surface_pose", [this]() {
+  logger.addLogEntry(name_ + "_surface_pose", this, [this]() {
     const auto & robot = robots.robot(rIndex);
     return robot.surface(surfaceName).X_0_s(robot);
   });
-  logger.addLogEntry(name_ + "_target_pose", [this]() { return target(); });
-}
-
-void SurfaceTransformTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  TrajectoryBase::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_surface_pose");
-  logger.removeLogEntry(name_ + "_target_pose");
+  logger.addLogEntry(name_ + "_target_pose", this, [this]() { return target(); });
 }
 
 std::function<bool(const mc_tasks::MetaTask &, std::string &)> SurfaceTransformTask::buildCompletionCriteria(

--- a/src/mc_tasks/VectorOrientationTask.cpp
+++ b/src/mc_tasks/VectorOrientationTask.cpp
@@ -87,17 +87,9 @@ const Eigen::Vector3d & VectorOrientationTask::actual() const
 void VectorOrientationTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  logger.addLogEntry(name_ + "_target", [this]() -> const Eigen::Vector3d & { return targetVector(); });
-  logger.addLogEntry(name_ + "_current", [this]() -> const Eigen::Vector3d & { return actual(); });
-  logger.addLogEntry(name_ + "_error", [this]() -> Eigen::Vector3d { return eval(); });
-}
-
-void VectorOrientationTask::removeFromLogger(mc_rtc::Logger & logger)
-{
-  TrajectoryBase::removeFromLogger(logger);
-  logger.removeLogEntry(name_ + "_target");
-  logger.removeLogEntry(name_ + "_current");
-  logger.removeLogEntry(name_ + "_error");
+  logger.addLogEntry(name_ + "_target", this, [this]() -> const Eigen::Vector3d & { return targetVector(); });
+  MC_RTC_LOG_HELPER(logger, name_ + "_current", this, &VectorOrientationTask::actual);
+  MC_RTC_LOG_HELPER(logger, name_ + "_error", this, &VectorOrientationTask::eval);
 }
 
 void VectorOrientationTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/VectorOrientationTask.cpp
+++ b/src/mc_tasks/VectorOrientationTask.cpp
@@ -87,9 +87,9 @@ const Eigen::Vector3d & VectorOrientationTask::actual() const
 void VectorOrientationTask::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  logger.addLogEntry(name_ + "_target", this, [this]() -> const Eigen::Vector3d & { return targetVector(); });
-  MC_RTC_LOG_HELPER(logger, name_ + "_current", this, &VectorOrientationTask::actual);
-  MC_RTC_LOG_HELPER(logger, name_ + "_error", this, &VectorOrientationTask::eval);
+  MC_RTC_LOG_GETTER(name_ + "_target", targetVector);
+  MC_RTC_LOG_HELPER(name_ + "_current", actual);
+  MC_RTC_LOG_HELPER(name_ + "_error", eval);
 }
 
 void VectorOrientationTask::addToGUI(mc_rtc::gui::StateBuilder & gui)

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -198,7 +198,7 @@ void StabilizerTask::updateContacts(mc_solver::QPSolver & solver)
   if(!addContacts_.empty())
   {
     // Remove previous contacts
-    for(const auto contactT : contactTasks)
+    for(const auto & contactT : contactTasks)
     {
       mc_rtc::log::info("{}: Removing contact {}", name(), contactT->surface());
       MetaTask::removeFromLogger(*contactT, *solver.logger());

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -293,14 +293,14 @@ void StabilizerTask::removeFromGUI(mc_rtc::gui::StateBuilder & gui)
 void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
 {
   // Globbal log entries added to other categories
-  MC_RTC_LOG_HELPER(logger, "perf_" + name_, this, &StabilizerTask::runTime_);
+  MC_RTC_LOG_HELPER("perf_" + name_, runTime_);
 
-  MC_RTC_LOG_HELPER(logger, name_ + "_error_dcm_average", this, &StabilizerTask::dcmAverageError_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_error_dcm_pos", this, &StabilizerTask::dcmError_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_error_dcm_vel", this, &StabilizerTask::dcmVelError_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_error_dfz_force", this, &StabilizerTask::dfzForceError_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_error_dfz_height", this, &StabilizerTask::dfzHeightError_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_error_vdc", this, &StabilizerTask::vdcHeightError_);
+  MC_RTC_LOG_HELPER(name_ + "_error_dcm_average", dcmAverageError_);
+  MC_RTC_LOG_HELPER(name_ + "_error_dcm_pos", dcmError_);
+  MC_RTC_LOG_HELPER(name_ + "_error_dcm_vel", dcmVelError_);
+  MC_RTC_LOG_HELPER(name_ + "_error_dfz_force", dfzForceError_);
+  MC_RTC_LOG_HELPER(name_ + "_error_dfz_height", dfzHeightError_);
+  MC_RTC_LOG_HELPER(name_ + "_error_vdc", vdcHeightError_);
   logger.addLogEntry(name_ + "_admittance_cop", this, [this]() -> const Eigen::Vector2d & { return c_.copAdmittance; });
   logger.addLogEntry(name_ + "_admittance_dfz", this, [this]() { return c_.dfzAdmittance; });
   logger.addLogEntry(name_ + "_dcmDerivator_filtered", this, [this]() { return dcmDerivator_.eval(); });
@@ -325,19 +325,19 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
                      [this]() { return std::pow(c_.fdqpWeights.pressureSqrt, 2); });
   logger.addLogEntry(name_ + "_vdc_frequency", this, [this]() { return c_.vdcFrequency; });
   logger.addLogEntry(name_ + "_vdc_stiffness", this, [this]() { return c_.vdcStiffness; });
-  MC_RTC_LOG_HELPER(logger, name_ + "_wrench", this, &StabilizerTask::distribWrench_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_support_min", this, &StabilizerTask::supportMin_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_support_max", this, &StabilizerTask::supportMax_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_left_foot_ratio", this, &StabilizerTask::leftFootRatio_);
+  MC_RTC_LOG_HELPER(name_ + "_wrench", distribWrench_);
+  MC_RTC_LOG_HELPER(name_ + "_support_min", supportMin_);
+  MC_RTC_LOG_HELPER(name_ + "_support_max", supportMax_);
+  MC_RTC_LOG_HELPER(name_ + "_left_foot_ratio", leftFootRatio_);
 
   // Stabilizer targets
-  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_com", this, &StabilizerTask::comTarget_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_comd", this, &StabilizerTask::comdTarget_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_comdd", this, &StabilizerTask::comddTarget_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_dcm", this, &StabilizerTask::dcmTarget_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_omega", this, &StabilizerTask::omega_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_zmp", this, &StabilizerTask::zmpTarget_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_target_stabilizer_zmp", this, &StabilizerTask::distribZMP_);
+  MC_RTC_LOG_HELPER(name_ + "_target_pendulum_com", comTarget_);
+  MC_RTC_LOG_HELPER(name_ + "_target_pendulum_comd", comdTarget_);
+  MC_RTC_LOG_HELPER(name_ + "_target_pendulum_comdd", comddTarget_);
+  MC_RTC_LOG_HELPER(name_ + "_target_pendulum_dcm", dcmTarget_);
+  MC_RTC_LOG_HELPER(name_ + "_target_pendulum_omega", omega_);
+  MC_RTC_LOG_HELPER(name_ + "_target_pendulum_zmp", zmpTarget_);
+  MC_RTC_LOG_HELPER(name_ + "_target_stabilizer_zmp", distribZMP_);
 
   logger.addLogEntry(name_ + "_contactState", this, [this]() -> int {
     if(inDoubleSupport())
@@ -364,10 +364,10 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
                      [this]() { return realRobot().surfacePose(footSurface(ContactState::Left)); });
   logger.addLogEntry(name_ + "_realRobot_RightFoot", this,
                      [this]() { return realRobot().surfacePose(footSurface(ContactState::Right)); });
-  MC_RTC_LOG_HELPER(logger, name_ + "_realRobot_com", this, &StabilizerTask::measuredCoM_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_realRobot_comd", this, &StabilizerTask::measuredCoMd_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_realRobot_dcm", this, &StabilizerTask::measuredDCM_);
-  MC_RTC_LOG_HELPER(logger, name_ + "_realRobot_dcm_unbiased", this, &StabilizerTask::measuredDCMUnbiased_);
+  MC_RTC_LOG_HELPER(name_ + "_realRobot_com", measuredCoM_);
+  MC_RTC_LOG_HELPER(name_ + "_realRobot_comd", measuredCoMd_);
+  MC_RTC_LOG_HELPER(name_ + "_realRobot_dcm", measuredDCM_);
+  MC_RTC_LOG_HELPER(name_ + "_realRobot_dcm_unbiased", measuredDCMUnbiased_);
   logger.addLogEntry(name_ + "_realRobot_posW", this,
                      [this]() -> const sva::PTransformd & { return realRobot().posW(); });
   logger.addLogEntry(name_ + "_realRobot_wrench", this,

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -293,52 +293,53 @@ void StabilizerTask::removeFromGUI(mc_rtc::gui::StateBuilder & gui)
 void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
 {
   // Globbal log entries added to other categories
-  logger.addLogEntry("perf_" + name_, [this]() { return runTime_; });
+  MC_RTC_LOG_HELPER(logger, "perf_" + name_, this, &StabilizerTask::runTime_);
 
-  logger.addLogEntry(name_ + "_error_dcm_average", [this]() { return dcmAverageError_; });
-  logger.addLogEntry(name_ + "_error_dcm_pos", [this]() { return dcmError_; });
-  logger.addLogEntry(name_ + "_error_dcm_vel", [this]() { return dcmVelError_; });
-  logger.addLogEntry(name_ + "_error_dfz_force", [this]() { return dfzForceError_; });
-  logger.addLogEntry(name_ + "_error_dfz_height", [this]() { return dfzHeightError_; });
-  logger.addLogEntry(name_ + "_error_vdc", [this]() { return vdcHeightError_; });
-  logger.addLogEntry(name_ + "_admittance_cop", [this]() { return c_.copAdmittance; });
-  zmpcc_.addToLogger(logger, name_);
-  logger.addLogEntry(name_ + "_admittance_dfz", [this]() { return c_.dfzAdmittance; });
-  logger.addLogEntry(name_ + "_dcmDerivator_filtered", [this]() { return dcmDerivator_.eval(); });
-  logger.addLogEntry(name_ + "_dcmDerivator_timeConstant", [this]() { return dcmDerivator_.timeConstant(); });
-  logger.addLogEntry(name_ + "_dcmIntegrator_timeConstant", [this]() { return dcmIntegrator_.timeConstant(); });
-  logger.addLogEntry(name_ + "_dcmTracking_derivGain", [this]() { return c_.dcmDerivGain; });
-  logger.addLogEntry(name_ + "_dcmTracking_integralGain", [this]() { return c_.dcmIntegralGain; });
-  logger.addLogEntry(name_ + "_dcmTracking_propGain", [this]() { return c_.dcmPropGain; });
-  logger.addLogEntry(name_ + "_dcmBias_dcmMeasureErrorStd", [this]() { return c_.dcmBias.dcmMeasureErrorStd; });
-  logger.addLogEntry(name_ + "_dcmBias_zmpMeasureErrorStd", [this]() { return c_.dcmBias.zmpMeasureErrorStd; });
-  logger.addLogEntry(name_ + "_dcmBias_driftPerSecondStd", [this]() { return c_.dcmBias.biasDriftPerSecondStd; });
-  logger.addLogEntry(name_ + "_dcmBias_biasLimit",
+  MC_RTC_LOG_HELPER(logger, name_ + "_error_dcm_average", this, &StabilizerTask::dcmAverageError_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_error_dcm_pos", this, &StabilizerTask::dcmError_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_error_dcm_vel", this, &StabilizerTask::dcmVelError_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_error_dfz_force", this, &StabilizerTask::dfzForceError_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_error_dfz_height", this, &StabilizerTask::dfzHeightError_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_error_vdc", this, &StabilizerTask::vdcHeightError_);
+  logger.addLogEntry(name_ + "_admittance_cop", this, [this]() -> const Eigen::Vector2d & { return c_.copAdmittance; });
+  logger.addLogEntry(name_ + "_admittance_dfz", this, [this]() { return c_.dfzAdmittance; });
+  logger.addLogEntry(name_ + "_dcmDerivator_filtered", this, [this]() { return dcmDerivator_.eval(); });
+  logger.addLogEntry(name_ + "_dcmDerivator_timeConstant", this, [this]() { return dcmDerivator_.timeConstant(); });
+  logger.addLogEntry(name_ + "_dcmIntegrator_timeConstant", this, [this]() { return dcmIntegrator_.timeConstant(); });
+  logger.addLogEntry(name_ + "_dcmTracking_derivGain", this, [this]() { return c_.dcmDerivGain; });
+  logger.addLogEntry(name_ + "_dcmTracking_integralGain", this, [this]() { return c_.dcmIntegralGain; });
+  logger.addLogEntry(name_ + "_dcmTracking_propGain", this, [this]() { return c_.dcmPropGain; });
+  logger.addLogEntry(name_ + "_dcmBias_dcmMeasureErrorStd", this, [this]() { return c_.dcmBias.dcmMeasureErrorStd; });
+  logger.addLogEntry(name_ + "_dcmBias_zmpMeasureErrorStd", this, [this]() { return c_.dcmBias.zmpMeasureErrorStd; });
+  logger.addLogEntry(name_ + "_dcmBias_driftPerSecondStd", this, [this]() { return c_.dcmBias.biasDriftPerSecondStd; });
+  logger.addLogEntry(name_ + "_dcmBias_biasLimit", this,
                      [this]() -> const Eigen::Vector2d & { return c_.dcmBias.biasLimit; });
-  logger.addLogEntry(name_ + "_dcmBias_localBias", [this]() { return dcmEstimator_.getLocalBias(); });
-  logger.addLogEntry(name_ + "_dcmBias_bias", [this]() { return dcmEstimator_.getBias(); });
-  logger.addLogEntry(name_ + "_dfz_damping", [this]() { return c_.dfzDamping; });
-  logger.addLogEntry(name_ + "_fdqp_weights_ankleTorque",
+  logger.addLogEntry(name_ + "_dcmBias_localBias", this, [this]() { return dcmEstimator_.getLocalBias(); });
+  logger.addLogEntry(name_ + "_dcmBias_bias", this, [this]() { return dcmEstimator_.getBias(); });
+  logger.addLogEntry(name_ + "_dfz_damping", this, [this]() { return c_.dfzDamping; });
+  logger.addLogEntry(name_ + "_fdqp_weights_ankleTorque", this,
                      [this]() { return std::pow(c_.fdqpWeights.ankleTorqueSqrt, 2); });
-  logger.addLogEntry(name_ + "_fdqp_weights_netWrench", [this]() { return std::pow(c_.fdqpWeights.netWrenchSqrt, 2); });
-  logger.addLogEntry(name_ + "_fdqp_weights_pressure", [this]() { return std::pow(c_.fdqpWeights.pressureSqrt, 2); });
-  logger.addLogEntry(name_ + "_vdc_frequency", [this]() { return c_.vdcFrequency; });
-  logger.addLogEntry(name_ + "_vdc_stiffness", [this]() { return c_.vdcStiffness; });
-  logger.addLogEntry(name_ + "_wrench", [this]() -> const sva::ForceVecd & { return distribWrench_; });
-  logger.addLogEntry(name_ + "_support_min", [this]() -> const Eigen::Vector2d & { return supportMin_; });
-  logger.addLogEntry(name_ + "_support_max", [this]() -> const Eigen::Vector2d & { return supportMax_; });
-  logger.addLogEntry(name_ + "_left_foot_ratio", [this]() { return leftFootRatio_; });
+  logger.addLogEntry(name_ + "_fdqp_weights_netWrench", this,
+                     [this]() { return std::pow(c_.fdqpWeights.netWrenchSqrt, 2); });
+  logger.addLogEntry(name_ + "_fdqp_weights_pressure", this,
+                     [this]() { return std::pow(c_.fdqpWeights.pressureSqrt, 2); });
+  logger.addLogEntry(name_ + "_vdc_frequency", this, [this]() { return c_.vdcFrequency; });
+  logger.addLogEntry(name_ + "_vdc_stiffness", this, [this]() { return c_.vdcStiffness; });
+  MC_RTC_LOG_HELPER(logger, name_ + "_wrench", this, &StabilizerTask::distribWrench_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_support_min", this, &StabilizerTask::supportMin_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_support_max", this, &StabilizerTask::supportMax_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_left_foot_ratio", this, &StabilizerTask::leftFootRatio_);
 
   // Stabilizer targets
-  logger.addLogEntry(name_ + "_target_pendulum_com", [this]() -> const Eigen::Vector3d & { return comTarget_; });
-  logger.addLogEntry(name_ + "_target_pendulum_comd", [this]() -> const Eigen::Vector3d & { return comdTarget_; });
-  logger.addLogEntry(name_ + "_target_pendulum_comdd", [this]() -> const Eigen::Vector3d & { return comddTarget_; });
-  logger.addLogEntry(name_ + "_target_pendulum_dcm", [this]() -> const Eigen::Vector3d & { return dcmTarget_; });
-  logger.addLogEntry(name_ + "_target_pendulum_omega", [this]() { return omega_; });
-  logger.addLogEntry(name_ + "_target_pendulum_zmp", [this]() -> const Eigen::Vector3d & { return zmpTarget_; });
-  logger.addLogEntry(name_ + "_target_stabilizer_zmp", [this]() -> const Eigen::Vector3d & { return distribZMP_; });
+  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_com", this, &StabilizerTask::comTarget_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_comd", this, &StabilizerTask::comdTarget_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_comdd", this, &StabilizerTask::comddTarget_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_dcm", this, &StabilizerTask::dcmTarget_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_omega", this, &StabilizerTask::omega_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_target_pendulum_zmp", this, &StabilizerTask::zmpTarget_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_target_stabilizer_zmp", this, &StabilizerTask::distribZMP_);
 
-  logger.addLogEntry(name_ + "_contactState", [this]() -> int {
+  logger.addLogEntry(name_ + "_contactState", this, [this]() -> int {
     if(inDoubleSupport())
       return 0;
     else if(inContact(ContactState::Left))
@@ -350,26 +351,30 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   });
 
   // Log computed robot properties
-  logger.addLogEntry(name_ + "_controlRobot_LeftFoot",
+  logger.addLogEntry(name_ + "_controlRobot_LeftFoot", this,
                      [this]() { return robot().surfacePose(footSurface(ContactState::Left)); });
-  logger.addLogEntry(name_ + "_controlRobot_RightFoot",
+  logger.addLogEntry(name_ + "_controlRobot_RightFoot", this,
                      [this]() { return robot().surfacePose(footSurface(ContactState::Right)); });
-  logger.addLogEntry(name_ + "_controlRobot_com", [this]() { return robot().com(); });
-  logger.addLogEntry(name_ + "_controlRobot_comd", [this]() { return robot().comVelocity(); });
-  logger.addLogEntry(name_ + "_controlRobot_posW", [this]() -> const sva::PTransformd & { return robot().posW(); });
+  logger.addLogEntry(name_ + "_controlRobot_com", this, [this]() { return robot().com(); });
+  logger.addLogEntry(name_ + "_controlRobot_comd", this, [this]() { return robot().comVelocity(); });
+  logger.addLogEntry(name_ + "_controlRobot_posW", this,
+                     [this]() -> const sva::PTransformd & { return robot().posW(); });
 
-  logger.addLogEntry(name_ + "_realRobot_LeftFoot",
+  logger.addLogEntry(name_ + "_realRobot_LeftFoot", this,
                      [this]() { return realRobot().surfacePose(footSurface(ContactState::Left)); });
-  logger.addLogEntry(name_ + "_realRobot_RightFoot",
+  logger.addLogEntry(name_ + "_realRobot_RightFoot", this,
                      [this]() { return realRobot().surfacePose(footSurface(ContactState::Right)); });
-  logger.addLogEntry(name_ + "_realRobot_com", [this]() -> const Eigen::Vector3d & { return measuredCoM_; });
-  logger.addLogEntry(name_ + "_realRobot_comd", [this]() -> const Eigen::Vector3d & { return measuredCoMd_; });
-  logger.addLogEntry(name_ + "_realRobot_dcm", [this]() -> const Eigen::Vector3d & { return measuredDCM_; });
-  logger.addLogEntry(name_ + "_realRobot_dcm_unbiased",
-                     [this]() -> const Eigen::Vector3d & { return measuredDCMUnbiased_; });
-  logger.addLogEntry(name_ + "_realRobot_posW", [this]() -> const sva::PTransformd & { return realRobot().posW(); });
-  logger.addLogEntry(name_ + "_realRobot_wrench", [this]() -> const sva::ForceVecd & { return measuredNetWrench_; });
-  logger.addLogEntry(name_ + "_realRobot_zmp", [this]() -> const Eigen::Vector3d & { return measuredZMP_; });
+  MC_RTC_LOG_HELPER(logger, name_ + "_realRobot_com", this, &StabilizerTask::measuredCoM_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_realRobot_comd", this, &StabilizerTask::measuredCoMd_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_realRobot_dcm", this, &StabilizerTask::measuredDCM_);
+  MC_RTC_LOG_HELPER(logger, name_ + "_realRobot_dcm_unbiased", this, &StabilizerTask::measuredDCMUnbiased_);
+  logger.addLogEntry(name_ + "_realRobot_posW", this,
+                     [this]() -> const sva::PTransformd & { return realRobot().posW(); });
+  logger.addLogEntry(name_ + "_realRobot_wrench", this,
+                     [this]() -> const sva::ForceVecd & { return measuredNetWrench_; });
+  logger.addLogEntry(name_ + "_realRobot_zmp", this, [this]() -> const Eigen::Vector3d & { return measuredZMP_; });
+
+  zmpcc_.addToLogger(logger, name_);
 
   MetaTask::addToLogger(*comTask, logger);
   MetaTask::addToLogger(*pelvisTask, logger);
@@ -378,62 +383,8 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
 
 void StabilizerTask::removeFromLogger(mc_rtc::Logger & logger)
 {
-  logger.removeLogEntry("perf_" + name_);
-  logger.removeLogEntry(name_ + "_contactState");
-  logger.removeLogEntry(name_ + "_error_dcm_average");
-  logger.removeLogEntry(name_ + "_error_dcm_pos");
-  logger.removeLogEntry(name_ + "_error_dcm_vel");
-  logger.removeLogEntry(name_ + "_error_dfz_force");
-  logger.removeLogEntry(name_ + "_error_dfz_height");
-  logger.removeLogEntry(name_ + "_error_vdc");
+  MetaTask::removeFromLogger(logger);
   zmpcc_.removeFromLogger(logger, name_);
-  logger.removeLogEntry(name_ + "_admittance_cop");
-  logger.removeLogEntry(name_ + "_admittance_dfz");
-  logger.removeLogEntry(name_ + "_dcmDerivator_filtered");
-  logger.removeLogEntry(name_ + "_dcmDerivator_timeConstant");
-  logger.removeLogEntry(name_ + "_dcmIntegrator_timeConstant");
-  logger.removeLogEntry(name_ + "_dcmTracking_derivGain");
-  logger.removeLogEntry(name_ + "_dcmTracking_integralGain");
-  logger.removeLogEntry(name_ + "_dcmTracking_propGain");
-  logger.removeLogEntry(name_ + "_dcmBias_dcmMeasureErrorStd");
-  logger.removeLogEntry(name_ + "_dcmBias_zmpMeasureErrorStd");
-  logger.removeLogEntry(name_ + "_dcmBias_driftPerSecondStd");
-  logger.removeLogEntry(name_ + "_dcmBias_biasLimit");
-  logger.removeLogEntry(name_ + "_dcmBias_localBias");
-  logger.removeLogEntry(name_ + "_dcmBias_bias");
-  logger.removeLogEntry(name_ + "_dfz_damping");
-  logger.removeLogEntry(name_ + "_fdqp_weights_ankleTorque");
-  logger.removeLogEntry(name_ + "_fdqp_weights_netWrench");
-  logger.removeLogEntry(name_ + "_fdqp_weights_pressure");
-  logger.removeLogEntry(name_ + "_vdc_frequency");
-  logger.removeLogEntry(name_ + "_vdc_stiffness");
-  logger.removeLogEntry(name_ + "_wrench");
-  logger.removeLogEntry(name_ + "_zmp");
-  logger.removeLogEntry(name_ + "_support_min");
-  logger.removeLogEntry(name_ + "_support_max");
-  logger.removeLogEntry(name_ + "_left_foot_ratio");
-  logger.removeLogEntry(name_ + "_target_pendulum_com");
-  logger.removeLogEntry(name_ + "_target_pendulum_comd");
-  logger.removeLogEntry(name_ + "_target_pendulum_comdd");
-  logger.removeLogEntry(name_ + "_target_pendulum_dcm");
-  logger.removeLogEntry(name_ + "_target_pendulum_omega");
-  logger.removeLogEntry(name_ + "_target_pendulum_zmp");
-  logger.removeLogEntry(name_ + "_target_stabilizer_zmp");
-  logger.removeLogEntry(name_ + "_controlRobot_LeftFoot");
-  logger.removeLogEntry(name_ + "_controlRobot_RightFoot");
-  logger.removeLogEntry(name_ + "_controlRobot_com");
-  logger.removeLogEntry(name_ + "_controlRobot_comd");
-  logger.removeLogEntry(name_ + "_controlRobot_posW");
-  logger.removeLogEntry(name_ + "_realRobot_LeftFoot");
-  logger.removeLogEntry(name_ + "_realRobot_RightFoot");
-  logger.removeLogEntry(name_ + "_realRobot_com");
-  logger.removeLogEntry(name_ + "_realRobot_comd");
-  logger.removeLogEntry(name_ + "_realRobot_dcm");
-  logger.removeLogEntry(name_ + "_realRobot_dcm_unbiased");
-  logger.removeLogEntry(name_ + "_realRobot_posW");
-  logger.removeLogEntry(name_ + "_realRobot_wrench");
-  logger.removeLogEntry(name_ + "_realRobot_zmp");
-
   MetaTask::removeFromLogger(*comTask, logger);
   MetaTask::removeFromLogger(*pelvisTask, logger);
   MetaTask::removeFromLogger(*torsoTask, logger);

--- a/src/mc_tasks/lipm_stabilizer/ZMPCC.cpp
+++ b/src/mc_tasks/lipm_stabilizer/ZMPCC.cpp
@@ -73,15 +73,14 @@ void ZMPCC::removeFromGUI(mc_rtc::gui::StateBuilder & gui, const std::vector<std
 
 void ZMPCC::addToLogger(mc_rtc::Logger & logger, const std::string & name)
 {
-  logger.addLogEntry(name + "_zmpcc_comAdmittance",
+  logger.addLogEntry(name + "_zmpcc_comAdmittance", this,
                      [this]() -> const Eigen::Vector2d & { return config_.comAdmittance; });
-  logger.addLogEntry(name + "_zmpcc_errorZMP", [this]() -> const Eigen::Vector3d & { return error_; });
+  MC_RTC_LOG_HELPER(logger, name + "_zmpcc_errorZMP", this, &ZMPCC::error_);
 }
 
-void ZMPCC::removeFromLogger(mc_rtc::Logger & logger, const std::string & name)
+void ZMPCC::removeFromLogger(mc_rtc::Logger & logger, const std::string &)
 {
-  logger.removeLogEntry(name + "_zmpcc_comAdmittance");
-  logger.removeLogEntry(name + "_zmpcc_errorZMP");
+  logger.removeLogEntries(this);
 }
 
 } // namespace lipm_stabilizer

--- a/src/mc_tasks/lipm_stabilizer/ZMPCC.cpp
+++ b/src/mc_tasks/lipm_stabilizer/ZMPCC.cpp
@@ -75,7 +75,7 @@ void ZMPCC::addToLogger(mc_rtc::Logger & logger, const std::string & name)
 {
   logger.addLogEntry(name + "_zmpcc_comAdmittance", this,
                      [this]() -> const Eigen::Vector2d & { return config_.comAdmittance; });
-  MC_RTC_LOG_HELPER(logger, name + "_zmpcc_errorZMP", this, &ZMPCC::error_);
+  MC_RTC_LOG_HELPER(name + "_zmpcc_errorZMP", error_);
 }
 
 void ZMPCC::removeFromLogger(mc_rtc::Logger & logger, const std::string &)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,6 +78,7 @@ mc_rtc_test(testConfigurationHelpers mc_rtc_utils)
 mc_rtc_test(test_io_utils mc_rtc_utils)
 get_filename_component(EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../doc/_examples" ABSOLUTE)
 mc_rtc_test(testSchemaExamples mc_tasks)
+mc_rtc_test(testLogger mc_rtc_utils)
 
 ###########################
 # -- FSM related tests -- #

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -78,7 +78,7 @@ mc_rtc_test(testConfigurationHelpers mc_rtc_utils)
 mc_rtc_test(test_io_utils mc_rtc_utils)
 get_filename_component(EXAMPLE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../doc/_examples" ABSOLUTE)
 mc_rtc_test(testSchemaExamples mc_tasks)
-mc_rtc_test(testLogger mc_rtc_utils)
+mc_rtc_test(testLogger mc_rbdyn)
 
 ###########################
 # -- FSM related tests -- #

--- a/tests/testLogger.cpp
+++ b/tests/testLogger.cpp
@@ -9,6 +9,13 @@
 namespace bfs = boost::filesystem;
 #include <boost/test/unit_test.hpp>
 
+#include "utils.h"
+
+bool operator==(const Eigen::Quaterniond & lhs, const Eigen::Quaterniond & rhs)
+{
+  return lhs.vec() == rhs.vec();
+}
+
 /** Check one iteration of the logger */
 template<typename Callback>
 void check(mc_rtc::Logger & logger, Callback && cb)
@@ -18,6 +25,116 @@ void check(mc_rtc::Logger & logger, Callback && cb)
   mc_rtc::log::FlatLog log(logger.path());
   cb(log);
 }
+
+/** Check the value in a FlatLog at a given index */
+template<typename T>
+void check(const mc_rtc::log::FlatLog & log, const std::string & entry, size_t idx, const T & member)
+{
+  const T * raw = log.getRaw<T>(entry, idx);
+  BOOST_REQUIRE(raw && *raw == member);
+}
+
+struct LogData
+{
+  /** Some data members supported by the logger */
+  bool b = random_bool();
+  double d = rnd();
+  std::string s = random_string();
+  Eigen::Vector2d v2d = Eigen::Vector2d::Random();
+  Eigen::Vector3d v3d = Eigen::Vector3d::Random();
+  Eigen::Vector6d v6d = Eigen::Vector6d::Random();
+  Eigen::VectorXd vxd = Eigen::VectorXd::Random(36);
+  Eigen::Quaterniond q = random_quat();
+  sva::PTransformd pt = random_pt();
+  sva::ForceVecd fv = random_fv();
+  sva::MotionVecd mv = random_mv();
+  std::vector<double> v = random_vector();
+
+  /** Change data */
+  void refresh()
+  {
+    *this = LogData{};
+  }
+
+  void addToLogger(mc_rtc::Logger & logger, bool withSource)
+  {
+#define ADD_LOG_ENTRY(NAME, MEMBER)                                        \
+  withSource ? logger.addLogEntry(NAME, this, [this]() { return MEMBER; }) \
+             : logger.addLogEntry(NAME, [this]() { return MEMBER; });
+    ADD_LOG_ENTRY("bool", b);
+    ADD_LOG_ENTRY("double", d);
+    ADD_LOG_ENTRY("std::string", s);
+    ADD_LOG_ENTRY("Eigen::Vector2d", v2d);
+    ADD_LOG_ENTRY("Eigen::Vector3d", v3d);
+    ADD_LOG_ENTRY("Eigen::Vector6d", v6d);
+    ADD_LOG_ENTRY("Eigen::VectorXd", vxd);
+    ADD_LOG_ENTRY("Eigen::Quaterniond", q);
+    ADD_LOG_ENTRY("sva::PTransformd", pt);
+    ADD_LOG_ENTRY("sva::ForceVecd", fv);
+    ADD_LOG_ENTRY("sva::MotionVecd", mv);
+    ADD_LOG_ENTRY("std::vector<double>", v);
+#undef ADD_LOG_ENTRY
+  }
+
+  void removeFromLogger(mc_rtc::Logger & logger)
+  {
+    logger.removeLogEntry("bool");
+    logger.removeLogEntry("double");
+    logger.removeLogEntry("std::string");
+    logger.removeLogEntry("Eigen::Vector2d");
+    logger.removeLogEntry("Eigen::Vector3d");
+    logger.removeLogEntry("Eigen::Vector6d");
+    logger.removeLogEntry("Eigen::VectorXd");
+    logger.removeLogEntry("Eigen::Quaterniond");
+    logger.removeLogEntry("sva::PTransformd");
+    logger.removeLogEntry("sva::ForceVecd");
+    logger.removeLogEntry("sva::MotionVecd");
+    logger.removeLogEntry("std::vector<double>");
+  }
+
+  /** Check that the latest entry in the FlatLog has the same values as in the class */
+  void check(const mc_rtc::log::FlatLog & log)
+  {
+    BOOST_REQUIRE(log.size() >= 1);
+    size_t idx = log.size() - 1;
+    ::check(log, "bool", idx, b);
+    ::check(log, "double", idx, d);
+    ::check(log, "std::string", idx, s);
+    ::check(log, "Eigen::Vector2d", idx, v2d);
+    ::check(log, "Eigen::Vector3d", idx, v3d);
+    ::check(log, "Eigen::Vector6d", idx, v6d);
+    ::check(log, "Eigen::VectorXd", idx, vxd);
+    ::check(log, "Eigen::Quaterniond", idx, q);
+    ::check(log, "sva::PTransformd", idx, pt);
+    ::check(log, "sva::ForceVecd", idx, fv);
+    ::check(log, "sva::MotionVecd", idx, mv);
+    ::check(log, "std::vector<double>", idx, v);
+  }
+
+  /** Check that the entry at the given index has none of the class data */
+  void check_empty(const mc_rtc::log::FlatLog & log, size_t idx)
+  {
+    BOOST_REQUIRE(log.getRaw<bool>("bool", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<double>("double", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<std::string>("std::string", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<Eigen::Vector2d>("Eigen::Vector2d", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<Eigen::Vector3d>("Eigen::Vector3d", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<Eigen::Vector6d>("Eigen::Vector6d", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<Eigen::VectorXd>("Eigen::VectorXd", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<Eigen::Quaterniond>("Eigen::Quaterniond", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<sva::PTransformd>("sva::PTransformd", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<sva::ForceVecd>("sva::ForceVecd", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<sva::MotionVecd>("sva::MotionVecd", idx) == nullptr);
+    BOOST_REQUIRE(log.getRaw<std::vector<double>>("std::vector<double>", idx) == nullptr);
+  }
+
+  /** Shortcut to check the latest iteration is empty */
+  void check_empty(const mc_rtc::log::FlatLog & log)
+  {
+    BOOST_REQUIRE(log.size() >= 1);
+    check_empty(log, log.size() - 1);
+  }
+};
 
 BOOST_AUTO_TEST_CASE(TestLogger)
 {
@@ -30,5 +147,61 @@ BOOST_AUTO_TEST_CASE(TestLogger)
     BOOST_REQUIRE(log.size() == 1);
     auto t0 = log.getRaw<double>("t", 0);
     BOOST_REQUIRE(t0 && *t0 == 0.0);
+  });
+  /** Iteration 2, add callbacks without a source */
+  LogData data;
+  data.addToLogger(logger, false);
+  check(logger, [&data](const mc_rtc::log::FlatLog & log) {
+    std::set<std::string> entries = {"t",
+                                     "bool",
+                                     "double",
+                                     "std::string",
+                                     "Eigen::Vector2d",
+                                     "Eigen::Vector3d",
+                                     "Eigen::Vector6d",
+                                     "Eigen::VectorXd",
+                                     "Eigen::Quaterniond",
+                                     "sva::PTransformd",
+                                     "sva::ForceVecd",
+                                     "sva::MotionVecd",
+                                     "std::vector<double>"};
+    BOOST_REQUIRE(log.entries() == entries);
+    BOOST_REQUIRE(log.size() == 2);
+    data.check_empty(log, 0);
+    data.check(log);
+  });
+  /** Iteration 3, remove everything "manually" */
+  data.removeFromLogger(logger);
+  check(logger, [&data](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == 3);
+    data.check_empty(log);
+  });
+  /** Iteration 4, add everything with a source */
+  data.addToLogger(logger, true);
+  check(logger, [&data](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == 4);
+    data.check(log);
+  });
+  /** Iteration 5, remove everything via the source */
+  logger.removeLogEntries(&data);
+  check(logger, [&data](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == 5);
+    data.check_empty(log);
+  });
+  /** Iteration 6 to 100, refresh data and check everything is ok */
+  data.addToLogger(logger, true);
+  for(size_t i = 6; i <= 100; ++i)
+  {
+    check(logger, [&data, i](const mc_rtc::log::FlatLog & log) {
+      BOOST_REQUIRE(log.size() == i);
+      data.check(log);
+      data.refresh();
+    });
+  }
+  /** Iteration 101, remove the data once more */
+  logger.removeLogEntries(&data);
+  check(logger, [&data](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == 101);
+    data.check_empty(log);
   });
 }

--- a/tests/testLogger.cpp
+++ b/tests/testLogger.cpp
@@ -117,6 +117,38 @@ public:
     logger.addLogEntry("std::vector<double>", this, &LogData::v);
   }
 
+  void addToLoggerWithMemberPointerFast(mc_rtc::Logger & logger)
+  {
+    logger.addLogEntry<decltype(&LogData::b), &LogData::b>("bool", this);
+    logger.addLogEntry<decltype(&LogData::d), &LogData::d>("double", this);
+    logger.addLogEntry<decltype(&LogData::s), &LogData::s>("std::string", this);
+    logger.addLogEntry<decltype(&LogData::v2d), &LogData::v2d>("Eigen::Vector2d", this);
+    logger.addLogEntry<decltype(&LogData::v3d), &LogData::v3d>("Eigen::Vector3d", this);
+    logger.addLogEntry<decltype(&LogData::v6d), &LogData::v6d>("Eigen::Vector6d", this);
+    logger.addLogEntry<decltype(&LogData::vxd), &LogData::vxd>("Eigen::VectorXd", this);
+    logger.addLogEntry<decltype(&LogData::q), &LogData::q>("Eigen::Quaterniond", this);
+    logger.addLogEntry<decltype(&LogData::pt), &LogData::pt>("sva::PTransformd", this);
+    logger.addLogEntry<decltype(&LogData::fv), &LogData::fv>("sva::ForceVecd", this);
+    logger.addLogEntry<decltype(&LogData::mv), &LogData::mv>("sva::MotionVecd", this);
+    logger.addLogEntry<decltype(&LogData::v), &LogData::v>("std::vector<double>", this);
+  }
+
+  void addToLoggerWithMemberPointerMacro(mc_rtc::Logger & logger)
+  {
+    MC_RTC_LOG_HELPER(logger, "bool", this, &LogData::b);
+    MC_RTC_LOG_HELPER(logger, "double", this, &LogData::d);
+    MC_RTC_LOG_HELPER(logger, "std::string", this, &LogData::s);
+    MC_RTC_LOG_HELPER(logger, "Eigen::Vector2d", this, &LogData::v2d);
+    MC_RTC_LOG_HELPER(logger, "Eigen::Vector3d", this, &LogData::v3d);
+    MC_RTC_LOG_HELPER(logger, "Eigen::Vector6d", this, &LogData::v6d);
+    MC_RTC_LOG_HELPER(logger, "Eigen::VectorXd", this, &LogData::vxd);
+    MC_RTC_LOG_HELPER(logger, "Eigen::Quaterniond", this, &LogData::q);
+    MC_RTC_LOG_HELPER(logger, "sva::PTransformd", this, &LogData::pt);
+    MC_RTC_LOG_HELPER(logger, "sva::ForceVecd", this, &LogData::fv);
+    MC_RTC_LOG_HELPER(logger, "sva::MotionVecd", this, &LogData::mv);
+    MC_RTC_LOG_HELPER(logger, "std::vector<double>", this, &LogData::v);
+  }
+
   void addToLoggerWithGetter(mc_rtc::Logger & logger)
   {
     logger.addLogEntry("bool", this, &LogData::get_b);
@@ -131,6 +163,38 @@ public:
     logger.addLogEntry("sva::ForceVecd", this, &LogData::get_fv);
     logger.addLogEntry("sva::MotionVecd", this, &LogData::get_mv);
     logger.addLogEntry("std::vector<double>", this, &LogData::get_v);
+  }
+
+  void addToLoggerWithGetterFast(mc_rtc::Logger & logger)
+  {
+    logger.addLogEntry<decltype(&LogData::get_b), &LogData::get_b>("bool", this);
+    logger.addLogEntry<decltype(&LogData::get_d), &LogData::get_d>("double", this);
+    logger.addLogEntry<decltype(&LogData::get_s), &LogData::get_s>("std::string", this);
+    logger.addLogEntry<decltype(&LogData::get_v2d), &LogData::get_v2d>("Eigen::Vector2d", this);
+    logger.addLogEntry<decltype(&LogData::get_v3d), &LogData::get_v3d>("Eigen::Vector3d", this);
+    logger.addLogEntry<decltype(&LogData::get_v6d), &LogData::get_v6d>("Eigen::Vector6d", this);
+    logger.addLogEntry<decltype(&LogData::get_vxd), &LogData::get_vxd>("Eigen::VectorXd", this);
+    logger.addLogEntry<decltype(&LogData::get_q), &LogData::get_q>("Eigen::Quaterniond", this);
+    logger.addLogEntry<decltype(&LogData::get_pt), &LogData::get_pt>("sva::PTransformd", this);
+    logger.addLogEntry<decltype(&LogData::get_fv), &LogData::get_fv>("sva::ForceVecd", this);
+    logger.addLogEntry<decltype(&LogData::get_mv), &LogData::get_mv>("sva::MotionVecd", this);
+    logger.addLogEntry<decltype(&LogData::get_v), &LogData::get_v>("std::vector<double>", this);
+  }
+
+  void addToLoggerWithGetterMacro(mc_rtc::Logger & logger)
+  {
+    MC_RTC_LOG_HELPER(logger, "bool", this, &LogData::get_b);
+    MC_RTC_LOG_HELPER(logger, "double", this, &LogData::get_d);
+    MC_RTC_LOG_HELPER(logger, "std::string", this, &LogData::get_s);
+    MC_RTC_LOG_HELPER(logger, "Eigen::Vector2d", this, &LogData::get_v2d);
+    MC_RTC_LOG_HELPER(logger, "Eigen::Vector3d", this, &LogData::get_v3d);
+    MC_RTC_LOG_HELPER(logger, "Eigen::Vector6d", this, &LogData::get_v6d);
+    MC_RTC_LOG_HELPER(logger, "Eigen::VectorXd", this, &LogData::get_vxd);
+    MC_RTC_LOG_HELPER(logger, "Eigen::Quaterniond", this, &LogData::get_q);
+    MC_RTC_LOG_HELPER(logger, "sva::PTransformd", this, &LogData::get_pt);
+    MC_RTC_LOG_HELPER(logger, "sva::ForceVecd", this, &LogData::get_fv);
+    MC_RTC_LOG_HELPER(logger, "sva::MotionVecd", this, &LogData::get_mv);
+    MC_RTC_LOG_HELPER(logger, "std::vector<double>", this, &LogData::get_v);
   }
 
   void removeFromLogger(mc_rtc::Logger & logger)
@@ -198,18 +262,20 @@ BOOST_AUTO_TEST_CASE(TestLogger)
   using Policy = mc_rtc::Logger::Policy;
   mc_rtc::Logger logger(Policy::NON_THREADED, bfs::temp_directory_path().string(), "mc-rtc-test");
   logger.start("logger", 1.0);
+  size_t iter = 1;
   /** Iteration 1 only time */
-  check(logger, [](const mc_rtc::log::FlatLog & log) {
+  check(logger, [&](const mc_rtc::log::FlatLog & log) {
     BOOST_REQUIRE(log.entries() == std::set<std::string>{"t"});
-    BOOST_REQUIRE(log.size() == 1);
+    BOOST_REQUIRE(log.size() == iter);
     auto t0 = log.getRaw<double>("t", 0);
     BOOST_REQUIRE(t0 && *t0 == 0.0);
+    iter++;
   });
   /** Iteration 2, add callbacks without a source */
   LogData data;
   data.addToLogger(logger, false);
   /** Malloc is allowed in this test because we provided naive callbacks */
-  check<true>(logger, [&data](const mc_rtc::log::FlatLog & log) {
+  check<true>(logger, [&](const mc_rtc::log::FlatLog & log) {
     std::set<std::string> entries = {"t",
                                      "bool",
                                      "double",
@@ -224,76 +290,151 @@ BOOST_AUTO_TEST_CASE(TestLogger)
                                      "sva::MotionVecd",
                                      "std::vector<double>"};
     BOOST_REQUIRE(log.entries() == entries);
-    BOOST_REQUIRE(log.size() == 2);
+    BOOST_REQUIRE(log.size() == iter);
     data.check_empty(log, 0);
     data.check(log);
+    iter++;
   });
   /** Iteration 3, remove everything "manually" */
   data.removeFromLogger(logger);
-  check(logger, [&data](const mc_rtc::log::FlatLog & log) {
-    BOOST_REQUIRE(log.size() == 3);
+  check(logger, [&](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == iter);
     data.check_empty(log);
+    iter++;
   });
   /** Iteration 4, add everything with a source */
   data.addToLogger(logger, true);
   /** Malloc is allowed in this test because we provided naive callbacks */
-  check<true>(logger, [&data](const mc_rtc::log::FlatLog & log) {
-    BOOST_REQUIRE(log.size() == 4);
+  check<true>(logger, [&](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == iter);
     data.check(log);
+    iter++;
   });
   /** Iteration 5, remove everything via the source */
   logger.removeLogEntries(&data);
-  check(logger, [&data](const mc_rtc::log::FlatLog & log) {
-    BOOST_REQUIRE(log.size() == 5);
+  check(logger, [&](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == iter);
     data.check_empty(log);
+    iter++;
   });
   /** Iteration 6 to 100, refresh data and check everything is ok */
   data.addToLogger(logger, true);
-  for(size_t i = 6; i <= 100; ++i)
+  for(iter = 6; iter <= 100; ++iter)
   {
     /** Malloc is allowed in this test because we provided naive callbacks */
-    check<true>(logger, [&data, i](const mc_rtc::log::FlatLog & log) {
-      BOOST_REQUIRE(log.size() == i);
+    check<true>(logger, [&](const mc_rtc::log::FlatLog & log) {
+      BOOST_REQUIRE(log.size() == iter);
       data.check(log);
       data.refresh();
     });
   }
   /** Iteration 101, remove the data once more */
   logger.removeLogEntries(&data);
-  check(logger, [&data](const mc_rtc::log::FlatLog & log) {
-    BOOST_REQUIRE(log.size() == 101);
+  check(logger, [&](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == iter);
     data.check_empty(log);
+    iter++;
   });
   /** Iteration 102 to 150, add from pointer to member, refresh data and check everything is ok */
   data.addToLoggerWithMemberPointer(logger);
-  for(size_t i = 102; i <= 150; ++i)
+  for(iter = 102; iter <= 150; ++iter)
   {
-    check(logger, [&data, i](const mc_rtc::log::FlatLog & log) {
-      BOOST_REQUIRE(log.size() == i);
+    check(logger, [&](const mc_rtc::log::FlatLog & log) {
+      BOOST_REQUIRE(log.size() == iter);
       data.check(log);
       data.refresh();
     });
   }
   /** Iteration 151, remove the data once more */
   logger.removeLogEntries(&data);
-  check(logger, [&data](const mc_rtc::log::FlatLog & log) {
-    BOOST_REQUIRE(log.size() == 151);
+  check(logger, [&](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == iter);
     data.check_empty(log);
+    iter++;
   });
   /** Iteration 152 to 200, add from pointer to method, refresh data and check everything is ok */
   data.addToLoggerWithGetter(logger);
-  for(size_t i = 152; i <= 200; ++i)
+  for(iter = 152; iter <= 200; ++iter)
   {
-    check(logger, [&data, i](const mc_rtc::log::FlatLog & log) {
-      BOOST_REQUIRE(log.size() == i);
+    check(logger, [&](const mc_rtc::log::FlatLog & log) {
+      BOOST_REQUIRE(log.size() == iter);
       data.check(log);
       data.refresh();
     });
   }
   /** Iteration 201, remove the data once more */
   logger.removeLogEntries(&data);
-  check(logger, [&data](const mc_rtc::log::FlatLog & log) {
-    BOOST_REQUIRE(log.size() == 201);
+  check(logger, [&](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == iter);
     data.check_empty(log);
+    iter++;
+  });
+  /** Iteration 202 to 250, add from fast pointer to member, refresh data and check everything is ok */
+  data.addToLoggerWithMemberPointerFast(logger);
+  for(iter = 202; iter <= 250; ++iter)
+  {
+    check(logger, [&](const mc_rtc::log::FlatLog & log) {
+      BOOST_REQUIRE(log.size() == iter);
+      data.check(log);
+      data.refresh();
+    });
+  }
+  /** Iteration 251, remove the data once more */
+  logger.removeLogEntries(&data);
+  check(logger, [&](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == iter);
+    data.check_empty(log);
+    iter++;
+  });
+  /** Iteration 252 to 300, add from fast pointer to method, refresh data and check everything is ok */
+  data.addToLoggerWithGetterFast(logger);
+  for(iter = 252; iter <= 300; ++iter)
+  {
+    check(logger, [&](const mc_rtc::log::FlatLog & log) {
+      BOOST_REQUIRE(log.size() == iter);
+      data.check(log);
+      data.refresh();
+    });
+  }
+  /** Iteration 301, remove the data once more */
+  logger.removeLogEntries(&data);
+  check(logger, [&](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == iter);
+    data.check_empty(log);
+    iter++;
+  });
+  /** Iteration 302 to 350, add from fast pointer to member, refresh data and check everything is ok */
+  data.addToLoggerWithMemberPointerMacro(logger);
+  for(iter = 302; iter <= 350; ++iter)
+  {
+    check(logger, [&](const mc_rtc::log::FlatLog & log) {
+      BOOST_REQUIRE(log.size() == iter);
+      data.check(log);
+      data.refresh();
+    });
+  }
+  /** Iteration 351, remove the data once more */
+  logger.removeLogEntries(&data);
+  check(logger, [&](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == iter);
+    data.check_empty(log);
+    iter++;
+  });
+  /** Iteration 352 to 400, add from fast pointer to method, refresh data and check everything is ok */
+  data.addToLoggerWithGetterMacro(logger);
+  for(iter = 352; iter <= 400; ++iter)
+  {
+    check(logger, [&](const mc_rtc::log::FlatLog & log) {
+      BOOST_REQUIRE(log.size() == iter);
+      data.check(log);
+      data.refresh();
+    });
+  }
+  /** Iteration 401, remove the data once more */
+  logger.removeLogEntries(&data);
+  check(logger, [&](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.size() == iter);
+    data.check_empty(log);
+    iter++;
   });
 }

--- a/tests/testLogger.cpp
+++ b/tests/testLogger.cpp
@@ -103,22 +103,6 @@ public:
 
   void addToLoggerWithMemberPointer(mc_rtc::Logger & logger)
   {
-    logger.addLogEntry("bool", this, &LogData::b);
-    logger.addLogEntry("double", this, &LogData::d);
-    logger.addLogEntry("std::string", this, &LogData::s);
-    logger.addLogEntry("Eigen::Vector2d", this, &LogData::v2d);
-    logger.addLogEntry("Eigen::Vector3d", this, &LogData::v3d);
-    logger.addLogEntry("Eigen::Vector6d", this, &LogData::v6d);
-    logger.addLogEntry("Eigen::VectorXd", this, &LogData::vxd);
-    logger.addLogEntry("Eigen::Quaterniond", this, &LogData::q);
-    logger.addLogEntry("sva::PTransformd", this, &LogData::pt);
-    logger.addLogEntry("sva::ForceVecd", this, &LogData::fv);
-    logger.addLogEntry("sva::MotionVecd", this, &LogData::mv);
-    logger.addLogEntry("std::vector<double>", this, &LogData::v);
-  }
-
-  void addToLoggerWithMemberPointerFast(mc_rtc::Logger & logger)
-  {
     logger.addLogEntry<decltype(&LogData::b), &LogData::b>("bool", this);
     logger.addLogEntry<decltype(&LogData::d), &LogData::d>("double", this);
     logger.addLogEntry<decltype(&LogData::s), &LogData::s>("std::string", this);
@@ -150,22 +134,6 @@ public:
   }
 
   void addToLoggerWithGetter(mc_rtc::Logger & logger)
-  {
-    logger.addLogEntry("bool", this, &LogData::get_b);
-    logger.addLogEntry("double", this, &LogData::get_d);
-    logger.addLogEntry("std::string", this, &LogData::get_s);
-    logger.addLogEntry("Eigen::Vector2d", this, &LogData::get_v2d);
-    logger.addLogEntry("Eigen::Vector3d", this, &LogData::get_v3d);
-    logger.addLogEntry("Eigen::Vector6d", this, &LogData::get_v6d);
-    logger.addLogEntry("Eigen::VectorXd", this, &LogData::get_vxd);
-    logger.addLogEntry("Eigen::Quaterniond", this, &LogData::get_q);
-    logger.addLogEntry("sva::PTransformd", this, &LogData::get_pt);
-    logger.addLogEntry("sva::ForceVecd", this, &LogData::get_fv);
-    logger.addLogEntry("sva::MotionVecd", this, &LogData::get_mv);
-    logger.addLogEntry("std::vector<double>", this, &LogData::get_v);
-  }
-
-  void addToLoggerWithGetterFast(mc_rtc::Logger & logger)
   {
     logger.addLogEntry<decltype(&LogData::get_b), &LogData::get_b>("bool", this);
     logger.addLogEntry<decltype(&LogData::get_d), &LogData::get_d>("double", this);
@@ -370,7 +338,7 @@ BOOST_AUTO_TEST_CASE(TestLogger)
     iter++;
   });
   /** Iteration 202 to 250, add from fast pointer to member, refresh data and check everything is ok */
-  data.addToLoggerWithMemberPointerFast(logger);
+  data.addToLoggerWithMemberPointerMacro(logger);
   for(iter = 202; iter <= 250; ++iter)
   {
     check(logger, [&](const mc_rtc::log::FlatLog & log) {
@@ -387,8 +355,8 @@ BOOST_AUTO_TEST_CASE(TestLogger)
     iter++;
   });
   /** Iteration 252 to 300, add from fast pointer to method, refresh data and check everything is ok */
-  data.addToLoggerWithGetterFast(logger);
-  for(iter = 252; iter <= 300; ++iter)
+  data.addToLoggerWithGetterMacro(logger);
+  for(iter = 252; iter <= 200; ++iter)
   {
     check(logger, [&](const mc_rtc::log::FlatLog & log) {
       BOOST_REQUIRE(log.size() == iter);
@@ -397,40 +365,6 @@ BOOST_AUTO_TEST_CASE(TestLogger)
     });
   }
   /** Iteration 301, remove the data once more */
-  logger.removeLogEntries(&data);
-  check(logger, [&](const mc_rtc::log::FlatLog & log) {
-    BOOST_REQUIRE(log.size() == iter);
-    data.check_empty(log);
-    iter++;
-  });
-  /** Iteration 302 to 350, add from fast pointer to member, refresh data and check everything is ok */
-  data.addToLoggerWithMemberPointerMacro(logger);
-  for(iter = 302; iter <= 350; ++iter)
-  {
-    check(logger, [&](const mc_rtc::log::FlatLog & log) {
-      BOOST_REQUIRE(log.size() == iter);
-      data.check(log);
-      data.refresh();
-    });
-  }
-  /** Iteration 351, remove the data once more */
-  logger.removeLogEntries(&data);
-  check(logger, [&](const mc_rtc::log::FlatLog & log) {
-    BOOST_REQUIRE(log.size() == iter);
-    data.check_empty(log);
-    iter++;
-  });
-  /** Iteration 352 to 400, add from fast pointer to method, refresh data and check everything is ok */
-  data.addToLoggerWithGetterMacro(logger);
-  for(iter = 352; iter <= 400; ++iter)
-  {
-    check(logger, [&](const mc_rtc::log::FlatLog & log) {
-      BOOST_REQUIRE(log.size() == iter);
-      data.check(log);
-      data.refresh();
-    });
-  }
-  /** Iteration 401, remove the data once more */
   logger.removeLogEntries(&data);
   check(logger, [&](const mc_rtc::log::FlatLog & log) {
     BOOST_REQUIRE(log.size() == iter);

--- a/tests/testLogger.cpp
+++ b/tests/testLogger.cpp
@@ -119,18 +119,18 @@ public:
 
   void addToLoggerWithMemberPointerMacro(mc_rtc::Logger & logger)
   {
-    MC_RTC_LOG_HELPER(logger, "bool", this, &LogData::b);
-    MC_RTC_LOG_HELPER(logger, "double", this, &LogData::d);
-    MC_RTC_LOG_HELPER(logger, "std::string", this, &LogData::s);
-    MC_RTC_LOG_HELPER(logger, "Eigen::Vector2d", this, &LogData::v2d);
-    MC_RTC_LOG_HELPER(logger, "Eigen::Vector3d", this, &LogData::v3d);
-    MC_RTC_LOG_HELPER(logger, "Eigen::Vector6d", this, &LogData::v6d);
-    MC_RTC_LOG_HELPER(logger, "Eigen::VectorXd", this, &LogData::vxd);
-    MC_RTC_LOG_HELPER(logger, "Eigen::Quaterniond", this, &LogData::q);
-    MC_RTC_LOG_HELPER(logger, "sva::PTransformd", this, &LogData::pt);
-    MC_RTC_LOG_HELPER(logger, "sva::ForceVecd", this, &LogData::fv);
-    MC_RTC_LOG_HELPER(logger, "sva::MotionVecd", this, &LogData::mv);
-    MC_RTC_LOG_HELPER(logger, "std::vector<double>", this, &LogData::v);
+    MC_RTC_LOG_HELPER("bool", b);
+    MC_RTC_LOG_HELPER("double", d);
+    MC_RTC_LOG_HELPER("std::string", s);
+    MC_RTC_LOG_HELPER("Eigen::Vector2d", v2d);
+    MC_RTC_LOG_HELPER("Eigen::Vector3d", v3d);
+    MC_RTC_LOG_HELPER("Eigen::Vector6d", v6d);
+    MC_RTC_LOG_HELPER("Eigen::VectorXd", vxd);
+    MC_RTC_LOG_HELPER("Eigen::Quaterniond", q);
+    MC_RTC_LOG_HELPER("sva::PTransformd", pt);
+    MC_RTC_LOG_HELPER("sva::ForceVecd", fv);
+    MC_RTC_LOG_HELPER("sva::MotionVecd", mv);
+    MC_RTC_LOG_HELPER("std::vector<double>", v);
   }
 
   void addToLoggerWithGetter(mc_rtc::Logger & logger)
@@ -151,18 +151,18 @@ public:
 
   void addToLoggerWithGetterMacro(mc_rtc::Logger & logger)
   {
-    MC_RTC_LOG_HELPER(logger, "bool", this, &LogData::get_b);
-    MC_RTC_LOG_HELPER(logger, "double", this, &LogData::get_d);
-    MC_RTC_LOG_HELPER(logger, "std::string", this, &LogData::get_s);
-    MC_RTC_LOG_HELPER(logger, "Eigen::Vector2d", this, &LogData::get_v2d);
-    MC_RTC_LOG_HELPER(logger, "Eigen::Vector3d", this, &LogData::get_v3d);
-    MC_RTC_LOG_HELPER(logger, "Eigen::Vector6d", this, &LogData::get_v6d);
-    MC_RTC_LOG_HELPER(logger, "Eigen::VectorXd", this, &LogData::get_vxd);
-    MC_RTC_LOG_HELPER(logger, "Eigen::Quaterniond", this, &LogData::get_q);
-    MC_RTC_LOG_HELPER(logger, "sva::PTransformd", this, &LogData::get_pt);
-    MC_RTC_LOG_HELPER(logger, "sva::ForceVecd", this, &LogData::get_fv);
-    MC_RTC_LOG_HELPER(logger, "sva::MotionVecd", this, &LogData::get_mv);
-    MC_RTC_LOG_HELPER(logger, "std::vector<double>", this, &LogData::get_v);
+    MC_RTC_LOG_HELPER("bool", get_b);
+    MC_RTC_LOG_HELPER("double", get_d);
+    MC_RTC_LOG_HELPER("std::string", get_s);
+    MC_RTC_LOG_HELPER("Eigen::Vector2d", get_v2d);
+    MC_RTC_LOG_HELPER("Eigen::Vector3d", get_v3d);
+    MC_RTC_LOG_HELPER("Eigen::Vector6d", get_v6d);
+    MC_RTC_LOG_HELPER("Eigen::VectorXd", get_vxd);
+    MC_RTC_LOG_HELPER("Eigen::Quaterniond", get_q);
+    MC_RTC_LOG_HELPER("sva::PTransformd", get_pt);
+    MC_RTC_LOG_HELPER("sva::ForceVecd", get_fv);
+    MC_RTC_LOG_HELPER("sva::MotionVecd", get_mv);
+    MC_RTC_LOG_HELPER("std::vector<double>", get_v);
   }
 
   void removeFromLogger(mc_rtc::Logger & logger)

--- a/tests/testLogger.cpp
+++ b/tests/testLogger.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2015-2021 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#include <mc_rtc/log/FlatLog.h>
+#include <mc_rtc/log/Logger.h>
+
+#include <boost/filesystem.hpp>
+namespace bfs = boost::filesystem;
+#include <boost/test/unit_test.hpp>
+
+/** Check one iteration of the logger */
+template<typename Callback>
+void check(mc_rtc::Logger & logger, Callback && cb)
+{
+  logger.log();
+  logger.flush();
+  mc_rtc::log::FlatLog log(logger.path());
+  cb(log);
+}
+
+BOOST_AUTO_TEST_CASE(TestLogger)
+{
+  using Policy = mc_rtc::Logger::Policy;
+  mc_rtc::Logger logger(Policy::NON_THREADED, bfs::temp_directory_path().string(), "mc-rtc-test");
+  logger.start("logger", 1.0);
+  /** Iteration 1 only time */
+  check(logger, [](const mc_rtc::log::FlatLog & log) {
+    BOOST_REQUIRE(log.entries() == std::set<std::string>{"t"});
+    BOOST_REQUIRE(log.size() == 1);
+    auto t0 = log.getRaw<double>("t", 0);
+    BOOST_REQUIRE(t0 && *t0 == 0.0);
+  });
+}

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -132,7 +132,7 @@ bool random_bool()
 {
   static std::random_device rd;
   static std::mt19937_64 gen(rd());
-  static std::uniform_int_distribution<uint8_t> dis(0, 1);
+  static std::uniform_int_distribution<> dis(0, 1);
   return dis(gen);
 }
 

--- a/tests/utils.h
+++ b/tests/utils.h
@@ -88,12 +88,28 @@ std::string makeConfigFile(const std::string & data, const std::string & ext = "
   return fIn;
 }
 
+Eigen::Quaterniond random_quat()
+{
+  Eigen::Quaterniond q{Eigen::Vector4d::Random()};
+  q.normalize();
+  return q;
+}
+
 sva::PTransformd random_pt()
 {
   Eigen::Vector3d t = Eigen::Vector3d::Random();
-  Eigen::Quaterniond q{Eigen::Vector4d::Random()};
-  q.normalize();
+  Eigen::Quaterniond q = random_quat();
   return {q, t};
+}
+
+sva::ForceVecd random_fv()
+{
+  return {Eigen::Vector3d::Random(), Eigen::Vector3d::Random()};
+}
+
+sva::MotionVecd random_mv()
+{
+  return {Eigen::Vector3d::Random(), Eigen::Vector3d::Random()};
 }
 
 double rnd()
@@ -108,6 +124,44 @@ size_t random_size()
 {
   static std::random_device rd;
   static std::mt19937_64 gen(rd());
-  static std::uniform_int_distribution<size_t> dis(10, 100);
+  static std::uniform_int_distribution<size_t> dis(10, 1024);
   return dis(gen);
+}
+
+bool random_bool()
+{
+  static std::random_device rd;
+  static std::mt19937_64 gen(rd());
+  static std::uniform_int_distribution<uint8_t> dis(0, 1);
+  return dis(gen);
+}
+
+std::vector<double> random_vector()
+{
+  std::vector<double> v(random_size());
+  for(size_t i = 0; i < v.size(); ++i)
+  {
+    v[i] = rnd();
+  }
+  return v;
+}
+
+char random_char()
+{
+  static const std::array<char, 70> chars = {'0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'A', 'B', 'C', 'D',
+                                             'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R',
+                                             'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+                                             'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n', 'o', 'p', 'q', 'r', 's', 't',
+                                             'u', 'v', 'w', 'x', 'y', 'z', '.', ':', '<', '>', ';', '-', '_', ' '};
+  static std::random_device rd;
+  static std::mt19937_64 gen(rd());
+  static std::uniform_int_distribution<size_t> dis(0, chars.size() - 1);
+  return chars[dis(gen)];
+}
+
+std::string random_string()
+{
+  std::string s(random_size(), 'a');
+  std::generate_n(s.begin(), s.size(), random_char);
+  return s;
 }


### PR DESCRIPTION
This PR adds a source (pointer to the element that registered a log entry) for every log entry in the logger. The goal is to hugely simplify book-keeping when adding log entries


This is done by adding a source parameter in `addLogEntry`, i.e.

```cpp
// Usual way, no source registered, can only be removed by removeLogEntry
logger.addLogEntry("bla", []() { return bla; });
// New way with a source
logger.addLogEntry("bla", source, []() { return bla; });
```

This allows removing a bulk of log entries at once as such:
```cpp
logger.removeLogEntries(source);
```

Furthermore, I have added an helper to register member or method logging, such as:
```cpp
// Assuming MyClass::vector_ is e.g. an Eigen::Vector3d member
logger.addLogEntry<decltype(&MyClass::vector_), &MyClass::vector>("my_vector", this);
// Also work with a method MyClass::computeStuff()
logger.addLogEntry<decltype(&MyClass::computeStuff), &MyClass::computeStuff>("my_stuff", this);
```

For methods there is two extra caveats:
- only `const` method are accepted (arbitrarily, there is no technical limitation)
- overloaded methods (e.g. getter/setter with the same name) cannot be used so one has to fall back to either writing a "classic" `addLogEntry` or spell-out the method pointer type

This is strictly equivalent to:
```cpp
logger.addLogEntry("my_vector", this, [this]() -> const Eigen::Vector3d & { return vector_; });
logger.addLogEntry("my_stuff", this, [this]() { return computeStuff(); });
```

But you don't have to remember to return a reference (the same is true for the method version).

The syntax is not super nice, so there is a macro to help writing such entries:

```cpp
// logger is the logger instance in this context, can be ctl.logger() in a FSM state for example
MC_RTC_LOG_HELPER(logger, "member", this, &MyClass::member);
// Same as
logger.addLogEntry<decltype(&MyClass::member), &MyClass::member>("member", this);
```

With C++17, it will be possible to simply write
```cpp
logger.addLogEntry<&MyClass::member>("member", this);
```

Also done/to be done:
- [x] Use simplified remove in tasks, observers and states
- [x] Removed redundant `virtual ... override` in mc_tasks (since I was touching pretty much all tasks header)
- [x] Added an extensive test of the logger
- [x] Fix minor bug in `EncoderObserver`
- [x] Update the documentation accordingly