### PR TITLE
[mc_tasks] Updating mimic joint posture targets

### DIFF
--- a/src/mc_tasks/PostureTask.cpp
+++ b/src/mc_tasks/PostureTask.cpp
@@ -205,6 +205,19 @@ void PostureTask::target(const std::map<std::string, std::vector<double>> & join
          == j.second.size())
       {
         q[robots_.robot(rIndex_).jointIndexByName(j.first)] = j.second;
+        if(mimics_.count(j.first))
+        {
+          for(auto ji : mimics_.at(j.first))
+          {
+            const auto & mimic = robots_.robot(rIndex_).mb().joint(ji);
+            if(static_cast<size_t>(mimic.dof()) == j.second.size())
+            {
+              for(unsigned i = 0; i < j.second.size(); i++){
+                q[static_cast<size_t>(ji)][i] = mimic.mimicMultiplier() * j.second[i] + mimic.mimicOffset();
+              }
+            }
+          }
+        }
       }
       else
       {

--- a/src/mc_tasks/PostureTask.cpp
+++ b/src/mc_tasks/PostureTask.cpp
@@ -212,7 +212,8 @@ void PostureTask::target(const std::map<std::string, std::vector<double>> & join
             const auto & mimic = robots_.robot(rIndex_).mb().joint(ji);
             if(static_cast<size_t>(mimic.dof()) == j.second.size())
             {
-              for(unsigned i = 0; i < j.second.size(); i++){
+              for(unsigned i = 0; i < j.second.size(); i++)
+              {
                 q[static_cast<size_t>(ji)][i] = mimic.mimicMultiplier() * j.second[i] + mimic.mimicOffset();
               }
             }


### PR DESCRIPTION
When setting a posture target via a call to the `PostureTask::target` function, the mimic joint targets don't get updated, resulting in an unexpected/undesired robot behavior.
It is done, however, when setting the posture task target in GUI via `NumbeSlider` or `NumberInput`.

This PR adds the mimic joint target update to the `PostureTask::target` function.