### PR TITLE
Fix DataStore issue with libc++

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,6 @@ jobs:
         sudo rm -f /etc/apt/sources.list.d/dotnetdev.list /etc/apt/sources.list.d/microsoft-prod.list
     - name: macOS cleanup
       run: |
-        sudo xcode-select -switch /Applications/Xcode_11.7.app
         sudo rm '/usr/local/bin/2to3'
       if: startsWith(runner.os, 'macOS')
     - name: Clear environment (script)


### PR DESCRIPTION
This PR changes the way type-checking is done in the `DataStore`

The issue is similar to what is described [here](https://stackoverflow.com/questions/19496643/using-clang-fvisibility-hidden-and-typeinfo-and-type-erasure) where the combination of `-fvisibility=hidden`  (which we use in mc_rtc) and `libc++` means the same non-visible types get different `typeid`.

Thus the `DataStore` now does type-checking in two ways:
- first the type's id is compared with known viable ids (current behaviour)
- if that fails, it will compare the demangled type names

In the good scenario (no type issue and all types are visible) this has no extra cost compared to the current implementation. It fixes the non-ideal scenario where all types are not visible for libc++ with a small overhead to check the type names. It makes it a little more expensive in failing scenarios (trying to retrieve the wrong type)

Closes #104 and #138 as the failure in macOS is due to this issue