### PR TITLE
[mc_tasks] add hold function of impedance task

### DIFF
--- a/include/mc_tasks/ImpedanceTask.h
+++ b/include/mc_tasks/ImpedanceTask.h
@@ -205,9 +205,12 @@ public:
   /*! \brief Set hold mode.
    *
    *  In hold mode, the compliance modification (deltaCompPoseW_) is automatically updated so that the final target pose
-   * sent to the QP (i.e. compliancePose()) remains constant even if the user-specified target pose changes. This is
-   * useful when the user wants to change the target pose without moving the object held by the robot (e.g., when there
-   * is an error in the object pose and it is corrected based on vision sensor measurements).
+   * sent to the QP (i.e. compliancePose()) remains constant even if the user-specified target pose changes. A typical
+   * use case for hold mode is to set the current end-effector pose as targetPose. Thanks to the hold mode, the robot
+   * does not move the end-effector pose, but the deltaCompPoseW_ becomes smaller, and the external force exerted by the
+   * spring term of impedance dynamics becomes smaller. Without the hold mode, the mass and damper effects of impedance
+   * dynamics would cause the compliancePose to temporarily deviate from the commanded targetPose, causes unintended
+   * movement of the end-effector.
    */
   inline void hold(bool hold) noexcept
   {
@@ -240,7 +243,6 @@ protected:
 
   // Target pose, velocity, and acceleration in the world frame
   sva::PTransformd targetPoseW_ = sva::PTransformd::Identity();
-  sva::PTransformd prevTargetPoseW_ = sva::PTransformd::Identity();
   sva::MotionVecd targetVelW_ = sva::MotionVecd::Zero();
   sva::MotionVecd targetAccelW_ = sva::MotionVecd::Zero();
 
@@ -253,7 +255,6 @@ protected:
 
   // Hold mode
   bool hold_ = false;
-  sva::PTransformd holdOffsetPose_ = sva::PTransformd::Identity();
 
   void update(mc_solver::QPSolver & solver) override;
 

--- a/include/mc_tasks/ImpedanceTask.h
+++ b/include/mc_tasks/ImpedanceTask.h
@@ -197,7 +197,7 @@ public:
   }
 
   /*! \brief Get whether hold mode is enabled. */
-  bool hold() const noexcept
+  inline bool hold() const noexcept
   {
     return hold_;
   }
@@ -209,7 +209,7 @@ public:
    * useful when the user wants to change the target pose without moving the object held by the robot (e.g., when there
    * is an error in the object pose and it is corrected based on vision sensor measurements).
    */
-  void setHold(bool hold)
+  inline void hold(bool hold) noexcept
   {
     hold_ = hold;
   }

--- a/include/mc_tasks/ImpedanceTask.h
+++ b/include/mc_tasks/ImpedanceTask.h
@@ -196,6 +196,24 @@ public:
     lowPass_.cutoffPeriod(cutoffPeriod);
   }
 
+  /*! \brief Get whether hold mode is enabled. */
+  bool hold() const noexcept
+  {
+    return hold_;
+  }
+
+  /*! \brief Set hold mode.
+   *
+   *  In hold mode, the compliance modification (deltaCompPoseW_) is automatically updated so that the final target pose
+   * sent to the QP (i.e. compliancePose()) remains constant even if the user-specified target pose changes. This is
+   * useful when the user wants to change the target pose without moving the object held by the robot (e.g., when there
+   * is an error in the object pose and it is corrected based on vision sensor measurements).
+   */
+  void setHold(bool hold)
+  {
+    hold_ = hold;
+  }
+
   /*! \brief Load parameters from a Configuration object. */
   void load(mc_solver::QPSolver & solver, const mc_rtc::Configuration & config) override;
 
@@ -222,6 +240,7 @@ protected:
 
   // Target pose, velocity, and acceleration in the world frame
   sva::PTransformd targetPoseW_ = sva::PTransformd::Identity();
+  sva::PTransformd prevTargetPoseW_ = sva::PTransformd::Identity();
   sva::MotionVecd targetVelW_ = sva::MotionVecd::Zero();
   sva::MotionVecd targetAccelW_ = sva::MotionVecd::Zero();
 
@@ -231,6 +250,10 @@ protected:
   sva::ForceVecd filteredMeasuredWrench_ = sva::ForceVecd::Zero();
 
   mc_filter::LowPass<sva::ForceVecd> lowPass_;
+
+  // Hold mode
+  bool hold_ = false;
+  sva::PTransformd holdOffsetPose_ = sva::PTransformd::Identity();
 
   void update(mc_solver::QPSolver & solver) override;
 

--- a/src/mc_tasks/ImpedanceTask.cpp
+++ b/src/mc_tasks/ImpedanceTask.cpp
@@ -130,7 +130,8 @@ void ImpedanceTask::update(mc_solver::QPSolver & solver)
     holdOffsetPose_ = prevTargetPoseW_ * targetPoseW_.inv();
     // Transform to target pose frame (see compliancePose implementation)
     sva::PTransformd T_0_d(targetPoseW_.rotation());
-    deltaCompPoseW_ = deltaCompPoseW_ * T_0_d.inv() * holdOffsetPose_ * T_0_d;
+    // deltaCompPoseW_ = deltaCompPoseW_ * T_0_d.inv() * holdOffsetPose_ * T_0_d;
+    deltaCompPoseW_ = T_0_d.inv() * SurfaceTransformTask::target() * targetPoseW_.inv() * T_0_d;
   }
   else
   {

--- a/src/mc_tasks/ImpedanceTask.cpp
+++ b/src/mc_tasks/ImpedanceTask.cpp
@@ -226,7 +226,6 @@ void ImpedanceTask::addToLogger(mc_rtc::Logger & logger)
   MC_RTC_LOG_HELPER(name_ + "_filteredMeasuredWrench", filteredMeasuredWrench_);
   logger.addLogEntry(name_ + "_cutoffPeriod", this, [this]() { return cutoffPeriod(); });
 
-  // hold
   MC_RTC_LOG_HELPER(name_ + "_hold", hold_);
   MC_RTC_LOG_HELPER(name_ + "_holdOffsetPose", holdOffsetPose_);
 }
@@ -253,7 +252,6 @@ void ImpedanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
                                          [this]() { return this->filteredMeasuredWrench_.vector(); }),
                  mc_rtc::gui::NumberInput("cutoffPeriod", [this]() { return this->cutoffPeriod(); },
                                           [this](double a) { return this->cutoffPeriod(a); }),
-                 // hold
                  mc_rtc::gui::Checkbox("hold", [this]() { return hold_; }, [this]() { hold_ = !hold_; }));
   gui.addElement({"Tasks", name_, "Impedance gains"},
                  mc_rtc::gui::ArrayInput("mass", {"cx", "cy", "cz", "fx", "fy", "fz"},


### PR DESCRIPTION
This PR add function to hold the target pose in impedance task.
In hold mode, the compliance modification (deltaCompPoseW_) is automatically updated so that the final target pose sent to the QP (i.e. compliancePose()) remains constant even if the user-specified target pose changes. This is useful when the user wants to change the target pose without moving the object held by the robot (e.g., when there is an error in the object pose and it is corrected based on vision sensor measurements).

Below are the results of a brief test of a simple controller. [Impedance Controller](https://github.com/mmurooka/mc_rtc/tree/impedance-hold-sample/src/mc_control/samples/Impedance) in [mmurooka/impedance-hold-sample branch](https://github.com/mmurooka/mc_rtc/tree/impedance-hold-sample) is used.

In this test, JVRC1Fixed is reaching left gripper forward with ImpedanceTask but the gripper cannot reach to the target pose because it collides with the wall in front of the robot in 0-10 sec in the graph.
In 10-16 sec, the target pose of ImpedanceTask is updated to the current actual gripper pose with linear interpolation. Without PR, the resultant target pose of the gripper [red line] (which is which is sum of original target pose and compliance delta pose) moves back because the compliance delta pose [blue line] remains for a while due to the damping term of the ImpedanceParameter. When loco-manipulating an object, it is an undesirable behavior for this robot's hand to move backwards. With PR (enabling holding mode [orange line] during this interpolation update), the resultant target pose is almost unchanged.

### Before PR (hold mode is always disabled)
![before1](https://user-images.githubusercontent.com/6636600/113267441-51bd0000-9311-11eb-9ef0-dfdc77c52c53.png)
![before2](https://user-images.githubusercontent.com/6636600/113267453-55e91d80-9311-11eb-9b4b-e825cfaa4d14.png)

### Hold strategy 1 (Hold mode is enabled during updating the target pose)
![after1](https://user-images.githubusercontent.com/6636600/113267478-5c779500-9311-11eb-88ab-a68ec4669857.png)
![after2](https://user-images.githubusercontent.com/6636600/113267488-5e415880-9311-11eb-9f0e-ca9fb6aac78d.png)
