### PR TITLE
[stabilizer] Consistently load the configuration

### DIFF
--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -305,9 +305,16 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
 
   void load(const mc_rtc::Configuration & config)
   {
-    config("safety_tresholds", safetyThresholds);
+    if(config.has("safety_tresholds"))
+    {
+      safetyThresholds.load(config("safety_tresholds"));
+    }
 
-    config("fdqp_weights", fdqpWeights);
+    if(config.has("fdqp_weights"))
+    {
+      fdqpWeights.load(config("fdqp_weights"));
+    }
+
     config("leftFootSurface", leftFootSurface);
     config("rightFootSurface", rightFootSurface);
     config("torsoBodyName", torsoBodyName);
@@ -334,7 +341,10 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       dcmTracking("derivator_time_constant", dcmDerivatorTimeConstant);
       dcmTracking("integrator_time_constant", dcmIntegratorTimeConstant);
     }
-    config("dcm_bias", dcmBias);
+    if(config.has("dcm_bias"))
+    {
+      dcmBias.load(config("dcm_bias"));
+    }
     if(config.has("tasks"))
     {
       auto tasks = config("tasks");
@@ -399,6 +409,10 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       vdc("stiffness", vdcStiffness);
     }
 
+    if(config.has("zmpcc"))
+    {
+      zmpcc.load(config("zmpcc"));
+    }
     config("zmpcc", zmpcc);
   }
 

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -18,6 +18,7 @@ namespace lipm_stabilizer
 struct MC_RBDYN_DLLAPI FDQPWeights
 {
   FDQPWeights() : ankleTorqueSqrt(std::sqrt(100)), netWrenchSqrt(std::sqrt(10000)), pressureSqrt(std::sqrt(1)) {}
+  /* All weights must be strictly positive */
   FDQPWeights(double netWrench, double ankleTorque, double pressure)
   : ankleTorqueSqrt(std::sqrt(ankleTorque)), netWrenchSqrt(std::sqrt(netWrench)), pressureSqrt(std::sqrt(pressure))
   {
@@ -25,6 +26,31 @@ struct MC_RBDYN_DLLAPI FDQPWeights
   double ankleTorqueSqrt;
   double netWrenchSqrt;
   double pressureSqrt;
+
+  void load(const mc_rtc::Configuration & config)
+  {
+    if(config.has("ankle_torque"))
+    {
+      ankleTorqueSqrt = std::sqrt(static_cast<double>(config("ankle_torque")));
+    }
+    if(config.has("net_wrench"))
+    {
+      netWrenchSqrt = std::sqrt(static_cast<double>(config.has("net_wrench")));
+    }
+    if(config.has("pressure"))
+    {
+      pressureSqrt = std::sqrt(static_cast<double>(config("pressure")));
+    }
+  }
+
+  mc_rtc::Configuration save() const
+  {
+    mc_rtc::Configuration config;
+    config.add("ankle_torque", std::pow(ankleTorqueSqrt, 2));
+    config.add("net_wrench", std::pow(netWrenchSqrt, 2));
+    config.add("pressure", std::pow(pressureSqrt, 2));
+    return config;
+  }
 };
 
 /**
@@ -52,6 +78,40 @@ struct SafetyThresholds
                                                     targets when close to contact switches. */
   /**< Minimum force for valid ZMP computation (throws otherwise) */
   double MIN_NET_TOTAL_FORCE_ZMP = 1.;
+
+  void load(const mc_rtc::Configuration & config)
+  {
+    config("MAX_AVERAGE_DCM_ERROR", MAX_AVERAGE_DCM_ERROR);
+    config("MAX_COP_ADMITTANCE", MAX_COP_ADMITTANCE);
+    config("MAX_DCM_D_GAIN", MAX_DCM_D_GAIN);
+    config("MAX_DCM_I_GAIN", MAX_DCM_I_GAIN);
+    config("MAX_DCM_P_GAIN", MAX_DCM_P_GAIN);
+    config("MAX_DFZ_ADMITTANCE", MAX_DFZ_ADMITTANCE);
+    config("MAX_DFZ_DAMPING", MAX_DFZ_DAMPING);
+    config("MAX_FDC_RX_VEL", MAX_FDC_RX_VEL);
+    config("MAX_FDC_RY_VEL", MAX_FDC_RY_VEL);
+    config("MAX_FDC_RZ_VEL", MAX_FDC_RZ_VEL);
+    config("MIN_DS_PRESSURE", MIN_DS_PRESSURE);
+    config("MIN_NET_TOTAL_FORCE_ZMP", MIN_NET_TOTAL_FORCE_ZMP);
+  }
+
+  mc_rtc::Configuration save() const
+  {
+    mc_rtc::Configuration config;
+    config.add("MAX_AVERAGE_DCM_ERROR", MAX_AVERAGE_DCM_ERROR);
+    config.add("MAX_COP_ADMITTANCE", MAX_COP_ADMITTANCE);
+    config.add("MAX_DCM_D_GAIN", MAX_DCM_D_GAIN);
+    config.add("MAX_DCM_I_GAIN", MAX_DCM_I_GAIN);
+    config.add("MAX_DCM_P_GAIN", MAX_DCM_P_GAIN);
+    config.add("MAX_DFZ_ADMITTANCE", MAX_DFZ_ADMITTANCE);
+    config.add("MAX_DFZ_DAMPING", MAX_DFZ_DAMPING);
+    config.add("MAX_FDC_RX_VEL", MAX_FDC_RX_VEL);
+    config.add("MAX_FDC_RY_VEL", MAX_FDC_RY_VEL);
+    config.add("MAX_FDC_RZ_VEL", MAX_FDC_RZ_VEL);
+    config.add("MIN_DS_PRESSURE", MIN_DS_PRESSURE);
+    config.add("MIN_NET_TOTAL_FORCE_ZMP", MIN_NET_TOTAL_FORCE_ZMP);
+    return config;
+  }
 };
 
 /** Parameters for the DCM bias estimator */
@@ -70,6 +130,28 @@ struct DCMBiasEstimatorConfiguration
   bool withDCMBias = false;
   /// Whether the DCM filter is enabled
   bool withDCMFilter = false;
+
+  void load(const mc_rtc::Configuration & config)
+  {
+    config("dcmMeasureErrorStd", dcmMeasureErrorStd);
+    config("zmpMeasureErrorStd", zmpMeasureErrorStd);
+    config("biasDriftPerSecondStd", biasDriftPerSecondStd);
+    config("biasLimit", biasLimit);
+    config("withDCMBias", withDCMBias);
+    config("withDCMFilter", withDCMFilter);
+  }
+
+  mc_rtc::Configuration save() const
+  {
+    mc_rtc::Configuration config;
+    config.add("dcmMeasureErrorStd", dcmMeasureErrorStd);
+    config.add("zmpMeasureErrorStd", zmpMeasureErrorStd);
+    config.add("biasDriftPerSecondStd", biasDriftPerSecondStd);
+    config.add("biasLimit", biasLimit);
+    config.add("withDCMBias", withDCMBias);
+    config.add("withDCMFilter", withDCMFilter);
+    return config;
+  }
 };
 
 } // namespace lipm_stabilizer
@@ -86,22 +168,13 @@ struct ConfigurationLoader<mc_rbdyn::lipm_stabilizer::FDQPWeights>
   static mc_rbdyn::lipm_stabilizer::FDQPWeights load(const mc_rtc::Configuration & config)
   {
     mc_rbdyn::lipm_stabilizer::FDQPWeights weights;
-    double ankleTorqueWeight = config("ankle_torque");
-    double netWrenchWeight = config("net_wrench");
-    double pressureWeight = config("pressure");
-    weights.ankleTorqueSqrt = std::sqrt(ankleTorqueWeight);
-    weights.netWrenchSqrt = std::sqrt(netWrenchWeight);
-    weights.pressureSqrt = std::sqrt(pressureWeight);
+    weights.load(config);
     return weights;
   }
 
   static mc_rtc::Configuration save(const mc_rbdyn::lipm_stabilizer::FDQPWeights & weights)
   {
-    mc_rtc::Configuration config;
-    config.add("ankle_torque", std::pow(weights.ankleTorqueSqrt, 2));
-    config.add("net_wrench", std::pow(weights.netWrenchSqrt, 2));
-    config.add("pressure", std::pow(weights.pressureSqrt, 2));
-    return config;
+    return weights.save();
   }
 };
 
@@ -114,37 +187,13 @@ struct ConfigurationLoader<mc_rbdyn::lipm_stabilizer::SafetyThresholds>
   static mc_rbdyn::lipm_stabilizer::SafetyThresholds load(const mc_rtc::Configuration & config)
   {
     mc_rbdyn::lipm_stabilizer::SafetyThresholds safety;
-    config("MAX_AVERAGE_DCM_ERROR", safety.MAX_AVERAGE_DCM_ERROR);
-    config("MAX_COP_ADMITTANCE", safety.MAX_COP_ADMITTANCE);
-    config("MAX_DCM_D_GAIN", safety.MAX_DCM_D_GAIN);
-    config("MAX_DCM_I_GAIN", safety.MAX_DCM_I_GAIN);
-    config("MAX_DCM_P_GAIN", safety.MAX_DCM_P_GAIN);
-    config("MAX_DFZ_ADMITTANCE", safety.MAX_DFZ_ADMITTANCE);
-    config("MAX_DFZ_DAMPING", safety.MAX_DFZ_DAMPING);
-    config("MAX_FDC_RX_VEL", safety.MAX_FDC_RX_VEL);
-    config("MAX_FDC_RY_VEL", safety.MAX_FDC_RY_VEL);
-    config("MAX_FDC_RZ_VEL", safety.MAX_FDC_RZ_VEL);
-    config("MIN_DS_PRESSURE", safety.MIN_DS_PRESSURE);
-    config("MIN_NET_TOTAL_FORCE_ZMP", safety.MIN_NET_TOTAL_FORCE_ZMP);
+    safety.load(config);
     return safety;
   }
 
   static mc_rtc::Configuration save(const mc_rbdyn::lipm_stabilizer::SafetyThresholds & safety)
   {
-    mc_rtc::Configuration config;
-    config.add("MAX_AVERAGE_DCM_ERROR", safety.MAX_AVERAGE_DCM_ERROR);
-    config.add("MAX_COP_ADMITTANCE", safety.MAX_COP_ADMITTANCE);
-    config.add("MAX_DCM_D_GAIN", safety.MAX_DCM_D_GAIN);
-    config.add("MAX_DCM_I_GAIN", safety.MAX_DCM_I_GAIN);
-    config.add("MAX_DCM_P_GAIN", safety.MAX_DCM_P_GAIN);
-    config.add("MAX_DFZ_ADMITTANCE", safety.MAX_DFZ_ADMITTANCE);
-    config.add("MAX_DFZ_DAMPING", safety.MAX_DFZ_DAMPING);
-    config.add("MAX_FDC_RX_VEL", safety.MAX_FDC_RX_VEL);
-    config.add("MAX_FDC_RY_VEL", safety.MAX_FDC_RY_VEL);
-    config.add("MAX_FDC_RZ_VEL", safety.MAX_FDC_RZ_VEL);
-    config.add("MIN_DS_PRESSURE", safety.MIN_DS_PRESSURE);
-    config.add("MIN_NET_TOTAL_FORCE_ZMP", safety.MIN_NET_TOTAL_FORCE_ZMP);
-    return config;
+    return safety.save();
   }
 };
 
@@ -157,25 +206,13 @@ struct ConfigurationLoader<mc_rbdyn::lipm_stabilizer::DCMBiasEstimatorConfigurat
   static mc_rbdyn::lipm_stabilizer::DCMBiasEstimatorConfiguration load(const mc_rtc::Configuration & config)
   {
     mc_rbdyn::lipm_stabilizer::DCMBiasEstimatorConfiguration bias;
-    config("dcmMeasureErrorStd", bias.dcmMeasureErrorStd);
-    config("zmpMeasureErrorStd", bias.zmpMeasureErrorStd);
-    config("biasDriftPerSecondStd", bias.biasDriftPerSecondStd);
-    config("biasLimit", bias.biasLimit);
-    config("withDCMBias", bias.withDCMBias);
-    config("withDCMFilter", bias.withDCMFilter);
+    bias.load(config);
     return bias;
   }
 
   static mc_rtc::Configuration save(const mc_rbdyn::lipm_stabilizer::DCMBiasEstimatorConfiguration & bias)
   {
-    mc_rtc::Configuration config;
-    config.add("dcmMeasureErrorStd", bias.dcmMeasureErrorStd);
-    config.add("zmpMeasureErrorStd", bias.zmpMeasureErrorStd);
-    config.add("biasDriftPerSecondStd", bias.biasDriftPerSecondStd);
-    config.add("biasLimit", bias.biasLimit);
-    config.add("withDCMBias", bias.withDCMBias);
-    config.add("withDCMFilter", bias.withDCMFilter);
-    return config;
+    return bias.save();
   }
 };
 } // namespace mc_rtc
@@ -241,6 +278,13 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   double vdcStiffness = 1000.; /**< Stiffness used in single-support vertical drift compensation */
 
   DCMBiasEstimatorConfiguration dcmBias; /**< Parameters for the DCM bias estimation */
+
+  StabilizerConfiguration() {}
+
+  StabilizerConfiguration(const mc_rtc::Configuration & conf)
+  {
+    load(conf);
+  }
 
   /**
    * @brief Checks that the chosen parameters are within the parameters defined
@@ -320,13 +364,29 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       {
         if(tasks("contact").has("damping"))
         {
-          double d = tasks("contact")("damping");
-          contactDamping = sva::MotionVecd({d, d, d}, {d, d, d});
+          try
+          {
+            double d = tasks("contact")("damping");
+            contactDamping = sva::MotionVecd({d, d, d}, {d, d, d});
+          }
+          catch(mc_rtc::Configuration::Exception & e)
+          {
+            e.silence();
+            contactDamping = tasks("contact")("damping");
+          }
         }
         if(tasks("contact").has("stiffness"))
         {
-          double k = tasks("contact")("stiffness");
-          contactStiffness = sva::MotionVecd({k, k, k}, {k, k, k});
+          try
+          {
+            double k = tasks("contact")("stiffness");
+            contactStiffness = sva::MotionVecd({k, k, k}, {k, k, k});
+          }
+          catch(mc_rtc::Configuration::Exception & e)
+          {
+            e.silence();
+            contactStiffness = tasks("contact")("stiffness");
+          }
         }
         tasks("contact")("stiffness", contactStiffness);
         tasks("contact")("weight", contactWeight);

--- a/include/mc_rbdyn/lipm_stabilizer/ZMPCCConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/ZMPCCConfiguration.h
@@ -18,6 +18,21 @@ struct MC_RBDYN_DLLAPI ZMPCCConfiguration
   double integratorLeakRate = 0.1; /**< Leak rate */
   double maxCoMOffset = 0.05; /**< Maximum CoM offset due to admittance control in [m] */
   double maxCoMAdmitance = 20; /**< Maximum admittance for CoM admittance control */
+
+  void load(const mc_rtc::Configuration & config)
+  {
+    config("comAdmittance", comAdmittance);
+    config("maxCoMOffset", maxCoMOffset);
+    config("integratorLeakRate", integratorLeakRate);
+  }
+  mc_rtc::Configuration save() const
+  {
+    mc_rtc::Configuration config;
+    config.add("comAdmittance", comAdmittance);
+    config.add("maxCoMOffset", maxCoMOffset);
+    config.add("integratorLeakRate", integratorLeakRate);
+    return config;
+  }
 };
 } // namespace lipm_stabilizer
 } // namespace mc_rbdyn
@@ -33,22 +48,13 @@ struct ConfigurationLoader<mc_rbdyn::lipm_stabilizer::ZMPCCConfiguration>
   static mc_rbdyn::lipm_stabilizer::ZMPCCConfiguration load(const mc_rtc::Configuration & config)
   {
     mc_rbdyn::lipm_stabilizer::ZMPCCConfiguration zmpcc;
-    if(config.has("zmpcc"))
-    {
-      config("zmpcc")("comAdmittance", zmpcc.comAdmittance);
-      config("zmpcc")("maxCoMOffset", zmpcc.maxCoMOffset);
-      config("zmpcc")("integratorLeakRate", zmpcc.integratorLeakRate);
-    }
+    zmpcc.load(config);
     return zmpcc;
   }
 
   static mc_rtc::Configuration save(const mc_rbdyn::lipm_stabilizer::ZMPCCConfiguration & zmpcc)
   {
-    mc_rtc::Configuration config;
-    config.add("comAdmittance", zmpcc.comAdmittance);
-    config.add("maxCoMOffset", zmpcc.maxCoMOffset);
-    config.add("integratorLeakRate", zmpcc.integratorLeakRate);
-    return config;
+    return zmpcc.save();
   }
 };
 } // namespace mc_rtc


### PR DESCRIPTION
The intent of this PR is to allow to consistently incrementally change the `StabilizerConfiguration` parameters when calling `StabilizerConfiguration::load(mc_rtc::Configuration)` multiple times.

```cpp
auto conf = stabilizer->config();
// Default value for conf.dcmBias.dcmMeasureErrorStd = 0.01
conf.dcmBias.dcmMeasureErrorStd = 5;
mc_rtc::Configuration newConf;
newConf.add("dcm_bias");
newConf("dcm_bias").add("biasDriftPerSecondStd", 0.0001);
conf.load(newConf);
stabilizer->configure(conf);
// Now conf.dcmBias.dcmMeasureErrorStd = 0.01, aka the default value instead of the value '5' we've set previous
// conf.dcmBias.dcmMeasureErrorStd = 0.0001 as expected
```

That is nested types (`DCMBiasEstimatorConfiguration`, `ZMPCCConfiguration`, etc) are first reset to their default configuration and only the elements defined in the configuration when calling `StabilizerConfiguration::load(..)` are updated.


```json
    "dcm_bias": {               
        "dcmMeasureErrorStd": 5,
        "zmpMeasureErrorStd": 0.05,  
        "biasDriftPerSecondStd": 5.0,
        "biasLimit": [        
            0.02,             
            0.02              
        ],                      
        "withDCMBias": false,         
        "withDCMFilter": false
    },               

    "dcm_bias": {
        "dcmMeasureErrorStd": 0.01, // unexpected should be 5
        "zmpMeasureErrorStd": 0.05,
        "biasDriftPerSecondStd": 0.0001, // as expected
        "biasLimit": [
            0.02,
            0.02
        ],
        "withDCMBias": false,
        "withDCMFilter": false
    },
```

This PR makes the loading behavior consistent: only the elements specified in the `mc_rtc::Configuration` are modified.

I'll merge when pipeline succeeds.