### PR TITLE
Spline trajectory task log fix

### DIFF
--- a/doc/tutorials/samples/list-of-samples.md
+++ b/doc/tutorials/samples/list-of-samples.md
@@ -123,7 +123,7 @@ To run this controller, simply put in [your mc_rtc configuration]({{site.baseurl
 
 ```yaml
 MainRobot: JVRC1
-Enabled: Admittance
+Enabled: AdmittanceSample
 ```
 
 # Impedance

--- a/include/mc_rtc/gui/StateBuilder.h
+++ b/include/mc_rtc/gui/StateBuilder.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2021 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #pragma once
@@ -245,6 +245,12 @@ struct MC_RTC_GUI_DLLAPI StateBuilder
    */
   mc_rtc::Configuration data();
 
+  /** Return the number of elements in the GUI */
+  inline size_t size() const
+  {
+    return elements_.size();
+  }
+
 private:
   template<typename T>
   void addElementImpl(const std::vector<std::string> & category, ElementsStacking stacking, T element, size_t rem = 0);
@@ -288,6 +294,16 @@ private:
     std::vector<Category>::iterator find(const std::string & name);
     /** For each category, keeps track of the line id for next elements added */
     int id;
+    /** Returns the number of elements in this category and its sub-categories */
+    inline size_t size() const
+    {
+      size_t s = 0;
+      for(const auto & c : sub)
+      {
+        s += c.size();
+      }
+      return s + elements.size();
+    }
   };
   Category elements_;
 

--- a/include/mc_rtc/log/Logger.h
+++ b/include/mc_rtc/log/Logger.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2021 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #pragma once
@@ -246,6 +246,12 @@ public:
 
   /** Flush the log data to disk (only implemented in the synchronous method) */
   void flush();
+
+  /** Returns the number of entries currently in the log */
+  inline size_t size() const
+  {
+    return log_entries_.size();
+  }
 
 private:
   /** Hold information about a log entry stored in this instance */

--- a/include/mc_tasks/SplineTrajectoryTask.hpp
+++ b/include/mc_tasks/SplineTrajectoryTask.hpp
@@ -387,9 +387,9 @@ template<typename Derived>
 void SplineTrajectoryTask<Derived>::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
-  logger.addLogEntry(name_ + "_surfacePose", [this]() {
-    const auto & robot = this->robots.robot(rIndex_);
-    return robot.surfacePose(surfaceName_);
+  logger.addLogEntry(name_ + "_surfacePose", this, [this]() {
+    const auto & robot = this->robots.robot(this->rIndex_);
+    return robot.surfacePose(this->surfaceName_);
   });
   MC_RTC_LOG_GETTER(name_ + "_targetPose", target);
   MC_RTC_LOG_GETTER(name_ + "_refPose", refPose);

--- a/include/mc_tasks/SplineTrajectoryTask.hpp
+++ b/include/mc_tasks/SplineTrajectoryTask.hpp
@@ -388,8 +388,8 @@ void SplineTrajectoryTask<Derived>::addToLogger(mc_rtc::Logger & logger)
 {
   TrajectoryBase::addToLogger(logger);
   logger.addLogEntry(name_ + "_surfacePose", this, [this]() {
-    const auto & robot = this->robots.robot(this->rIndex_);
-    return robot.surfacePose(this->surfaceName_);
+    const auto & robot = this->robots.robot(rIndex_);
+    return robot.surfacePose(surfaceName_);
   });
   MC_RTC_LOG_GETTER(name_ + "_targetPose", target);
   MC_RTC_LOG_GETTER(name_ + "_refPose", refPose);


### PR DESCRIPTION
Without explicitly specifying `this->` like this PR, you get the following SEGV when running the [admittance sample](https://jrl-umi3218.github.io/mc_rtc/tutorials/samples/sample-admittance.html). Also, you get SEGV when stepping forward/backward with `LIPMStabilizer` controller probably for the same reason.

It didn't happen before, so it may start to happen after [the latest logger update](https://github.com/jrl-umi3218/mc_rtc/pull/115). But I don't know the actual reason why this change is needed.

I haven't checked if there is any other place (i.e., template task class) that needs similar fix.

```
Thread 25 "choreonoid" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fff61504700 (LWP 3003)]
mc_rbdyn::Robots::robot (this=0xbf202026160d2447, idx=1274965924) at /home/mmurooka/jrl/mc_rtc/src/mc_rbdyn/Robots.cpp:159
159                       if(idx >= robots_.size())
(gdb) bt
#0  mc_rbdyn::Robots::robot (this=0xbf202026160d2447, idx=1274965924) at /home/mmurooka/jrl/mc_rtc/src/mc_rbdyn/Robots.cpp:159
#1  0x00007fff658f4933 in mc_tasks::SplineTrajectoryTask<mc_tasks::BSplineTrajectoryTask>::addToLogger(mc_rtc::Logger&)::{lambda()#1}::operator()() const (__closure=0x7fff541cc9d0) at /home/mmurooka/jrl/mc_rtc/include/mc_tasks/SplineTrajectoryTask.hpp:391
#2  mc_rtc::Logger::addLogEntry<mc_tasks::SplineTrajectoryTask<mc_tasks::BSplineTrajectoryTask>::addToLogger(mc_rtc::Logger&)::{lambda()#1}, void, 0>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void const*, mc_tasks::SplineTrajectoryTask<mc_tasks::BSplineTrajectoryTask>::addToLogger(mc_rtc::Logger&)::{lambda()#1}&&)::{lambda(mc_rtc::MessagePackBuilder&)#1}::operator()(mc_rtc::MessagePackBuilder) (builder=..., __closure=0x7fff541cc9d0) at /home/mmurooka/jrl/mc_rtc/include/mc_rtc/log/Logger.h:132
#3  std::_Function_handler<void (mc_rtc::MessagePackBuilder&), mc_rtc::Logger::addLogEntry<mc_tasks::SplineTrajectoryTask<mc_tasks::BSplineTrajectoryTask>::addToLogger(mc_rtc::Logger&)::{lambda()#1}, void, 0>(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, void const*, mc_tasks::SplineTrajectoryTask<mc_tasks::BSplineTrajectoryTask>::addToLogger(mc_rtc::Logger&)::{lambda()#1}&&)::{lambda(mc_rtc::MessagePackBuilder&)#1}>::_M_invoke(std::_Any_data const&, mc_rtc::MessagePackBuilder&) (__functor=..., __args#0=...)
at /usr/include/c++/7/bits/std_function.h:316
#4  0x00007fff66d99c51 in std::function<void (mc_rtc::MessagePackBuilder&)>::operator()(mc_rtc::MessagePackBuilder&) const (__args#0=...,
this=0x7fff541cc9d0) at /usr/include/c++/7/bits/std_function.h:706
#5  mc_rtc::Logger::log (this=0x7fff40400150) at /home/mmurooka/jrl/mc_rtc/src/mc_rtc/Logger.cpp:266
#6  0x00007fff6735117c in mc_control::MCGlobalController::run (this=this@entry=0x7fff400b3768)
at /home/mmurooka/jrl/mc_rtc/src/mc_control/mc_global_controller.cpp:711
#7  0x00007fff675bdc11 in MCControl::onExecute (this=0x7fff400a6230, ec_id=<optimized out>)
at /home/mmurooka/jrl/mc_openrtm/src/MCControl.cpp:348
#8  0x00007fffc1c2731d in RTC::RTObject_impl::on_execute (this=0x7fff400a6230, ec_id=1000) at RTObject.cpp:1029
#9  0x00007fffc1cbf103 in _0RL_lcfn_bf82f9885dac07a6_b2000000 (cd=0x7fff61503a70, svnt=<optimized out>)
at ../../../../src/lib/rtm/idl/RTCSK.cc:2100
#10 0x00007fffc277894f in omni::omniOrbPOA::dispatch(omniCallDescriptor&, omniLocalIdentity*) () from /usr/lib/libomniORB4.so.1
(gdb) p idx
$1 = 1274965924
```

~~[Adding log source](https://github.com/jrl-umi3218/mc_rtc/compare/master...mmurooka:SplineTrajectoryTask-log-fix?expand=1#diff-54372414bf890e60f96c593370cecc1910762b7882afc9e267f81dc771e7d876R390) may be not directly related to this issue.~~