### PR TITLE
[mc_rbdyn] Allow a RobotModule to specify extra collision objects

### DIFF
--- a/doc/_data/schemas/mc_rbdyn/RobotModule.json
+++ b/doc/_data/schemas/mc_rbdyn/RobotModule.json
@@ -89,16 +89,35 @@
     },
     "convexHulls":
     {
-      "description": "Each key should be a body name, each entry in the vector associated to a key should be the collision object name and the path to the convex file",
+      "description": "Each key should be a collision object name, each entry in the vector associated to a key should be the parent's body name and the path to the convex file",
       "type": "object",
       "patternProperties":
       {
         "*": { "$ref": "#/definitions/string_pair" }
       }
     },
+    "collisionObjects":
+    {
+      "description": "Each key should be a collision object name, each entry in the vector associated to a key should be the parent's body name and a definition of the object",
+      "type": "object",
+      "patternProperties":
+      {
+        "*":
+        {
+          "type": "array",
+          "items":
+          [
+            { "type": "string" },
+            { "$ref": "/../../mc_rbdyn/S_ObjectPtr.json" }
+          ],
+          "minItems": 2,
+          "maxItems": 2
+        }
+      }
+    },
     "stpbvHulls":
     {
-      "description": "Each key should be a body name, each entry in the vector associated to a key should be the collision object name and the path to the convex file",
+      "description": "Each key should be a collision object name, each entry in the vector associated to a key should be the parent's body name and the path to the convex file",
       "type": "object",
       "patternProperties":
       {
@@ -180,8 +199,8 @@
       "type": "array", "items": { "type": "string" }
     },
     "gripperSafety": { "$ref": "/../../mc_rbdyn/RobotModule.Gripper.Safety.json" },
-    "lipmStabilizer": 
-    { 
+    "lipmStabilizer":
+    {
       "$ref": "/../../mc_rbdyn/StabilizerConfiguration.json",
       "description": "Default configuration for {% doxygen mc_tasks::lipm_stabilizer::StabilizerTask %}"
     }

--- a/doc/_data/schemas/mc_rbdyn/S_ObjectPtr.json
+++ b/doc/_data/schemas/mc_rbdyn/S_ObjectPtr.json
@@ -1,0 +1,89 @@
+{
+  "title": "mc_rbdyn::S_ObjectPtr",
+  "type": "object",
+  "properties":
+  {
+    "type":
+    {
+      "enum": ["box", "capsule", "cone", "cylinder", "point", "polyhedron", "sphere", "stp-bv", "stp-bv-p", "superellipsoid"],
+      "description": "Type of sch object"
+    },
+    "width":
+    {
+      "type": "number",
+      "description": "Width of the box (if type == box)"
+    },
+    "height":
+    {
+      "type": "number",
+      "description": "Height of the box (if type == box)<br/>Height of the cone (if type == cone)"
+    },
+    "depth":
+    {
+      "type": "number",
+      "description": "Depth of the box (if type == box)"
+    },
+    "angle":
+    {
+      "type": "number",
+      "description": "Angle of the cone (if type == cone)"
+    },
+    "p1":
+    {
+      "type": "array",
+      "items":
+      {
+        "type": "number"
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "description": "Starting point of the capsule (if type == capsule)<br/>Starting point of the cylinder (if type == cylinder)"
+    },
+    "p2":
+    {
+      "type": "array",
+      "items":
+      {
+        "type": "number"
+      },
+      "minItems": 3,
+      "maxItems": 3,
+      "description": "End point of the capsule (if type == capsule)<br/>End point of the cylinder (if type == cylinder)"
+    },
+    "radius":
+    {
+      "type": "number",
+      "description": "Radius of the capsule (if type == capsule)<br/>Radius of the cylinder (if type == cylinder)<br/>Radius of the sphere (if type == sphere)"
+    },
+    "filename":
+    {
+      "type": "string",
+      "description": "Path to the file with data for the object (if type == polyhedron or type == stp-bv or type == stp-bv-p"
+    },
+    "a":
+    {
+      "type": "number",
+      "description": "First parameter of the superellipsoid (if type == superellipsoid"
+    },
+    "b":
+    {
+      "type": "number",
+      "description": "Second parameter of the superellipsoid (if type == superellipsoid"
+    },
+    "c":
+    {
+      "type": "number",
+      "description": "Third parameter of the superellipsoid (if type == superellipsoid"
+    },
+    "epsilon1":
+    {
+      "type": "number",
+      "description": "Epsilon 1 parameter of the superellipsoid (if type == superellipsoid"
+    },
+    "epsilon2":
+    {
+      "type": "number",
+      "description": "Epsilon 2 parameter of the superellipsoid (if type == superellipsoid"
+    }
+  }
+}

--- a/doc/_examples/json/mc_rbdyn/S_ObjectPtr.json
+++ b/doc/_examples/json/mc_rbdyn/S_ObjectPtr.json
@@ -1,0 +1,19 @@
+// Box example
+{
+  "type": "box",
+  "width": 0.1,
+  "height": 0.2,
+  "depth": 0.3
+}
+// Sphere example
+{
+  "type": "sphere",
+  "radius": 0.5
+}
+// Cylinder example
+{
+  "type": "cylinder",
+  "p1": [0, 0, 0],
+  "p2": [0.5, 0, 0.5],
+  "radius": 0.1
+}

--- a/doc/_examples/yaml/mc_rbdyn/S_ObjectPtr.yaml
+++ b/doc/_examples/yaml/mc_rbdyn/S_ObjectPtr.yaml
@@ -1,0 +1,13 @@
+# Box example
+type: box
+width: 0.1
+height: 0.2
+depth: 0.3
+# Sphere example
+type: sphere
+radius: 0.5
+# Cylinder example
+type: cylinder
+p1: [0, 0, 0]
+p2: [0.5, 0, 0.5]
+radius: 0.1

--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -14,8 +14,6 @@
 #include <RBDyn/MultiBodyConfig.h>
 #include <RBDyn/MultiBodyGraph.h>
 
-#include <sch/S_Object/S_Object.h>
-
 #include <memory>
 #include <unordered_map>
 
@@ -30,7 +28,6 @@ struct MC_RBDYN_DLLAPI Robot
   friend struct Robots;
 
 public:
-  using S_ObjectPtr = std::shared_ptr<sch::S_Object>;
   using convex_pair_t = std::pair<std::string, S_ObjectPtr>;
 
 public:

--- a/include/mc_rbdyn/RobotModule.h
+++ b/include/mc_rbdyn/RobotModule.h
@@ -22,6 +22,8 @@
 
 #include <RBDyn/parsers/common.h>
 
+#include <sch/S_Object/S_Object.h>
+
 #include <array>
 #include <map>
 #include <vector>
@@ -30,6 +32,8 @@
 
 namespace mc_rbdyn
 {
+
+using S_ObjectPtr = std::shared_ptr<sch::S_Object>;
 
 /** Holds a vector of unique pointers
  *
@@ -311,7 +315,9 @@ struct MC_RBDYN_DLLAPI RobotModule
 
   /** Returns a map describing the convex hulls for the robot
    *
-   * A key defines a valid collision name, a value is composed of two strings:
+   * A key defines a valid collision name, there should be no collision with the names in \ref collisionObjects()
+   *
+   * A value is composed of two strings:
    *
    * 1. the name of the body the convex is attached to
    *
@@ -323,6 +329,24 @@ struct MC_RBDYN_DLLAPI RobotModule
   const std::map<std::string, std::pair<std::string, std::string>> & convexHull() const
   {
     return _convexHull;
+  }
+
+  /** Returns a map describing collision objects for the robot
+   *
+   * A key defines a valid collision name, there should be no collision with the names \ref convexHull()
+   *
+   * A value is composed of two strings:
+   *
+   * 1. the name of the body the object is attached to
+   *
+   * 2. the collision object
+   *
+   * The transformation between the convex and the body it's attached to are
+   * provided in a separate map see \ref collisionTransforms()
+   */
+  const std::map<std::string, std::pair<std::string, S_ObjectPtr>> & collisionObjects() const
+  {
+    return _collisionObjects;
   }
 
   /** Returns a map describing the STPBV hulls for the robot
@@ -546,6 +570,8 @@ struct MC_RBDYN_DLLAPI RobotModule
   std::map<std::string, std::vector<double>> _stance;
   /** \see convexHull() */
   std::map<std::string, std::pair<std::string, std::string>> _convexHull;
+  /** \see collisionObjects() */
+  std::map<std::string, std::pair<std::string, S_ObjectPtr>> _collisionObjects;
   /** \see stpbvHull() */
   std::map<std::string, std::pair<std::string, std::string>> _stpbvHull;
   /** Holds visual representation of bodies in the robot */

--- a/include/mc_rbdyn/configuration_io.h
+++ b/include/mc_rbdyn/configuration_io.h
@@ -25,6 +25,9 @@
 #include <mc_rbdyn/GripperSurface.h>
 #include <mc_rbdyn/PlanarSurface.h>
 
+/* Serialized/deserialized from/to shared pointers */
+#include <sch-core/S_Object.h>
+
 /* Require a Robots instance to be deserialized */
 #include <mc_rbdyn/Contact.h>
 #include <mc_rtc/logging.h>
@@ -65,6 +68,8 @@ DECLARE_IO(rbd::parsers::Material::Color)
 DECLARE_IO(rbd::parsers::Material::Texture)
 DECLARE_IO(rbd::parsers::Material)
 DECLARE_IO(rbd::parsers::Visual)
+
+DECLARE_IO(mc_rbdyn::S_ObjectPtr)
 
 DECLARE_IO(mc_rbdyn::Base)
 DECLARE_IO(mc_rbdyn::BodySensor)


### PR DESCRIPTION
Closes #162

This PR adds a new field to `RobotModule`, namely `_collisionObjects` (or `rm.collisionObjects()`), which allows to add collision primitives to a robot that can be named.

Example, in a C++ `RobotModule` implementation

```cpp
_collisionObjects["dummy_sphere"] = {"L_WRIST_Y_S", std::make_shared<sch::S_Sphere>(0.1)};  
_collisionObjects["dummy_box"] = {"R_WRIST_Y_S", std::make_shared<sch::S_Box>(0.1, 0.1, 0.1)};
_collisionObjects["dummy_cyl"] = {"R_WRIST_Y_S", std::make_shared<sch::S_Cylinder>(sch::Point3{0, 0, -0.25}, sch::Point3{0, 0, -0.5}, 0.1)}; 
```

And in a YAML module:

```yaml
collisionObjects:
  dummy_sphere:
    - panda_link7
    - type: sphere
      radius: 0.1
  dummy_box:
    - panda_link7
    - type: box
      width: 0.5
      height: 0.5
      depth: 0.5
  dummy_cylinder:
    - panda_link7
    - type: cylinder
      p1: [0.0, 0.0, 0.5]
      p2: [0.0, 0.0, 1.0]
      radius: 0.1
```