### PR TITLE
Implement PostureTask dimWeight

### DIFF
--- a/include/mc_tasks/PostureTask.h
+++ b/include/mc_tasks/PostureTask.h
@@ -22,25 +22,41 @@ public:
   /*! \brief Load parameters from a Configuration object */
   void load(mc_solver::QPSolver & solver, const mc_rtc::Configuration & config) override;
 
-  /** Does not make much sense for PostureTask, prefer selectActiveJoints
-   * or selectUnactiveJoints */
-  void dimWeight(const Eigen::VectorXd &) override {}
-
-  /** Does not make much sense for PostureTask, prefer selectActiveJoints
-   * or selectUnactiveJoints */
-  Eigen::VectorXd dimWeight() const override
+  /*! \brief Set the task dimensional weight
+   *
+   * For simple cases (using 0/1 as weights) prefer \ref selectActiveJoints or \ref selectUnactiveJoints which are
+   * simpler to use
+   */
+  inline void dimWeight(const Eigen::VectorXd & dimW) override
   {
-    return Eigen::VectorXd::Zero(0);
+    pt_.dimWeight(dimW);
   }
 
+  Eigen::VectorXd dimWeight() const override
+  {
+    return pt_.dimWeight();
+  }
+
+  /*! \brief Select active joints for this task
+   *
+   * Manipulate \ref dimWeight() to achieve its effect
+   */
   void selectActiveJoints(mc_solver::QPSolver & solver,
                           const std::vector<std::string> & activeJointsName,
                           const std::map<std::string, std::vector<std::array<int, 2>>> & activeDofs = {}) override;
 
+  /*! \brief Select inactive joints for this task
+   *
+   * Manipulate \ref dimWeight() to achieve its effect
+   */
   void selectUnactiveJoints(mc_solver::QPSolver & solver,
                             const std::vector<std::string> & unactiveJointsName,
                             const std::map<std::string, std::vector<std::array<int, 2>>> & unactiveDofs = {}) override;
 
+  /*! \brief Reset the joint selector effect
+   *
+   * Reset dimWeight to ones
+   */
   void resetJointsSelector(mc_solver::QPSolver & solver) override;
 
   Eigen::VectorXd eval() const override;

--- a/tests/controllers/CMakeLists.txt
+++ b/tests/controllers/CMakeLists.txt
@@ -114,7 +114,7 @@ controller_test_construction_failure(NoDestroyController)
 controller_test_construction_failure(NoCreateController)
 
 set(LOG_ENABLED "true")
-controller_test_run(TestPostureController 400)
+controller_test_run(TestPostureController 1000)
 # These tests require a /tmp LogDirectory and symlinks to access the
 # *-latest.log symlink created by mc_rtc
 if(NOT DEFINED PYTHON_DEB_ROOT)
@@ -125,7 +125,7 @@ if(NOT DEFINED PYTHON_DEB_ROOT)
   if(ENABLE_FAST_TESTS)
     set(NRITER 5)
   else()
-    set(NRITER 400)
+    set(NRITER 1000)
   endif()
   add_test(NAME TestPostureControllerLog COMMAND python "${CMAKE_CURRENT_SOURCE_DIR}/check_log.py" "TestPostureController" ${NRITER} ${UTILS_BIN_DIR})
 


### PR DESCRIPTION
Use `tasks::qp::PostureTask::dimWeight` introduced in https://github.com/jrl-umi3218/Tasks/pull/77

- Improve implementation of selectActiveJoint/selectUnactiveJoints
- Provide accessor/setter