### PR TITLE
[mc_control/fsm] print a message of next state starting after teardown of previous state

### DIFF
--- a/src/mc_control/fsm/Executor.cpp
+++ b/src/mc_control/fsm/Executor.cpp
@@ -196,7 +196,6 @@ void Executor::next(Controller & ctl)
   }
   ready_ = false;
   transition_triggered_ = false;
-  mc_rtc::log::success("Starting state {}", next_state_);
   if(state_)
   {
     auto state_teardown_start = clock::now();
@@ -204,6 +203,7 @@ void Executor::next(Controller & ctl)
     ctl.resetPostures();
     state_teardown_dt_ = clock::now() - state_teardown_start;
   }
+  mc_rtc::log::success("Starting state {}", next_state_);
   if(config_.has("configs") && config_("configs").has(next_state_))
   {
     auto state_create_start = clock::now();


### PR DESCRIPTION
When printing a message from `teardown()`, it is easier to understand if it is displayed before the message of starting the next state.

Following is the example of a printing message when switching a state from `HwmStraightObjectMotion` to `HwmUpdateObjectPosePost`.

Before PR:

```
[success] Completed HwmStraightObjectMotion - output: OK
[success] Starting state HwmUpdateObjectPosePost
[info] [HwmStraightObjectMotion] Teardown
```

After PR:
```
[success] Completed HwmStraightObjectMotion - output: OK
[info] [HwmStraightObjectMotion] Teardown
[success] Starting state HwmUpdateObjectPosePost
```
