### PR TITLE
[mc_log_ui] Fix various issues (animations, saving, plot limits, default style, etc)

### DIFF
--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -619,12 +619,14 @@ class PlotFigure(object):
     self._axes(lambda axis: axis.legend())
 
   def draw(self, x_limits = None, y1_limits = None, y2_limits = None, frame0 = None, frame = None):
-    if self._3D:
-      x_limits = self._left().setLimits(x_limits, y1_limits, frame0 = frame0, frame = frame, zlim = y1_limits)
-    elif x_limits is None:
+    if x_limits is None:
         # No limit specified for XY/time plots, compute the best min-max x limits fitting both the left and right curves
-        x1_limits = self._left().getLimits(frame0, frame, 0)
-        x2_limits = self._right().getLimits(frame0, frame, 0)
+        x1_limits = None
+        x2_limits = None
+        if self._left() is not None:
+            x1_limits = self._left().getLimits(frame0, frame, 0)
+        if self._right() is not None:
+            x2_limits = self._right().getLimits(frame0, frame, 0)
         if x1_limits is None and x2_limits is not None:
             x_limits = x2_limits
         elif x2_limits is None and x1_limits is not None:
@@ -632,11 +634,18 @@ class PlotFigure(object):
         elif x1_limits is None and x2_limits is None:
             return
         else:
-          x_limits = [min(x1_limits[0], x2_limits[0]), max(x1_limits[1], x2_limits[1])]
+            x_limits = [min(x1_limits[0], x2_limits[0]), max(x1_limits[1], x2_limits[1])]
+        if x_limits is None:
+            return
         range_ = x_limits[1]-x_limits[0]
         x_limits = [x_limits[0] - range_ * 0.01, x_limits[1] + range_ * 0.01]
-        x_limits = self._left().setLimits(x_limits, y1_limits, frame0 = frame0, frame = frame)
-        x_limits = self._right().setLimits(x_limits, y2_limits, frame0 = frame0, frame = frame)
+
+    if self._3D:
+      x_limits = self._left().setLimits(x_limits, y1_limits, frame0 = frame0, frame = frame, zlim = y2_limits)
+    else:
+      x_limits = self._left().setLimits(x_limits, y1_limits, frame0 = frame0, frame = frame)
+      x_limits = self._right().setLimits(x_limits, y2_limits, frame0 = frame0, frame = frame)
+
     self._legend()
     self._drawGrid()
     top_offset = self._left().legendOffset(self._top_offset, -1)

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -142,12 +142,13 @@ class GenerateRangeDialog(QtWidgets.QDialog):
     super(GenerateRangeDialog, self).accept()
 
 def rpyFromMat(E):
-    """Same as mc_rbdyn::rpyFromMat."""
+    """Same as mc_rbdyn::rpyFromMat, but remapped between ]-PI,PI[ to ensure continuity of the plots."""
     roll = atan2(E[1][2], E[2][2]);
     pitch = -asin(E[0][2]);
     yaw = atan2(E[0][1], E[0][0]);
-    return [roll, pitch, yaw]
-
+    # atan(tan(x)) = x mod pi is used here to prevent angle jumps from 0 to 180deg
+    # by remapping the angle between ]-PI, PI[
+    return np.arctan(np.tan([roll, pitch, yaw]))
 
 def rpyFromQuat(quat):
     """Same as mc_rbdyn::rpyFromQuat."""

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -456,24 +456,26 @@ class PlotYAxis(object):
 
   def startAnimation(self, i0):
     for y_label in self.plots.keys():
-      style = self.style(y_label)
+      plotStyle = self.style(y_label)
       self.plots[y_label].remove()
       if not self._3D:
-        self.plots[y_label] = self._axis.plot(self.data[y_label][0][i0], self.data[y_label][1][i0], label = y_label, color = style.color, linestyle = style.linestyle, linewidth = style.linewidth)[0]
+        self.plots[y_label] = self._axis.plot(self.data[y_label][0][i0], self.data[y_label][1][i0], label = y_label)[0]
       else:
-        self.plots[y_label] = self._axis.plot([self.data[y_label][0][i0]], [self.data[y_label][1][i0]], [self.data[y_label][2][0]], label = y_label, color = style.color, linestyle = style.linestyle, linewidth = style.linewidth)[0]
+        self.plots[y_label] = self._axis.plot([self.data[y_label][0][i0]], [self.data[y_label][1][i0]], [self.data[y_label][2][0]], label = y_label)[0]
+      self.style(y_label, plotStyle)
 
   def stopAnimation(self):
     for y_label in self.plots.keys():
-      style = self.style(y_label)
+      plotStyle = self.style(y_label)
       self.plots[y_label].remove()
       if self.filtered[y_label] is not None:
         if not self._3D:
-          self.plots[y_label] = self._axis.plot(self.filtered[y_label][0], self.filtered[y_label][1], label = y_label, color = style.color, linestyle = style.linestyle, linewidth = style.linewidth)[0]
+          self.plots[y_label] = self._axis.plot(self.filtered[y_label][0], self.filtered[y_label][1], label = y_label)[0]
         else:
-          self.plots[y_label] = self._axis.plot(self.filtered[y_label][0], self.filtered[y_label][1], self.filtered[y_label][2], label = y_label, color = style.color, linestyle = style.linestyle, linewidth = style.linewidth)[0]
+          self.plots[y_label] = self._axis.plot(self.filtered[y_label][0], self.filtered[y_label][1], self.filtered[y_label][2], label = y_label)[0]
       else:
-        self.plots[y_label] = self._axis.plot(self.data[y_label][0], self.data[y_label][1], label = y_label, color = style.color, linestyle = style.linestyle, linewidth = style.linewidth)[0]
+        self.plots[y_label] = self._axis.plot(self.data[y_label][0], self.data[y_label][1], label = y_label)[0]
+      self.style(y_label, plotStyle)
 
   def add_plot(self, x, y, y_label, style = None):
     return self._plot(self._data()[x], self._data()[y], y_label, style, source = y)

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -1200,9 +1200,12 @@ class PlotCanvasWithToolbar(PlotFigure, QWidget):
     self.draw()
 
   def saveAnimation(self):
-    if not self.animation:
-        ShowErrorDialog("Can't save an empty animation")
-        return
+    if not self.animationButton.isChecked():
+      self.startAnimation()
+      if not self.animation:
+          ShowErrorDialog("Can't save an empty animation")
+          return
+      self.stopAnimation()
 
     fpath = QtWidgets.QFileDialog.getSaveFileName(self,  "Output animation", self.animation_path+"/output-animation.mp4", filter = "Video (*.mp4)")[0]
     if not len(fpath):
@@ -1211,10 +1214,6 @@ class PlotCanvasWithToolbar(PlotFigure, QWidget):
     filename, extension = os.path.splitext(fpath)
     if not extension:
       fpath = fpath + '.mp4'
-
-    if not self.animationButton.isChecked():
-      self.startAnimation()
-      self.stopAnimation()
 
     self.savingAnimation = True
     self.saveAnimationDialog.show()

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -142,13 +142,12 @@ class GenerateRangeDialog(QtWidgets.QDialog):
     super(GenerateRangeDialog, self).accept()
 
 def rpyFromMat(E):
-    """Same as mc_rbdyn::rpyFromMat, but remapped between ]-PI,PI[ to ensure continuity of the plots."""
+    """Same as mc_rbdyn::rpyFromMat."""
     roll = atan2(E[1][2], E[2][2]);
     pitch = -asin(E[0][2]);
     yaw = atan2(E[0][1], E[0][0]);
-    # atan(tan(x)) = x mod pi is used here to prevent angle jumps from 0 to 180deg
-    # by remapping the angle between ]-PI, PI[
-    return np.arctan(np.tan([roll, pitch, yaw]))
+    return [roll, pitch, yaw]
+
 
 def rpyFromQuat(quat):
     """Same as mc_rbdyn::rpyFromQuat."""

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -968,6 +968,8 @@ class PlotCanvasWithToolbar(PlotFigure, QWidget):
     self.setupLockButtons()
     self.setupAnimationButtons()
 
+    self.animation_path = QtCore.QStandardPaths.writableLocation(QtCore.QStandardPaths.DocumentsLocation)
+
   def setupLockButtons(self):
     layout = QHBoxLayout()
 
@@ -1157,12 +1159,10 @@ class PlotCanvasWithToolbar(PlotFigure, QWidget):
     self.draw()
 
   def saveAnimation(self):
-    if not self.animation:
-        ShowErrorDialog("Can't save an empty animation")
-        return
-    fpath = QtWidgets.QFileDialog.getSaveFileName(self,  "Output animation", 'output-animation.mp4', filter = "Video (*.mp4)")[0]
+    fpath = QtWidgets.QFileDialog.getSaveFileName(self,  "Output animation", self.animation_path+"/output-animation.mp4", filter = "Video (*.mp4)")[0]
     if not len(fpath):
       return
+    self.animation_path = os.path.split(fpath)[0]
     filename, extension = os.path.splitext(fpath)
     if not extension:
       fpath = fpath + '.mp4'
@@ -1171,6 +1171,10 @@ class PlotCanvasWithToolbar(PlotFigure, QWidget):
       self.animation.save(fpath)
     else:
       self.startAnimation()
+      if not self.animation:
+          ShowErrorDialog("Can't save an empty animation")
+          print "Could not save empty animation"
+          return
       self.animation.save(fpath)
       self.stopAnimation()
     print "Animation saved to %s" % fpath

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -345,7 +345,7 @@ class PlotYAxis(object):
         limits =  self.getLimits(frame0, frame, idx)
         # Ignore limits if all data is nan
         if limits is None:
-            return 0, 0
+            return None
         min_, max_ = setMargin(limits[0], limits[1])
       else:
         min_, max_ = setMargin(dataLim[0][idx], dataLim[1][idx])
@@ -635,8 +635,8 @@ class PlotFigure(object):
           x_limits = [min(x1_limits[0], x2_limits[0]), max(x1_limits[1], x2_limits[1])]
         range_ = x_limits[1]-x_limits[0]
         x_limits = [x_limits[0] - range_ * 0.01, x_limits[1] + range_ * 0.01]
-    x_limits = self._left().setLimits(x_limits, y1_limits, frame0 = frame0, frame = frame)
-    x_limits = self._right().setLimits(x_limits, y2_limits, frame0 = frame0, frame = frame)
+        x_limits = self._left().setLimits(x_limits, y1_limits, frame0 = frame0, frame = frame)
+        x_limits = self._right().setLimits(x_limits, y2_limits, frame0 = frame0, frame = frame)
     self._legend()
     self._drawGrid()
     top_offset = self._left().legendOffset(self._top_offset, -1)

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -9,6 +9,7 @@ from PyQt5 import QtCore, QtGui, QtWidgets
 
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QHBoxLayout, QComboBox
 
+import os
 import copy
 import math
 import matplotlib
@@ -36,6 +37,7 @@ try:
 except ImportError:
   import mc_log_ui
 from .mc_log_utils import InitDialogWithOkCancel
+from .mc_log_utils import ShowErrorDialog
 
 import sys
 if sys.version_info[0] > 2:
@@ -1090,9 +1092,15 @@ class PlotCanvasWithToolbar(PlotFigure, QWidget):
     self.draw()
 
   def saveAnimation(self):
-    fpath = QtWidgets.QFileDialog.getSaveFileName(self, "Output file", filter = "Video (*.mp4)")[0]
+    if not self.animation:
+        ShowErrorDialog("Can't save an empty animation")
+        return
+    fpath = QtWidgets.QFileDialog.getSaveFileName(self,  "Output animation", 'output-animation.mp4', filter = "Video (*.mp4)")[0]
     if not len(fpath):
       return
+    filename, extension = os.path.splitext(fpath)
+    if not extension:
+      fpath = fpath + '.mp4'
     if self.animationButton.isChecked():
       self.animation.save(fpath)
     else:

--- a/utils/mc_log_gui/mc_log_ui/mc_log_tab.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_tab.py
@@ -463,13 +463,22 @@ class MCLogTab(QtWidgets.QWidget):
 
   def setRobotModule(self, rm, loaded_files):
     self.rm = rm
-    if self.rm is None:
-      return
-    def setQNames(ySelector):
+    def findQList(ySelector):
       qList = ySelector.findItems("q", QtCore.Qt.MatchStartsWith | QtCore.Qt.MatchRecursive)
       qList += ySelector.findItems("alpha", QtCore.Qt.MatchStartsWith | QtCore.Qt.MatchRecursive)
       qList += ySelector.findItems("error", QtCore.Qt.MatchStartsWith | QtCore.Qt.MatchRecursive)
       qList += ySelector.findItems("tau", QtCore.Qt.MatchStartsWith | QtCore.Qt.MatchRecursive)
+      return qList
+    def clearQNames(qList):
+      def update_child_display(items):
+        for itm in items:
+          cCount = itm.childCount()
+          if cCount == 0:
+            itm.displayText = itm.originalText
+          else:
+            update_child_display([itm.child(i) for i in range(cCount)])
+      update_child_display(qList)
+    def setQNames(qList):
       def update_child_display(items):
         for itm in items:
           cCount = itm.childCount()
@@ -481,8 +490,13 @@ class MCLogTab(QtWidgets.QWidget):
           else:
             update_child_display([itm.child(i) for i in range(cCount)])
       update_child_display(qList)
-    setQNames(self.ui.y1Selector)
-    setQNames(self.ui.y2Selector)
+    if self.rm is None:
+      clearQNames(findQList(self.ui.y1Selector))
+      clearQNames(findQList(self.ui.y2Selector))
+      return
+    else:
+      setQNames(findQList(self.ui.y1Selector))
+      setQNames(findQList(self.ui.y2Selector))
     if self.data is None:
       return
     bounds = self.rm.bounds()

--- a/utils/mc_log_gui/mc_log_ui/mc_log_tab.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_tab.py
@@ -461,13 +461,12 @@ class MCLogTab(QtWidgets.QWidget):
     for c in [self.ui.canvas, self.XYCanvas, self._3DCanvas]:
       c.setPolyColors(colors)
 
-  def setRobotModule(self, rm, loaded_files):
+  def setRobotModule(self, rm, filtered_joints_prefix, loaded_files):
     self.rm = rm
     def findQList(ySelector):
-      qList = ySelector.findItems("q", QtCore.Qt.MatchStartsWith | QtCore.Qt.MatchRecursive)
-      qList += ySelector.findItems("alpha", QtCore.Qt.MatchStartsWith | QtCore.Qt.MatchRecursive)
-      qList += ySelector.findItems("error", QtCore.Qt.MatchStartsWith | QtCore.Qt.MatchRecursive)
-      qList += ySelector.findItems("tau", QtCore.Qt.MatchStartsWith | QtCore.Qt.MatchRecursive)
+      qList = []
+      for qPrefix in filtered_joints_prefix:
+          qList += ySelector.findItems(qPrefix, QtCore.Qt.MatchStartsWith | QtCore.Qt.MatchRecursive)
       return qList
     def clearQNames(qList):
       def update_child_display(items):
@@ -681,7 +680,7 @@ class MCLogTab(QtWidgets.QWidget):
     tab = MCLogTab(parent, type_)
     tab.x_data = x_data
     tab.setData(parent.data)
-    tab.setRobotModule(parent.rm, parent.loaded_files)
+    tab.setRobotModule(parent.rm, parent.jointKeyPrefixes, parent.loaded_files)
     if type_ is PlotType.TIME:
       for y,yl in zip(y1, y1_label):
         tab.tree_view.select(y, tab.ui.y1Selector, 0)

--- a/utils/mc_log_gui/mc_log_ui/mc_log_types.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_types.py
@@ -27,7 +27,7 @@ class PlotType(Enum):
   _3D = 2
 
 class LineStyle(object):
-  def __init__(self, color = 'black', linestyle = '-', linewidth = 0.5, visible = False, label = ""):
+  def __init__(self, color = 'black', linestyle = '-', linewidth = 1.0, visible = False, label = ""):
     self.color = color
     self.linestyle = linestyle
     self.linewidth = linewidth
@@ -49,7 +49,7 @@ class GraphLabels(object):
     self.y2_label = y2_label
 
 class ColorsSchemeConfiguration(object):
-  def __init__(self, f, default = 'Set1'):
+  def __init__(self, f, default = 'tab10'):
     cm = default
     ncolors = 12
     data = {}

--- a/utils/mc_log_gui/mc_log_ui/mc_log_ui.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_ui.py
@@ -668,14 +668,17 @@ class MCLogUI(QtWidgets.QMainWindow):
     self.polyColorsFile = os.path.expanduser("~") + "/.config/mc_log_ui/poly_colors.json"
     self.polyColorsScheme = ColorsSchemeConfiguration(self.polyColorsFile, 'Pastel1')
 
+    self.jointKeyPrefixes = ["q", "alpha", "tau", "error"]
+
     self.activeRobotAction = None
     self.rm = None
     if mc_rbdyn is not None:
       rMenu = QtWidgets.QMenu("Robot", self.ui.menubar)
       rGroup = QtWidgets.QActionGroup(rMenu)
+      cGroup = QtWidgets.QActionGroup(rMenu)
       rCategoryMenu = {}
       rActions = []
-      rMenu.addActions([RobotAction("Clear robot", rGroup)])
+      rMenu.addActions([RobotAction("Clear robot", cGroup)])
       rMenu.addSeparator()
       for r in mc_rbdyn.RobotLoader.available_robots():
         rAct = RobotAction(r, rGroup)
@@ -701,6 +704,7 @@ class MCLogUI(QtWidgets.QMainWindow):
       self.activeRobotAction.setChecked(True)
       self.setRobot(self.activeRobotAction)
       rGroup.triggered.connect(self.setRobot)
+      cGroup.triggered.connect(self.setRobot)
       self.ui.menubar.addMenu(rMenu)
 
     self.styleMenu = QtWidgets.QMenu("Style", self.ui.menubar)
@@ -843,10 +847,22 @@ class MCLogUI(QtWidgets.QMainWindow):
       defaultTitle = ""
     title, ok = QtWidgets.QInputDialog.getText(self, "User plot", "Title of your plot:", text = defaultTitle)
     if ok:
+      def convertJointIndex(key):
+        if self.rm is not None:
+          if any(key.startswith(x) for x in self.jointKeyPrefixes):
+            try:
+              prefix, separator, jName = key.rpartition("_")
+              rjo = self.rm.ref_joint_order()
+              if jName in rjo:
+                jIndex = rjo.index(jName)
+                return prefix + separator + str(jIndex)
+            except RuntimeError:
+              return key
+        return key
       type_ = tab.plotType()
       if type_ is PlotType.TIME:
-        y1 = filter(lambda k: k in self.data.keys(), canvas._left().plots.keys())
-        y2 = filter(lambda k: k in self.data.keys(), canvas._right().plots.keys())
+        y1 = [convertJointIndex(x) for x in filter(lambda k: convertJointIndex(k) in self.data.keys(), canvas._left().plots.keys())]
+        y2 = [convertJointIndex(x) for x in filter(lambda k: convertJointIndex(k) in self.data.keys(), canvas._right().plots.keys())]
         y1d = map(lambda sp: "{}_{}".format(sp.name, sp.id), filter(lambda sp: sp.idx == 0, tab.specials.values()))
         y2d = map(lambda sp: "{}_{}".format(sp.name, sp.id), filter(lambda sp: sp.idx == 1, tab.specials.values()))
       else:
@@ -857,9 +873,9 @@ class MCLogUI(QtWidgets.QMainWindow):
           y2 = []
         y1d = []
         y2d = []
-      style = { y: canvas.style_left(y) for y in canvas._left().plots.keys() }
+      style = { convertJointIndex(y): canvas.style_left(y) for y in canvas._left().plots.keys() }
       if canvas._right():
-        style2 = { y: canvas.style_right(y) for y in canvas._right().plots.keys() }
+        style2 = { convertJointIndex(y): canvas.style_right(y) for y in canvas._right().plots.keys() }
       else:
         style2 = {}
       grid = canvas._left().grid
@@ -923,7 +939,7 @@ class MCLogUI(QtWidgets.QMainWindow):
       for i in range(self.ui.tabWidget.count() - 1):
         tab = self.ui.tabWidget.widget(i)
         assert(isinstance(tab, MCLogTab))
-        tab.setRobotModule(self.rm, self.loaded_files)
+        tab.setRobotModule(self.rm, self.jointKeyPrefixes, self.loaded_files)
       self.saveDefaultRobot(action.actual())
 
     if action.actual() == "Clear robot":
@@ -963,7 +979,7 @@ class MCLogUI(QtWidgets.QMainWindow):
       plotW = MCLogTab(self)
       plotW.setData(self.data)
       plotW.setGridStyles(self.gridStyles)
-      plotW.setRobotModule(self.rm, self.loaded_files)
+      plotW.setRobotModule(self.rm, self.jointKeyPrefixes, self.loaded_files)
       plotW.setColors(self.colorsScheme.colors())
       plotW.setPolyColors(self.polyColorsScheme.colors())
       j = 1
@@ -1104,7 +1120,7 @@ class MCLogUI(QtWidgets.QMainWindow):
       assert(isinstance(tab, MCLogTab))
       tab.setData(self.data)
       tab.setGridStyles(self.gridStyles)
-      tab.setRobotModule(self.rm, self.loaded_files)
+      tab.setRobotModule(self.rm, self.jointKeyPrefixes, self.loaded_files)
       tab.setColors(self.colorsScheme.colors())
       tab.setPolyColors(self.polyColorsScheme.colors())
 

--- a/utils/mc_log_gui/mc_log_ui/mc_log_utils.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_utils.py
@@ -40,3 +40,9 @@ def InitDialogWithOkCancel(fun = None, Layout = QtWidgets.QFormLayout , apply_ =
     return wrap_init(fun)
   else:
     return wrap_init
+
+def ShowErrorDialog(text, parent = None):
+    err_diag = QtWidgets.QMessageBox(parent)
+    err_diag.setIcon(QtWidgets.QMessageBox.Critical)
+    err_diag.setText(text)
+    err_diag.exec_()


### PR DESCRIPTION
This PR fixes multiple issues with `mc_log_ui` and in particular the animated plots:

## Major:
**Allow to generate animated plots with missing data.**
Previously, trying to plot an animation with non-continous data (e.g. repeatedly adding/removing a task) would crash. Looking at the original PR (https://github.com/jrl-umi3218/mc_rtc/pull/13), it seems that the intent was to first generate a time range corresponding to valid data, and then generating a live plot for this time range. This is however not very intuitive, and still not crash-proof in case there are multiple curves displayed.

The new implementation:
- Looks for the first/last non-nan data amongst all displayed curves to automatically find the suitable time-range for the animation
- Fixes the computation of plot limits, notably for XY plots (previously only the left axis was taken into account). In this case, the x axis is shared between the left/right plots (its limits are the min/max value of all left and right curves). The left/right y axes can be scaled independently.
- The axes-locking feature still works as expected
- Margins between the curves and the figure axes is now handled consistently in all cases.

An example is worth a thousand words, here is an animated plot of walking showing the measured ZMP and feet limits, along with the right swing foot height. Note that the plot starts at `t=4s` automatically (there is no data before that as the walking hasn't yet started), and that the green curve (swing foot) is not continuous.

https://user-images.githubusercontent.com/67139/108188332-cddcf900-7152-11eb-95b0-015425c25206.mp4

Another example for XY plots (not very meaningful here, showing simultaneously a joint against another joint and the x vs y components of the CoM):

https://user-images.githubusercontent.com/67139/108188776-522f7c00-7153-11eb-854f-fb4aa8a033e3.mp4

- **[update] Add sliding windows**: 56ad31d implements sliding windows, aka "only show the last N seconds" of an animation


https://user-images.githubusercontent.com/67139/108198247-bdcb1680-715e-11eb-9682-591ae5e90778.mp4



## Minor:
- Prevent RPY from flipping between 0 and 180deg. This uses the `atan(tan(x))` trick to remap the angle between `]-PI, PI[`
- Saving animations:
  - Add `.mp4` extension by default (makes matplotlib crash if saving as anything else than mp4)
  - Prevent saving empty animation with a dialog error message
  - Remember the last used save directory (during the current session)
 - Use a color set without invisible yellow color by default (can still be changed from the style menu)
 - Double default line size
 

@mmurooka Can you check that this fixes the issues you were experiencing?