### PR TITLE
[observers] Add options to make observers optional/allowed to fail

### DIFF
--- a/doc/_data/schemas/Observers/ObserverPipeline.json
+++ b/doc/_data/schemas/Observers/ObserverPipeline.json
@@ -24,6 +24,8 @@
           "update": {"type": "boolean", "default": true, "description": "When true, update the state of real robots instances (requires the observer's run to have succeeded)"},
           "log": {"type": "boolean", "default": true, "description": "When true, log estimated values"},
           "gui": {"type": "boolean", "default": true, "description": "When true, show observer in the gui"},
+          "required": {"type": "boolean", "default": true, "description": "When false, ignore this observer if it could not be loaded"},
+          "successRequired": {"type": "boolean", "default": true, "description": "When true, the whole pipeline is considered to have failed if this observer's run() returns false"},
           "config":
           {
             "type": "object",

--- a/include/mc_observers/ObserverPipeline.h
+++ b/include/mc_observers/ObserverPipeline.h
@@ -47,6 +47,7 @@ struct MC_OBSERVERS_DLLAPI ObserverPipeline
       config("update", update_);
       config("log", log_);
       config("gui", gui_);
+      config("successRequired", successRequired_);
     }
 
     /* Const accessor to an observer generic interface
@@ -92,25 +93,33 @@ struct MC_OBSERVERS_DLLAPI ObserverPipeline
       return const_cast<T &>(static_cast<const PipelineObserver *>(this)->observer<T>());
     }
 
-    bool update() const
+    bool update() const noexcept
     {
       return update_;
     }
 
-    bool log() const
+    bool log() const noexcept
     {
       return log_;
     }
 
-    bool gui() const
+    bool gui() const noexcept
     {
       return gui_;
     }
 
     /** Returns whether the last call to this observer succeeded */
-    bool success() const
+    bool success() const noexcept
     {
       return success_;
+    }
+
+    /** Returns whether this observer must succeed or is allowed to fail
+     * When true, the whole pipeline will fail if this observer fails. Otherwise
+     * the pipeline will keep executing */
+    bool successRequired() const noexcept
+    {
+      return successRequired_;
     }
 
   protected:
@@ -118,6 +127,7 @@ struct MC_OBSERVERS_DLLAPI ObserverPipeline
     bool update_ = true; //< Whether to update the real robot instance from this observer
     bool log_ = true; //< Whether to log this observer
     bool gui_ = true; //< Whether to display the gui
+    bool successRequired_ = true; //< Whether this observer must succeed or is allowed to fail
     bool success_ = true; //< Whether this observer succeeded
   };
 

--- a/include/mc_observers/ObserverPipeline.h
+++ b/include/mc_observers/ObserverPipeline.h
@@ -287,13 +287,7 @@ protected:
   bool updateObservers_ = true; ///< Whether to update real robots from estimated state.
   bool success_ = false; ///< Whether the pipeline successfully executed
 
-  /** Observers that will be run by the pipeline.
-   *
-   * The pair contains:
-   * - The observer to run
-   * - A boolean set to true if the observer updates the real robot instance
-   *
-   * Provided by MCGlobalController */
+  /** Observers that will be run by the pipeline. */
   std::vector<PipelineObserver> pipelineObservers_;
 };
 

--- a/utils/config_build_and_install.macos.sh
+++ b/utils/config_build_and_install.macos.sh
@@ -10,3 +10,10 @@ then
   echo "ROS support is disabled as ROS was not detected. If you have ROS, please source the setup script before running this script."
   export WITH_ROS_SUPPORT="false"
 fi
+
+
+mc_rtc_extra_steps()
+{
+  # Temparary fix for the macOS setup on github actions
+  brew unlink gfortran && brew link gfortran
+}


### PR DESCRIPTION
This PR adds to new options to `ObserverPipeline`:

- `required: false`: load an observer if it exists on the system/is loadable, ignore it otherwise.
One example use case for that is `LIPMWalking` controller currently: when the `AttitudeObserver` exists, it is better to use it, but one might want to use only the integrated `KalmanFilter` (@mmurooka didn't have it on his system because it's an external dependency for now for example so he commented it out for now).

- `successRequired: false`: allow a specific observer to fail without affecting the status of the pipeline

Concrete example:

```yaml
ObserverPipelines:
  name: "LIPMWalkingObserverPipeline"
  gui: true
  observers:
    - type: Encoder
    - type: Attitude
      required: false # If the attitude observer is not present, the kalman filter updates the same sensor
    - type: KinematicInertial
      config:
        anchorFrame:
          maxAnchorFrameDiscontinuity: 0.02
    - type: SLAMObserver # only used for logging but not required
      log: true
      update: false
      required: false # if SLAMObserver is present use it, otherwise we don't care
      successRequired: false # it does not need to succeed for the whole pipeline to provide a valid robot state
    - type: BodySensor
      update: false
```

- This also adds a small code snippet to the documentation to showcase how to interact with observer pipelines from code.