### PR TITLE
[bugfix][KinematicInertialObserver] Fix orientation transform between IMU and base link

### DIFF
--- a/src/mc_observers/KinematicInertialPoseObserver.cpp
+++ b/src/mc_observers/KinematicInertialPoseObserver.cpp
@@ -109,7 +109,7 @@ void KinematicInertialPoseObserver::estimateOrientation(const mc_rbdyn::Robot & 
   const Eigen::Matrix3d & E_0_cIMU = X_0_cIMU.rotation();
   // Estimate IMU orientation: merges roll+pitch from measurement with yaw from control
   Eigen::Matrix3d E_0_eIMU = mergeRoll1Pitch1WithYaw2(E_0_mIMU, E_0_cIMU);
-  pose_.rotation() = E_0_eIMU.transpose() * X_rIMU_rBase.rotation();
+  pose_.rotation() = X_rIMU_rBase.rotation() * E_0_eIMU.transpose();
 }
 
 void KinematicInertialPoseObserver::estimatePosition(const mc_control::MCController & ctl)


### PR DESCRIPTION
When the IMU is not directly attached to the base link, the transformation between the IMU orientation and the base link orientation needs to be considered. The former code was applying this transformation
the wrong way around. In most cases this wasn't noticable, as the IMU frame is typically aligned with the base link frame. However, on HRP2,the IMU is located in the chest, whose orientation is arbitrary.

I only tested in simulation so far, but this seems to fix the issue #120.

Below is the curve corresponding to moving forward, turning 90deg in place, then moving forward again. The walk was done with the torso pitched `0.3rad` to further emphasize the problem. Without this patch the robot falls immediately while rotating, while with the patch I didn't notice any difference of behaviour between the first forward motion (pre-rotation) and second one (post rotation).

![estimator_bug_com](https://user-images.githubusercontent.com/67139/106436298-47b88580-64b7-11eb-9877-21f0e69c8242.png)

Here is the details for pre-rotation forward walk:
![estimator_bug_forward](https://user-images.githubusercontent.com/67139/106436545-9108d500-64b7-11eb-8832-a8be998d495f.png)

And here is the details for the post-rotation forward walk:
![estimator_bug_forward_90deg](https://user-images.githubusercontent.com/67139/106436588-9ebe5a80-64b7-11eb-92c5-291fb45401eb.png)

I will merge once this has been confirmed to work on the real robot by @mmurooka and @Dwaaap.
Fixes #120 