### PR TITLE
[GlobalPlugin] Give finer control on plugin calls

### DIFF
--- a/doc/_data/tutorials.yml
+++ b/doc/_data/tutorials.yml
@@ -131,6 +131,9 @@
   desc: These tutorials cover specific topics that most user should not have to deal with.
   tutorials:
     -
+      id: new-plugin
+      title: Implement a new plugin for mc_rtc
+    -
       id: new-interface
       title: Implement a new mc_rtc interface
     -

--- a/doc/_plugins/doxygen.rb.in
+++ b/doc/_plugins/doxygen.rb.in
@@ -68,7 +68,7 @@ module Jekyll
     def render(context)
       path = get_page(@text)
       if(path != "") then
-        "<a href=\"#{context.registers[:site].config['baseurl']}/doxygen.html##{path}\" target=\"blank_\">#{@text}</a>"
+        "<a href=\"#{context.registers[:site].config['baseurl']}/doxygen.html##{path}\" target=\"blank_\"><code>#{@text}</code></a>"
       else
         "#{@text}"
       end

--- a/doc/tutorials/advanced/new-plugin.html
+++ b/doc/tutorials/advanced/new-plugin.html
@@ -1,0 +1,48 @@
+---
+layout: tutorials
+toc: true
+---
+
+<p>In mc_rtc, every interface uses the {% doxygen mc_control::MCGlobalController %} class to initialize and run the controllers in the framework. In particular, they will run the {% doxygen mc_control::MCGlobalController::run() %} function on every iteration.</p>
+
+<p>The plugin system allows one to write a component that will run at the start and/or end of this run function.</p>
+
+<p>These plugins can be used for a variety of purpose:</p>
+
+<ul>
+  <li>Publish data using a 3rd-party middleware (for example, the ROS plugin)</li>
+  <li>Provide sensor data that is obtained with a different interface than the one where mc_rtc is running</li>
+  <li>Provide high-level functionalities that are above a single controller scope</li>
+</ul>
+
+{% include h2.html title="Writing your own plugin" %}
+
+<p>To write a plugin you should write a class that derives from the {% doxygen mc_control::GlobalPlugin %} class. Then you must implement the following functions:</p>
+
+<ul>
+  <li>{% doxygen mc_control::GlobalPlugin::init() %} is called by mc_rtc when {% doxygen mc_control::MCGlobalController::init() %} is called</li>
+  <li>{% doxygen mc_control::GlobalPlugin::reset() %} is called by mc_rtc when the controller is changed</li>
+  <li>{% doxygen mc_control::GlobalPlugin::before() %} is called by mc_rtc at the beginning of the run function</li>
+  <li>{% doxygen mc_control::GlobalPlugin::after() %} is called by mc_rtc at the end of the run function</li>
+</ul>
+
+<div class="alert alert-warning">mc_rtc will not call the reset method when the first controller is started &mdash; only the init method is called in that case. If needed, you can call the reset method from the init method.</div>
+
+<p>Finally, your class must be exported in a shared library that can be loaded by mc_rtc. The simplest way to achieve this is to use the <code>EXPORT_MC_RTC_PLUGIN</code> macro in mc_rtc, similar to its counterpart for controllers, states and robot modules.</p>
+
+{% include h3.html title="Customize what runs and when" %}
+
+<p>Optionally, you can override the {% doxygen mc_cotrol::GlobalPlugin::configuration() %} method. This lets you inform mc_rtc that your plugin does not to run before or after the run loop or whether your plugin should run when the controller is not running.</p>
+
+<p>By default, a plugin's <code>before</code> and <code>after</code> method is always called.</p>
+
+<div class="alert alert-info">It is even possible to load a plugin that does not run at all. This can be useful to register methods in the datastore or tasks and constraints in the meta task and constraint loaders.</div>
+
+{% include h3.html title="Autoload" %}
+
+<p>The CMake macro <code>add_plugin</code> automatically creates a CMake option named <code>AUTOLOAD_${PLUGIN}_PLUGIN</code>. When this option is <code>ON</code>, a special file will be installed in <code>${MC_RTC_INSTALL_PREFIX}/lib/mc_plugins/autoload</code>. When this file is present, the plugin will be automatically loaded regardless of the <code>Plugins</code> configuration entry.</p>
+
+{% include h2.html title="Get started" %}
+
+<p>Use the <a href="https://github.com/mc-rtc/new-plugin/">mc-rtc/new-plugin</a> template project to get started quickly. This template provides the barebone structure for a C++ <code>GlobalPlugin</code></p>
+

--- a/include/mc_control/GlobalPlugin.h
+++ b/include/mc_control/GlobalPlugin.h
@@ -22,6 +22,35 @@ struct MC_CONTROL_DLLAPI GlobalPlugin
 {
   virtual ~GlobalPlugin() = default;
 
+  /** Holds detail regarding how the plugin runs
+   *
+   * The plugin should return a configuration via \ref configuration()
+   *
+   * The default constructor for this object implies that:
+   * - the plugin uses before/after
+   * - the plugin runs even when the globla controller is not running
+   */
+  struct MC_CONTROL_DLLAPI GlobalPluginConfiguration
+  {
+    /** True if this plugin should run before the global controller (i.e. implements \ref before) */
+    bool should_run_before = true;
+    /** True if this plugin should run after the global controller (i.e. implements \ref after) */
+    bool should_run_after = true;
+    /** True if this plugin should run regardless of the gc.running status, if false, this plugin only runs when
+     * gc.running is true */
+    bool should_always_run = true;
+  };
+
+  /** Returns the plugin running configuration
+   *
+   * This impacts which functions are called and when they are called
+   *
+   */
+  virtual GlobalPluginConfiguration configuration()
+  {
+    return {};
+  }
+
   /** Initialize the plugin
    *
    * This function is called when the plugin is created by the

--- a/include/mc_control/mc_global_controller.h
+++ b/include/mc_control/mc_global_controller.h
@@ -812,10 +812,22 @@ private:
     ~PluginHandle();
     std::string name;
     GlobalPluginPtr plugin;
-    duration_ms plugin_before_dt{0};
-    duration_ms plugin_after_dt{0};
   };
   std::vector<PluginHandle> plugins_;
+  struct PluginBefore
+  {
+    GlobalPlugin * plugin;
+    duration_ms plugin_before_dt;
+  };
+  std::vector<PluginBefore> plugins_before_;
+  std::vector<GlobalPlugin *> plugins_before_always_;
+  struct PluginAfter
+  {
+    GlobalPlugin * plugin;
+    duration_ms plugin_after_dt;
+  };
+  std::vector<PluginAfter> plugins_after_;
+  std::vector<GlobalPlugin *> plugins_after_always_;
 
   void initGUI();
 

--- a/plugins/ROS/src/plugin/ROS.h
+++ b/plugins/ROS/src/plugin/ROS.h
@@ -21,6 +21,15 @@ struct ROSPlugin : public mc_control::GlobalPlugin
 
   void after(mc_control::MCGlobalController & controller) override;
 
+  inline mc_control::GlobalPlugin::GlobalPluginConfiguration configuration() override
+  {
+    mc_control::GlobalPlugin::GlobalPluginConfiguration out;
+    out.should_always_run = true;
+    out.should_run_after = true;
+    out.should_run_before = false;
+    return out;
+  }
+
   ~ROSPlugin() override;
 
 private:


### PR DESCRIPTION
A plugin can now provide a configuration object, this object can let mc_rtc know if:
- the plugin implements a before call
- the plugin implements an after call
- the plugin should be called when the global controller is not running

This also adds a documentation page about writing a new plugin for mc_rtc and a new template repository has been introduced [mc-rtc/new-plugin](https://github.com/mc-rtc/new-plugin)

Related to #146