### PR TITLE
[utils] Allow manually installed ROS systems

### DIFF
--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -107,7 +107,7 @@ readonly HELP_STRING="$(basename $0) [OPTIONS] ...
     --python-force-python3          {true, false} : whether to enforce the use of Python 3             (default $PYTHON_FORCE_PYTHON3)
     --python-build-2-and-3          {true, false} : whether to build both Python 2 and Python 3        (default $PYTHON_BUILD_PYTHON2_AND_PYTHON3)
     --with-ros-support              {true, false} : whether to build with ROS support                  (default $WITH_ROS_SUPPORT)
-    --ros-distro                    NAME          : the ros distro to use                              (default $ROS_DISTRO)
+    --ros-distro                    NAME          : the ros distro to use                              (default $MC_ROS_DISTRO)
     --install-system-dependencies      {true, false} : whether to install system packages              (default $INSTALL_SYSTEM_DEPENDENCIES)
     --clone-only                       {true, false} : only perform cloning                            (default $CLONE_ONLY)
     --skip-update                      {true, false} : skip git update                                 (default $SKIP_UPDATE)
@@ -282,7 +282,7 @@ do
 
         --ros-distro)
         i=$(($i+1))
-        ROS_DISTRO="${!i}"
+        MC_ROS_DISTRO="${!i}"
         ;;
 
         --allow-root)
@@ -432,9 +432,9 @@ then
   if [ -f $this_dir/config_build_and_install.`lsb_release -sc`.sh ]
   then
     . $this_dir/config_build_and_install.`lsb_release -sc`.sh
-    ROS_APT_DEPENDENCIES="ros-${ROS_DISTRO}-ros-base ros-${ROS_DISTRO}-rosdoc-lite ros-${ROS_DISTRO}-common-msgs ros-${ROS_DISTRO}-tf2-ros ros-${ROS_DISTRO}-xacro ros-${ROS_DISTRO}-rviz"
+    ROS_APT_DEPENDENCIES="ros-${MC_ROS_DISTRO}-ros-base ros-${MC_ROS_DISTRO}-rosdoc-lite ros-${MC_ROS_DISTRO}-common-msgs ros-${MC_ROS_DISTRO}-tf2-ros ros-${MC_ROS_DISTRO}-xacro ros-${MC_ROS_DISTRO}-rviz"
   else
-    ROS_DISTRO=""
+    MC_ROS_DISTRO=""
     APT_DEPENDENCIES=""
     ROS_APT_DEPENDENCIES=""
   fi
@@ -521,7 +521,7 @@ echo_log "   SKIP_UPDATE=$SKIP_UPDATE"
 echo_log "   SKIP_DIRTY_UPDATE=$SKIP_DIRTY_UPDATE"
 echo_log "   BUILD_LOGFILE=$BUILD_LOGFILE"
 echo_log "   ASK_USER_INPUT=$ASK_USER_INPUT"
-echo_log "   ROS_DISTRO=$ROS_DISTRO"
+echo_log "   MC_ROS_DISTRO=$MC_ROS_DISTRO"
 echo_log "   APT_DEPENDENCIES=$APT_DEPENDENCIES"
 echo_log "   ROS_APT_DEPENDENCIES=$ROS_APT_DEPENDENCIES"
 echo_log "   SUDO_CMD=$SUDO_CMD"
@@ -635,7 +635,7 @@ then
   echo_log "================================"
   echo_log "== Setting up ROS environment =="
   echo_log "================================"
-  if [ ! -e /opt/ros/${ROS_DISTRO}/setup.bash ] && $NOT_CLONE_ONLY
+  if [ "$ROS_DISTRO" != "$MC_ROS_DISTRO" ] && $NOT_CLONE_ONLY
   then
     if [ $OS = Ubuntu -o $OS = Debian ]
     then
@@ -649,11 +649,14 @@ then
   fi
   if [ $OS = Ubuntu -o $OS = Debian ]
   then
-    install_apt $ROS_APT_DEPENDENCIES
+    if $ROS_FROM_APT
+    then
+      install_apt $ROS_APT_DEPENDENCIES
+    fi 
   fi
   if $NOT_CLONE_ONLY
   then
-    . /opt/ros/${ROS_DISTRO}/setup.bash
+    . /opt/ros/${MC_ROS_DISTRO}/setup.bash
   fi
   CATKIN_DATA_WORKSPACE=$SOURCE_DIR/catkin_data_ws
   CATKIN_DATA_WORKSPACE_SRC=${CATKIN_DATA_WORKSPACE}/src

--- a/utils/build_and_install_default_config.sh
+++ b/utils/build_and_install_default_config.sh
@@ -3,6 +3,7 @@ export SOURCE_DIR=`cd $(dirname $0)/../../; pwd`
 export BUILD_SUBDIR=build
 export INSTALL_PREFIX="/usr/local"
 export WITH_ROS_SUPPORT="true"
+export $ROS_FROM_APT="true"
 export WITH_PYTHON_SUPPORT="true"
 export PYTHON_USER_INSTALL="false"
 export PYTHON_FORCE_PYTHON2="false"

--- a/utils/build_and_install_user_config.sample.sh
+++ b/utils/build_and_install_user_config.sample.sh
@@ -40,9 +40,10 @@
 
 ##
 # Whether to build with ROS support
-# On Ubuntu, ROS will be installed if you enable ROS support and it was not already installed. Otherwise, you are required to install ROS by yourself before attempting to install mc_rtc with ROS support;
+# On Ubuntu, ROS will be installed if you enable ROS support and ROS_FROM_APT and if it was not already installed. Otherwise, you are required to install ROS by yourself before attempting to install mc_rtc with ROS support;
 ##
 #export WITH_ROS_SUPPORT="true"
+#export ROS_FROM_APT="true"
 
 ##
 # Python settings

--- a/utils/config_build_and_install.bionic.sh
+++ b/utils/config_build_and_install.bionic.sh
@@ -1,4 +1,4 @@
-export ROS_DISTRO=melodic
+export MC_ROS_DISTRO=melodic
 export APT_DEPENDENCIES="wget cmake build-essential gfortran doxygen cython cython3 python-pip python-nose python3-nose python-numpy python3-numpy python-coverage python3-coverage python-setuptools python3-setuptools libeigen3-dev doxygen doxygen-latex libboost-all-dev libtinyxml2-dev libgeos++-dev libnanomsg-dev libyaml-cpp-dev libltdl-dev python-git python-pyqt5 qt5-default libqwt-qt5-dev python-matplotlib ninja-build"
 if $BUILD_BENCHMARKS
 then

--- a/utils/config_build_and_install.buster.sh
+++ b/utils/config_build_and_install.buster.sh
@@ -1,6 +1,7 @@
-export ROS_DISTRO=noetic
+export MC_ROS_DISTRO=noetic
 export APT_DEPENDENCIES="wget cmake build-essential gfortran doxygen cython cython3 python-pip python-nose python3-nose python-numpy python3-numpy python-coverage python3-coverage python-setuptools python3-setuptools libeigen3-dev doxygen doxygen-latex libboost-all-dev libtinyxml2-dev libgeos++-dev libnanomsg-dev libyaml-cpp-dev libltdl-dev python-git python-pyqt5 qt5-default libqwt-qt5-dev python-matplotlib ninja-build"
 if $BUILD_BENCHMARKS
 then
   export APT_DEPENDENCIES="$APT_DEPENDENCIES libbenchmark-dev"
 fi
+

--- a/utils/config_build_and_install.focal.sh
+++ b/utils/config_build_and_install.focal.sh
@@ -1,4 +1,4 @@
-export ROS_DISTRO=noetic
+export MC_ROS_DISTRO=noetic
 export SYSTEM_HAS_SPDLOG=ON
 export APT_DEPENDENCIES="curl wget cmake build-essential gfortran doxygen cython cython3 python-nose python3-nose python-numpy python3-numpy python-coverage python3-coverage python-setuptools python3-setuptools libeigen3-dev doxygen doxygen-latex libboost-all-dev libtinyxml2-dev libgeos++-dev libnanomsg-dev libyaml-cpp-dev libltdl-dev qt5-default libqwt-qt5-dev python3-matplotlib python3-pyqt5 libspdlog-dev ninja-build"
 if $BUILD_BENCHMARKS

--- a/utils/config_build_and_install.macos.sh
+++ b/utils/config_build_and_install.macos.sh
@@ -6,7 +6,7 @@ then
 fi
 
 export PIP_DEPENDENCIES="Cython coverage nose numpy matplotlib"
-if $WITH_ROS_SUPPORT && [ -z $ROS_DISTRO ]
+if $WITH_ROS_SUPPORT && [ -z $MC_ROS_DISTRO ]
 then
   echo "ROS support is disabled as ROS was not detected. If you have ROS, please source the setup script before running this script."
   export WITH_ROS_SUPPORT="false"

--- a/utils/config_build_and_install.trusty.sh
+++ b/utils/config_build_and_install.trusty.sh
@@ -1,4 +1,4 @@
-export ROS_DISTRO=indigo
+export MC_ROS_DISTRO=indigo
 export APT_DEPENDENCIES="wget cmake build-essential gfortran doxygen software-properties-common cython python-pip python-coverage python-numpy python-nose libtinyxml2-dev libboost-all-dev libgeos++-dev libgeos-dev libltdl-dev python-enum34 python-git qt4-default python-matplotlib ninja-build"
 
 mc_rtc_extra_steps()

--- a/utils/config_build_and_install.windows.sh
+++ b/utils/config_build_and_install.windows.sh
@@ -1,4 +1,4 @@
-export ROS_DISTRO=
+export MC_ROS_DISTRO=
 export PIP_DEPENDENCIES="Cython coverage nose numpy matplotlib pyqt5"
 export WITH_ROS_SUPPORT="false"
 export INSTALL_PREFIX=/c/devel/install

--- a/utils/config_build_and_install.xenial.sh
+++ b/utils/config_build_and_install.xenial.sh
@@ -1,4 +1,4 @@
-export ROS_DISTRO=kinetic
+export MC_ROS_DISTRO=kinetic
 export APT_DEPENDENCIES="wget cmake build-essential gfortran doxygen cython cython3 python-pip python-nose python3-nose python-numpy python3-numpy python-coverage python3-coverage python-setuptools python3-setuptools libeigen3-dev doxygen doxygen-latex libboost-all-dev libtinyxml2-dev libgeos++-dev libnanomsg-dev libyaml-cpp-dev libltdl-dev python-git python-pyqt5 qt5-default libqwt-qt5-dev python-matplotlib ninja-build"
 
 mc_rtc_extra_steps()


### PR DESCRIPTION
This PR makes it possible to run build_and_install.sh script when ROS is installed manually or from source.