### PR TITLE
[mc_tasks] add getter of comOffsetTarget_ in StabilizerTask

### DIFF
--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -346,6 +346,11 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return measuredCoM_;
   }
 
+  inline const Eigen::Vector3d & comOffsetTarget() noexcept
+  {
+    return comOffsetTarget_;
+  }
+
   inline bool inContact(ContactState state) const noexcept
   {
     return contacts_.count(state);


### PR DESCRIPTION
This is necessary for https://gite.lirmm.fr/jrp-2019/mc_hwm_planner/-/merge_requests/14