### PR TITLE
Better handle default form values

### DIFF
--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -475,7 +475,8 @@ protected:
   virtual void form_checkbox(const ElementId & /*formId*/,
                              const std::string & /*name*/,
                              bool /*required*/,
-                             bool /*default*/)
+                             bool /*default*/,
+                             bool /*default_from_user*/)
   {
   }
 
@@ -483,7 +484,8 @@ protected:
   virtual void form_integer_input(const ElementId & /*formId*/,
                                   const std::string & /*name*/,
                                   bool /*required*/,
-                                  int /*default*/)
+                                  int /*default*/,
+                                  bool /*default_from_user*/)
   {
   }
 
@@ -491,7 +493,8 @@ protected:
   virtual void form_number_input(const ElementId & /*formId*/,
                                  const std::string & /*name*/,
                                  bool /*required*/,
-                                 double /*default*/)
+                                 double /*default*/,
+                                 bool /*default_from_user*/)
   {
   }
 
@@ -499,7 +502,8 @@ protected:
   virtual void form_string_input(const ElementId & /*formId*/,
                                  const std::string & /*name*/,
                                  bool /*required*/,
-                                 const std::string & /*default*/)
+                                 const std::string & /*default*/,
+                                 bool /*default_from_user*/)
   {
   }
 
@@ -508,7 +512,8 @@ protected:
                                 const std::string & /*name*/,
                                 bool /*required*/,
                                 const Eigen::VectorXd & /*default*/,
-                                bool /*fixed_size*/)
+                                bool /*fixed_size*/,
+                                bool /*default_from_user*/)
   {
   }
 

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -471,50 +471,111 @@ protected:
     default_impl("Form", id);
   }
 
-  /** A checkbox within a form */
+  /** A checkbox within a form
+   *
+   * This is kept for backward compatibility, mc_rtc never calls this version and you should implement the full version
+   */
   virtual void form_checkbox(const ElementId & /*formId*/,
                              const std::string & /*name*/,
                              bool /*required*/,
-                             bool /*default*/,
+                             bool /*default*/)
+  {
+  }
+
+  /** A checkbox within a form */
+  virtual void form_checkbox(const ElementId & formId,
+                             const std::string & name,
+                             bool required,
+                             bool default_,
                              bool /*default_from_user*/)
+  {
+    form_checkbox(formId, name, required, default_);
+  }
+
+  /** An integer input within a form
+   *
+   * This is kept for backward compatibility, mc_rtc never calls this version and you should implement the full version
+   */
+  virtual void form_integer_input(const ElementId & /*formId*/,
+                                  const std::string & /*name*/,
+                                  bool /*required*/,
+                                  int /*default*/)
   {
   }
 
   /** An integer input within a form */
-  virtual void form_integer_input(const ElementId & /*formId*/,
-                                  const std::string & /*name*/,
-                                  bool /*required*/,
-                                  int /*default*/,
+  virtual void form_integer_input(const ElementId & formId,
+                                  const std::string & name,
+                                  bool required,
+                                  int default_,
                                   bool /*default_from_user*/)
+  {
+    form_integer_input(formId, name, required, default_);
+  }
+
+  /** A number input within a form
+   *
+   * This is kept for backward compatibility, mc_rtc never calls this version and you should implement the full version
+   */
+  virtual void form_number_input(const ElementId & /*formId*/,
+                                 const std::string & /*name*/,
+                                 bool /*required*/,
+                                 double /*default*/)
   {
   }
 
   /** A number input within a form */
-  virtual void form_number_input(const ElementId & /*formId*/,
+  virtual void form_number_input(const ElementId & formId,
+                                 const std::string & name,
+                                 bool required,
+                                 double default_,
+                                 bool /*default_from_user*/)
+  {
+    form_number_input(formId, name, required, default_);
+  }
+
+  /** A string input within a form
+   *
+   * This is kept for backward compatibility, mc_rtc never calls this version and you should implement the full version
+   */
+  virtual void form_string_input(const ElementId & /*formId*/,
                                  const std::string & /*name*/,
                                  bool /*required*/,
-                                 double /*default*/,
-                                 bool /*default_from_user*/)
+                                 const std::string & /*default*/)
   {
   }
 
   /** A string input within a form */
-  virtual void form_string_input(const ElementId & /*formId*/,
-                                 const std::string & /*name*/,
-                                 bool /*required*/,
-                                 const std::string & /*default*/,
+  virtual void form_string_input(const ElementId & formId,
+                                 const std::string & name,
+                                 bool required,
+                                 const std::string & default_,
                                  bool /*default_from_user*/)
   {
+    form_string_input(formId, name, required, default_);
   }
 
-  /** An array input within a form */
+  /** An array input within a form
+   *
+   * This is kept for backward compatibility, mc_rtc never calls this version and you should implement the full version
+   */
   virtual void form_array_input(const ElementId & /*formId*/,
                                 const std::string & /*name*/,
                                 bool /*required*/,
                                 const Eigen::VectorXd & /*default*/,
-                                bool /*fixed_size*/,
+                                bool /*fixed_size*/)
+  {
+  }
+
+  /** An array input within a form */
+  virtual void form_array_input(const ElementId & formId,
+                                const std::string & name,
+                                bool required,
+                                const Eigen::VectorXd & default_,
+                                bool fixed_size,
                                 bool /*default_from_user*/)
   {
+    form_array_input(formId, name, required, default_, fixed_size);
   }
 
   /** A combo input within a form

--- a/include/mc_rtc/gui/Form.h
+++ b/include/mc_rtc/gui/Form.h
@@ -115,20 +115,24 @@ template<typename T, Elements element>
 struct FormDataInput : public FormElement<FormDataInput<T, element>, element>
 {
   FormDataInput(const std::string & name, bool required, const T & def)
-  : FormElement<FormDataInput<T, element>, element>(name, required), def_(def)
+  : FormElement<FormDataInput<T, element>, element>(name, required), def_(def), has_def_(true)
   {
   }
 
-  FormDataInput(const std::string & name, bool required) : FormDataInput<T, element>(name, required, {}) {}
+  FormDataInput(const std::string & name, bool required) : FormDataInput<T, element>(name, required, {})
+  {
+    has_def_ = false;
+  }
 
   static constexpr size_t write_size_()
   {
-    return 1;
+    return 2;
   }
 
   void write_(mc_rtc::MessagePackBuilder & builder)
   {
     builder.write(def_);
+    builder.write(has_def_);
   }
 
   /** Invalid element */
@@ -136,6 +140,7 @@ struct FormDataInput : public FormElement<FormDataInput<T, element>, element>
 
 private:
   T def_;
+  bool has_def_;
 };
 
 using FormCheckbox = FormDataInput<bool, Elements::Checkbox>;
@@ -147,24 +152,27 @@ template<typename T>
 struct FormArrayInput : public FormElement<FormArrayInput<T>, Elements::ArrayInput>
 {
   FormArrayInput(const std::string & name, bool required, const T & def, bool fixed_size = true)
-  : FormElement<FormArrayInput, Elements::ArrayInput>(name, required), def_(def), fixed_size_(fixed_size)
+  : FormElement<FormArrayInput, Elements::ArrayInput>(name, required), def_(def), fixed_size_(fixed_size),
+    has_def_(true)
   {
   }
 
   FormArrayInput(const std::string & name, bool required, bool fixed_size = false)
   : FormArrayInput<T>(name, required, {}, fixed_size)
   {
+    has_def_ = false;
   }
 
   static constexpr size_t write_size_()
   {
-    return 2;
+    return 3;
   }
 
   void write_(mc_rtc::MessagePackBuilder & builder)
   {
     builder.write(def_);
     builder.write(fixed_size_);
+    builder.write(has_def_);
   }
 
   /** Invalid element */
@@ -173,6 +181,7 @@ struct FormArrayInput : public FormElement<FormArrayInput<T>, Elements::ArrayInp
 private:
   T def_;
   bool fixed_size_;
+  bool has_def_;
 };
 
 struct FormComboInput : public FormElement<FormComboInput, Elements::ComboInput>

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -684,19 +684,19 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
     switch(type)
     {
       case Elements::Checkbox:
-        form_checkbox(id, name, required, el[3]);
+        form_checkbox(id, name, required, el[3], el[4]);
         break;
       case Elements::IntegerInput:
-        form_integer_input(id, name, required, el[3]);
+        form_integer_input(id, name, required, el[3], el[4]);
         break;
       case Elements::NumberInput:
-        form_number_input(id, name, required, el[3]);
+        form_number_input(id, name, required, el[3], el[4]);
         break;
       case Elements::StringInput:
-        form_string_input(id, name, required, el[3]);
+        form_string_input(id, name, required, el[3], el[4]);
         break;
       case Elements::ArrayInput:
-        form_array_input(id, name, required, el[3], el[4]);
+        form_array_input(id, name, required, el[3], el[4], el[5]);
         break;
       case Elements::ComboInput:
         form_combo_input(id, name, required, el[3], el[4]);


### PR DESCRIPTION
This PR adds some information for the `ControlClient` so that it can distinguish wether a default form value was provided by the user or not.

The client should then act as follows when sending a form request:
- Send the default value if it was provided by the user, whether the data is required or not
- Error if the user did not provide a required field and the form has no default value
- Only send the data if the user provided a value when no default value is provided

Relates to #119

I have a PR ready to go for mc_rtc_rviz_panel that improves on form handling there