### PR TITLE
[mc_tasks] set roll and pitch of target torso zero.

### DIFF
--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -774,7 +774,7 @@ void StabilizerTask::run()
 
   // Update orientation tasks according to feet orientation
   sva::PTransformd X_0_a = anchorFrame(robot());
-  Eigen::Matrix3d pelvisOrientation = X_0_a.rotation();
+  Eigen::Matrix3d pelvisOrientation = sva::RotZ(mc_rbdyn::rpyFromMat(X_0_a.rotation())[2]);
   pelvisTask->orientation(pelvisOrientation);
   torsoTask->orientation(mc_rbdyn::rpyToMat({0, c_.torsoPitch, 0}) * pelvisOrientation);
 


### PR DESCRIPTION
The balancing issue in loco-manipoulation has been solved with this patch (https://gite.lirmm.fr/jrp-2019/mc_hwm_planner/-/issues/14#note_21892).

This change was suggested by @mitsuharu-morisawa to avoid using the feed back value as a reference. `anchorFrame(robot())` is modified by the `CoPTask`, which is unsuitable for use as a reference of the base link rotation.

This change has been used in HRP5P experiments for several months and in HRP2KAI experiments for several weeks.
I don't know if we can merge this change as it is, but I will make a Pull Request because it is a change that solves a major issue in balance control.