### PR TITLE
[mc_rbdyn] Fix an issue with robot copy

### DIFF
--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -949,16 +949,8 @@ protected:
         const sva::PTransformd * base = nullptr,
         const std::string & baseName = "");
 
-  /** Copy existing Robot with a new base
-   *
-   * \throws std::runtime_error if a robot named <copyName> already exists
-   **/
-  void copy(Robots & robots, const std::string & copyName, unsigned int robots_idx, const Base & base) const;
-  /** Copy existing Robot
-   *
-   * \throws std::runtime_error if a robot named <copyName> already exists
-   **/
-  void copy(Robots & robots, const std::string & copyName, unsigned int robots_idx) const;
+  /** Copy loaded data from this robot to a new robot **/
+  void copyLoadedData(Robot & destination) const;
 
   /** Used to set the surfaces' X_b_s correctly */
   void fixSurfaces();

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -385,17 +385,16 @@ Robot::Robot(const std::string & name,
         collisionTransforms_[o.first] = sva::PTransformd::Identity();
       }
     }
+    for(const auto & b : mb().bodies())
+    {
+      collisionTransforms_[b.name()] = sva::PTransformd::Identity();
+    }
+    for(const auto & p : module_.collisionTransforms())
+    {
+      collisionTransforms_[p.first] = p.second;
+    }
+    fixCollisionTransforms();
   }
-
-  for(const auto & b : mb().bodies())
-  {
-    collisionTransforms_[b.name()] = sva::PTransformd::Identity();
-  }
-  for(const auto & p : module_.collisionTransforms())
-  {
-    collisionTransforms_[p.first] = p.second;
-  }
-  fixCollisionTransforms();
 
   if(loadFiles)
   {
@@ -1368,10 +1367,8 @@ const sva::MotionVecd Robot::accW() const
   return sva::PTransformd{rot} * mbc().bodyAccB[0];
 }
 
-void Robot::copy(Robots & robots, const std::string & copyName, unsigned int robots_idx, const Base & base) const
+void Robot::copyLoadedData(Robot & robot) const
 {
-  robots.robots_.emplace_back(Robot(copyName, robots, robots_idx, false, &base.X_0_s, base.baseName));
-  auto & robot = robots.robots_.back();
   for(const auto & s : surfaces_)
   {
     robot.surfaces_[s.first] = s.second->copy();
@@ -1381,20 +1378,12 @@ void Robot::copy(Robots & robots, const std::string & copyName, unsigned int rob
   {
     robot.convexes_[cH.first] = {cH.second.first, S_ObjectPtr(cH.second.second->clone())};
   }
+  robot.collisionTransforms_ = collisionTransforms_;
+  robot.fixCollisionTransforms();
   fixSCH(robot, robot.convexes_, robot.collisionTransforms_);
   for(size_t i = 0; i < forceSensors_.size(); ++i)
   {
     robot.forceSensors_[i].copyCalibrator(forceSensors_[i]);
-  }
-}
-
-void Robot::copy(Robots & robots, const std::string & copyName, unsigned int robots_idx) const
-{
-  robots.robots_.emplace_back(Robot(copyName, robots, robots_idx, false));
-  auto & robot = robots.robots_.back();
-  for(const auto & s : surfaces_)
-  {
-    robot.surfaces_[s.first] = s.second->copy();
   }
 }
 

--- a/tests/test_mc_rbdyn.cpp
+++ b/tests/test_mc_rbdyn.cpp
@@ -6,6 +6,8 @@
 #include <chrono>
 #include <random>
 
+#include <sch/S_Object/S_Sphere.h>
+
 mc_rbdyn::Robots & get_robots()
 {
   static std::shared_ptr<mc_rbdyn::Robots> robots_ptr = nullptr;
@@ -21,47 +23,82 @@ mc_rbdyn::Robots & get_robots()
   return *robots_ptr;
 }
 
-BOOST_AUTO_TEST_CASE(TestRobotLoading)
+void TestRobotLoadingCommon(mc_rbdyn::RobotModulePtr rm, mc_rbdyn::RobotModulePtr envrm)
 {
-  configureRobotLoader();
-  auto rm = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
-  auto envrm = mc_rbdyn::RobotLoader::get_robot_module("env", std::string(mc_rtc::MC_ENV_DESCRIPTION_PATH),
-                                                       std::string("ground"));
   // Non-unique names
   BOOST_REQUIRE_THROW(mc_rbdyn::loadRobots({rm, rm}), std::runtime_error);
   std::shared_ptr<mc_rbdyn::Robots> robots_ptr = nullptr;
   BOOST_REQUIRE_NO_THROW(robots_ptr = mc_rbdyn::loadRobots({rm, envrm}));
   BOOST_REQUIRE(robots_ptr->hasRobot(rm->name));
   BOOST_REQUIRE(robots_ptr->hasRobot(envrm->name));
-  auto & robot = robots_ptr->robot(rm->name);
-  auto & env = robots_ptr->robot(envrm->name);
-  BOOST_REQUIRE_EQUAL(robot.name(), rm->name);
-  BOOST_REQUIRE_EQUAL(robot.robotIndex(), 0);
-  BOOST_REQUIRE_EQUAL(env.name(), envrm->name);
-  BOOST_REQUIRE_EQUAL(env.robotIndex(), 1);
-  robots_ptr->rename(robot.name(), "renamed");
-  BOOST_REQUIRE(robots_ptr->hasRobot("renamed"));
-  auto & renamed = robots_ptr->robot("renamed");
-  BOOST_REQUIRE_EQUAL(renamed.name(), "renamed");
-  BOOST_REQUIRE_EQUAL(robot.name(), "renamed");
-  BOOST_REQUIRE_EQUAL(renamed.robotIndex(), 0);
-  BOOST_REQUIRE_EQUAL(robot.robotIndex(), 0);
-  BOOST_REQUIRE(robots_ptr->hasRobot(envrm->name));
-  BOOST_REQUIRE_EQUAL(robots_ptr->robot(envrm->name).name(), envrm->name);
-  BOOST_REQUIRE_EQUAL(robots_ptr->robot(envrm->name).robotIndex(), 1);
+  {
+    auto & robot = robots_ptr->robot(rm->name);
+    auto & env = robots_ptr->robot(envrm->name);
+    BOOST_REQUIRE_EQUAL(robot.name(), rm->name);
+    BOOST_REQUIRE_EQUAL(robot.robotIndex(), 0);
+    BOOST_REQUIRE_EQUAL(env.name(), envrm->name);
+    BOOST_REQUIRE_EQUAL(env.robotIndex(), 1);
+    robots_ptr->rename(robot.name(), "renamed");
+    BOOST_REQUIRE(robots_ptr->hasRobot("renamed"));
+    auto & renamed = robots_ptr->robot("renamed");
+    BOOST_REQUIRE_EQUAL(renamed.name(), "renamed");
+    BOOST_REQUIRE_EQUAL(robot.name(), "renamed");
+    BOOST_REQUIRE_EQUAL(renamed.robotIndex(), 0);
+    BOOST_REQUIRE_EQUAL(robot.robotIndex(), 0);
+    BOOST_REQUIRE(robots_ptr->hasRobot(envrm->name));
+    BOOST_REQUIRE_EQUAL(robots_ptr->robot(envrm->name).name(), envrm->name);
+    BOOST_REQUIRE_EQUAL(robots_ptr->robot(envrm->name).robotIndex(), 1);
+    BOOST_REQUIRE_NO_THROW(robots_ptr->robotCopy(robot, "robotCopy"));
+  }
 
-  BOOST_REQUIRE_NO_THROW(robots_ptr->robotCopy(robot, "robotCopy"));
   BOOST_REQUIRE(robots_ptr->hasRobot("robotCopy"));
   auto & robotCopy = robots_ptr->robots().back();
   BOOST_REQUIRE(robotCopy.name() != rm->name);
   BOOST_REQUIRE_EQUAL(robots_ptr->robot("robotCopy").name(), "robotCopy");
   BOOST_REQUIRE_EQUAL(robotCopy.robotIndex(), 2);
   BOOST_REQUIRE_EQUAL(robots_ptr->robots().back().name(), "robotCopy");
+  auto & robot = robots_ptr->robot("renamed");
+  for(const auto & c : robot.convexes())
+  {
+    BOOST_REQUIRE(robotCopy.hasConvex(c.first));
+  }
+  for(const auto & s : robot.surfaces())
+  {
+    BOOST_REQUIRE(robotCopy.hasSurface(s.first));
+  }
+  for(const auto & fs : robot.forceSensors())
+  {
+    BOOST_REQUIRE(robotCopy.hasForceSensor(fs.name()));
+  }
+  for(const auto & bs : robot.bodySensors())
+  {
+    BOOST_REQUIRE(robotCopy.hasBodySensor(bs.name()));
+  }
 
   robots_ptr->removeRobot("robotCopy");
   BOOST_REQUIRE(!robots_ptr->hasRobot("robotCopy"));
   BOOST_REQUIRE(robots_ptr->hasRobot("renamed"));
   BOOST_REQUIRE(robots_ptr->hasRobot(envrm->name));
+}
+
+BOOST_AUTO_TEST_CASE(TestRobotLoading)
+{
+  configureRobotLoader();
+  auto rm = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
+  auto envrm = mc_rbdyn::RobotLoader::get_robot_module("env", std::string(mc_rtc::MC_ENV_DESCRIPTION_PATH),
+                                                       std::string("ground"));
+  TestRobotLoadingCommon(rm, envrm);
+}
+
+BOOST_AUTO_TEST_CASE(TestRobotLoadingWithCollisionObjects)
+{
+  configureRobotLoader();
+  auto rm = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
+  rm->_collisionObjects["L_HAND_SPHERE"] = {"L_WRIST_Y_S", std::make_shared<sch::S_Sphere>(0.09)};
+  rm->_collisionTransforms["L_HAND_SPHERE"] = sva::PTransformd::Identity();
+  auto envrm = mc_rbdyn::RobotLoader::get_robot_module("env", std::string(mc_rtc::MC_ENV_DESCRIPTION_PATH),
+                                                       std::string("ground"));
+  TestRobotLoadingCommon(rm, envrm);
 }
 
 BOOST_AUTO_TEST_CASE(TestRobotPosWVelWAccW)


### PR DESCRIPTION
Previous implementation could fail to copy the robot properly as the
robots_ vector was resized while copying a robot. This commit fixes this
by reforming a valid reference to the copied robot if needed