### PR TITLE
[mc_log_ui] Fix string value treatment

### DIFF
--- a/include/mc_rtc/gui/Form.h
+++ b/include/mc_rtc/gui/Form.h
@@ -191,8 +191,8 @@ struct FormComboInput : public FormElement<FormComboInput, Elements::ComboInput>
                         const std::vector<std::string> & values,
                         bool send_index = false,
                         int def = -1)
-  : FormElement<FormComboInput, Elements::ComboInput>(name, required), values_(values), def_(def),
-    send_index_(send_index)
+  : FormElement<FormComboInput, Elements::ComboInput>(name, required), values_(values), send_index_(send_index),
+    def_(def)
   {
   }
 

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -179,7 +179,7 @@ class PlotPolygonAxis(object):
     i0 = 0
     label = y[i0]
     while i < len(y):
-      if y[i] == label and i + 1 != len(y):
+      if y[i] == label and i + 1 < len(y):
         # Continue if the y value is same as that of previous timestep
         i += 1
         continue

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -180,19 +180,24 @@ class PlotPolygonAxis(object):
     label = y[i0]
     while i < len(y):
       if y[i] == label and i + 1 != len(y):
+        # Continue if the y value is same as that of previous timestep
         i += 1
         continue
+      # Add new color if the y value is new
       if label not in self.colors[y_label]:
         self.colors[y_label][label] = self.figure._next_poly_color()
       color = self.colors[y_label][label]
+      # Determine the last timestep of this label
       if i + 1 < len(y) and not np.isnan(x[i + 1]):
         xi = x[i + 1]
       else:
         xi = x[i]
         if np.isnan(xi):
           xi = x[i - 1]
+      # Make rectangle to draw
       if len(label) > 0:
         self.plots[y_label].append(self._axis.add_patch(Rectangle((x[i0], 0), xi - x[i0], 1, label = label, facecolor = color)))
+      # Store the last value. This is the initial value for the next label.
       i0 = i
       if i < len(y):
         label = y[i0]

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -182,9 +182,6 @@ class PlotPolygonAxis(object):
       if y[i] == label and i + 1 != len(y):
         i += 1
         continue
-      if len(label) == 0:
-        i += 1
-        continue
       if label not in self.colors[y_label]:
         self.colors[y_label][label] = self.figure._next_poly_color()
       color = self.colors[y_label][label]
@@ -194,7 +191,8 @@ class PlotPolygonAxis(object):
         xi = x[i]
         if np.isnan(xi):
           xi = x[i - 1]
-      self.plots[y_label].append(self._axis.add_patch(Rectangle((x[i0], 0), xi - x[i0], 1, label = label, facecolor = color)))
+      if len(label) > 0:
+        self.plots[y_label].append(self._axis.add_patch(Rectangle((x[i0], 0), xi - x[i0], 1, label = label, facecolor = color)))
       i0 = i
       if i < len(y):
         label = y[i0]

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -184,7 +184,9 @@ class PlotPolygonAxis(object):
         i += 1
         continue
       # Add new color if the y value is new
+      new_label = False
       if label not in self.colors[y_label]:
+        new_label = True
         self.colors[y_label][label] = self.figure._next_poly_color()
       color = self.colors[y_label][label]
       # Determine the last timestep of this label
@@ -193,6 +195,9 @@ class PlotPolygonAxis(object):
         xi = x[i - 1]
       # Make rectangle to draw
       if len(label) > 0:
+        if not new_label:
+          # Do not display labels in legends from the second time
+          label = "_" + label
         self.plots[y_label].append(self._axis.add_patch(Rectangle((x[i0], 0), xi - x[i0], 1, label = label, facecolor = color)))
       # Store the last value. This is the initial value for the next label.
       i0 = i

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -199,8 +199,7 @@ class PlotPolygonAxis(object):
         self.plots[y_label].append(self._axis.add_patch(Rectangle((x[i0], 0), xi - x[i0], 1, label = label, facecolor = color)))
       # Store the last value. This is the initial value for the next label.
       i0 = i
-      if i < len(y):
-        label = y[i0]
+      label = y[i0]
       i += 1
     return True
   def legend(self):

--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -188,12 +188,9 @@ class PlotPolygonAxis(object):
         self.colors[y_label][label] = self.figure._next_poly_color()
       color = self.colors[y_label][label]
       # Determine the last timestep of this label
-      if i + 1 < len(y) and not np.isnan(x[i + 1]):
-        xi = x[i + 1]
-      else:
-        xi = x[i]
-        if np.isnan(xi):
-          xi = x[i - 1]
+      xi = x[i]
+      if np.isnan(xi):
+        xi = x[i - 1]
       # Make rectangle to draw
       if len(label) > 0:
         self.plots[y_label].append(self._axis.add_patch(Rectangle((x[i0], 0), xi - x[i0], 1, label = label, facecolor = color)))


### PR DESCRIPTION
Fix string value treatment in mc_log_ui. The main fix is to draw the string with the value of the first time step empty correctly.

Follwing bin file is mc_rtc_log generated by Posture controller with https://github.com/jrl-umi3218/mc_rtc/commit/bcb393909b458372384c21075e86cd5fba292fc2 patch.
[mc-log-ui-string-20210731.zip](https://github.com/jrl-umi3218/mc_rtc/files/6911295/mc-log-ui-string-20210731.zip)

With the mc_log_ui without this PR, `Label1` is drawn correctly.
![label1](https://user-images.githubusercontent.com/6636600/127742366-9bdea6fa-6bb5-4cad-a256-693e1b24a663.png)

But `Label2` is not drawn correctly (nothing is drawn).
![label2_before](https://user-images.githubusercontent.com/6636600/127742376-cfb24d6e-ebca-4589-9472-ffa0b7635311.png)

With this PR, it is also drawn correctly.
![label2](https://user-images.githubusercontent.com/6636600/127742399-effe1ab7-ed97-4569-ae05-b577bd5acc14.png)
