### PR TITLE
Fix the stabilizer to be disabled correctly

### DIFF
--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -823,6 +823,8 @@ protected:
   StabilizerConfiguration defaultConfig_;
   /**< Last valid stabilizer configuration. */
   StabilizerConfiguration lastConfig_;
+  /**< Stabilizer configuration to disable. */
+  StabilizerConfiguration disableConfig_;
   /**< Online stabilizer configuration, can be set from the GUI. Defaults to defaultConfig_ */
   StabilizerConfiguration c_;
   /**< Whether the stabilizer needs to be reconfigured at the next

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -246,7 +246,7 @@ void StabilizerTask::update(mc_solver::QPSolver & solver)
   // Prevent configuration changes while the stabilizer is disabled
   if(!enabled_)
   {
-    c_ = lastConfig_;
+    c_ = disableConfig_;
     zmpcc_.configure(c_.zmpcc);
   }
   if(reconfigure_) configure_(solver);
@@ -294,14 +294,17 @@ void StabilizerTask::disable()
   mc_rtc::log::info("[StabilizerTask] disabled");
   // Save current configuration to be reused when re-enabling
   lastConfig_ = c_;
+  disableConfig_ = c_;
   // Set the stabilizer gains to zero
-  c_.copAdmittance.setZero();
-  c_.dcmDerivGain = 0.;
-  c_.dcmIntegralGain = 0.;
-  c_.dcmPropGain = 0.;
-  c_.dfzAdmittance = 0.;
-  c_.vdcFrequency = 0.;
-  c_.vdcStiffness = 0.;
+  disableConfig_.copAdmittance.setZero();
+  disableConfig_.dcmDerivGain = 0.;
+  disableConfig_.dcmIntegralGain = 0.;
+  disableConfig_.dcmPropGain = 0.;
+  disableConfig_.comdErrorGain = 0.;
+  disableConfig_.zmpdGain = 0.;
+  disableConfig_.dfzAdmittance = 0.;
+  disableConfig_.vdcFrequency = 0.;
+  disableConfig_.vdcStiffness = 0.;
   zmpcc_.enabled(false);
   enabled_ = false;
 }
@@ -317,6 +320,7 @@ void StabilizerTask::configure(const StabilizerConfiguration & config)
 {
   checkConfiguration(config);
   lastConfig_ = config;
+  disableConfig_ = config;
   c_ = config;
   c_.clampGains();
   reconfigure_ = true;


### PR DESCRIPTION
The stabilizer is not disabled correctly even when you push the button to disable or set yaml configuration to disable.

This is because the `disable()` method updates the configuration to disable the stabilizer
https://github.com/jrl-umi3218/mc_rtc/blob/7889be0eaf8a13e4ba8761121883497b744539a6/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp#L296-L304
But the updated configuration is overwritten with original one in `update()` method (this is incorrect)
https://github.com/jrl-umi3218/mc_rtc/blob/7889be0eaf8a13e4ba8761121883497b744539a6/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp#L247-L251

I'm not sure if this is the best implementation, as the configuration is treated in a bit confusing way.