### PR TITLE
[mc_tasks] Set name of stabilizer's subtasks

### DIFF
--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -352,6 +352,8 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
+  bool verbose = true; /**< Enable verbose output messages */
+
   SafetyThresholds safetyThresholds;
   FDQPWeights fdqpWeights;
 
@@ -428,6 +430,8 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
 
   void load(const mc_rtc::Configuration & config)
   {
+    config("verbose", verbose);
+
     if(config.has("safety_tresholds"))
     {
       safetyThresholds.load(config("safety_tresholds"));
@@ -548,6 +552,8 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   mc_rtc::Configuration save() const
   {
     mc_rtc::Configuration conf;
+    conf.add("verbose", verbose);
+
     conf.add("safety_tresholds", safetyThresholds);
     conf.add("fdqp_weights", fdqpWeights);
 

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -438,10 +438,10 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       fdqpWeights.load(config("fdqp_weights"));
     }
 
+    config("friction", friction);
     config("leftFootSurface", leftFootSurface);
     config("rightFootSurface", rightFootSurface);
     config("torsoBodyName", torsoBodyName);
-    config("friction", friction);
 
     if(config.has("admittance"))
     {
@@ -551,9 +551,10 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     conf.add("safety_tresholds", safetyThresholds);
     conf.add("fdqp_weights", fdqpWeights);
 
-    conf.add("torsoBodyName", torsoBodyName);
+    conf.add("friction", friction);
     conf.add("leftFootSurface", leftFootSurface);
     conf.add("rightFootSurface", rightFootSurface);
+    conf.add("torsoBodyName", torsoBodyName);
 
     conf.add("admittance");
     conf("admittance").add("cop", copAdmittance);

--- a/include/mc_tasks/MetaTask.h
+++ b/include/mc_tasks/MetaTask.h
@@ -49,13 +49,13 @@ public:
    * The name should be set before being added to the solver.
    *
    */
-  void name(const std::string & name)
+  virtual inline void name(const std::string & name)
   {
     name_ = name;
   }
 
   /** Get the name of the task */
-  inline const std::string & name() const
+  virtual inline const std::string & name() const
   {
     return name_;
   }

--- a/include/mc_tasks/MetaTask.h
+++ b/include/mc_tasks/MetaTask.h
@@ -55,7 +55,7 @@ public:
   }
 
   /** Get the name of the task */
-  virtual inline const std::string & name() const
+  inline const std::string & name() const
   {
     return name_;
   }

--- a/include/mc_tasks/TrajectoryTaskGeneric.hpp
+++ b/include/mc_tasks/TrajectoryTaskGeneric.hpp
@@ -436,6 +436,7 @@ void TrajectoryTaskGeneric<T>::addToLogger(mc_rtc::Logger & logger)
                        name_ + "_damping", [this]() { return damping_(0); },
                        name_ + "_stiffness", [this]() { return stiffness_(0); });
   // clang-format on
+  MC_RTC_LOG_HELPER(name_ + "_weight", weight_);
   MC_RTC_LOG_GETTER(name_ + "_dimWeight", dimWeight);
   MC_RTC_LOG_HELPER(name_ + "_dimDamping", damping_);
   MC_RTC_LOG_HELPER(name_ + "_dimStiffness", stiffness_);

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -95,14 +95,7 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
                  unsigned int robotIndex,
                  double dt);
 
-  /** Set a name for the task
-   *
-   * This name will be used to identify the task in logs, GUI...
-   *
-   * The name should be set before being added to the solver.
-   *
-   */
-  virtual inline void name(const std::string & name) override
+  inline void name(const std::string & name) override
   {
     name_ = name;
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -95,6 +95,30 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
                  unsigned int robotIndex,
                  double dt);
 
+  /** Set a name for the task
+   *
+   * This name will be used to identify the task in logs, GUI...
+   *
+   * The name should be set before being added to the solver.
+   *
+   */
+  virtual inline void name(const std::string & name) override
+  {
+    name_ = name;
+
+    // Rename the tasks managed by the stabilizer
+    // Doing so helps making the logs more consistent, and having a fixed name
+    // allows for predifined custom plots in the log ui.
+    const auto n = name_ + "_Tasks";
+    comTask->name(n + "_com");
+    footTasks.at(ContactState::Left)->name(n + "_cop_left");
+    footTasks.at(ContactState::Right)->name(n + "_cop_right");
+    pelvisTask->name(n + "_pelvis");
+    torsoTask->name(n + "_torso");
+  }
+
+  using MetaTask::name;
+
   /**
    * @brief Resets the stabilizer tasks and parameters to their default configuration.
    *

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -212,7 +212,10 @@ void StabilizerTask::updateContacts(mc_solver::QPSolver & solver)
     // Remove previous contacts
     for(const auto & contactT : contactTasks)
     {
-      mc_rtc::log::info("{}: Removing contact {}", name(), contactT->surface());
+      if(c_.verbose)
+      {
+        mc_rtc::log::info("{}: Removing contact {}", name(), contactT->surface());
+      }
       MetaTask::removeFromLogger(*contactT, *solver.logger());
       MetaTask::removeFromSolver(*contactT, solver);
     }
@@ -223,7 +226,10 @@ void StabilizerTask::updateContacts(mc_solver::QPSolver & solver)
     for(const auto contactState : addContacts_)
     {
       auto footTask = footTasks[contactState];
-      mc_rtc::log::info("{}: Adding contact {}", name(), footTask->surface());
+      if(c_.verbose)
+      {
+        mc_rtc::log::info("{}: Adding contact {}", name(), footTask->surface());
+      }
       MetaTask::addToSolver(*footTask, solver);
       MetaTask::addToLogger(*footTask, *solver.logger());
       contactTasks.push_back(footTask);

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -54,14 +54,7 @@ StabilizerTask::StabilizerTask(const mc_rbdyn::Robots & robots,
   torsoTask = std::make_shared<mc_tasks::OrientationTask>(torsoBodyName, robots_, robotIndex_);
 
   // Rename the tasks managed by the stabilizer
-  // Doing so helps making the logs more consistent, and having a fixed name
-  // allows for predifined custom plots in the log ui.
-  const auto n = name_ + "_Tasks";
-  comTask->name(n + "_com");
-  leftCoP->name(n + "_cop_left");
-  rightCoP->name(n + "_cop_right");
-  pelvisTask->name(n + "_pelvis");
-  torsoTask->name(n + "_torso");
+  name(name_);
 }
 
 StabilizerTask::StabilizerTask(const mc_rbdyn::Robots & robots,


### PR DESCRIPTION
This PR is to rename the stabilizer's subtasks correctly when setting the name of StabilizerTask. This PR also contains another commit to save log of weight in TrajectoryTaskGeneric.

It has nothing to do with the contents of the Pull Request, but StabilizerTask outputs a lot of messages on the following lines, which makes it difficult to see other important messages in the loco-manipulation experiments. Is there a good way to easily enable / disable these debug outputs?

https://github.com/jrl-umi3218/mc_rtc/blob/e8081721fe07d1300bcd69b1ab0a36f05b3bacfc/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp#L222
https://github.com/jrl-umi3218/mc_rtc/blob/e8081721fe07d1300bcd69b1ab0a36f05b3bacfc/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp#L233