### PR TITLE
Fix issues with contacts when the first robot has no dof

### DIFF
--- a/include/mc_rbdyn/Contact.h
+++ b/include/mc_rbdyn/Contact.h
@@ -147,6 +147,9 @@ public:
 
   std::string toStr() const;
 
+  /** If this is a contact r1::s1/r2::s2, this returns r2::s2/r1::s1 */
+  Contact swap(const mc_rbdyn::Robots & robots) const;
+
   bool operator==(const Contact & rhs) const;
   bool operator!=(const Contact & rhs) const;
 

--- a/src/mc_control/samples/CoM/mc_com_controller.cpp
+++ b/src/mc_control/samples/CoM/mc_com_controller.cpp
@@ -54,8 +54,9 @@ void MCCoMController::reset(const ControllerResetData & reset_data)
   MCController::reset(reset_data);
   comTask->reset();
   solver().addTask(comTask);
-  solver().setContacts({mc_rbdyn::Contact(robots(), leftFootSurface_, "AllGround"),
-                        mc_rbdyn::Contact(robots(), rightFootSurface_, "AllGround")});
+  solver().setContacts(
+      {mc_rbdyn::Contact(robots(), env().robotIndex(), robot().robotIndex(), "AllGround", leftFootSurface_),
+       mc_rbdyn::Contact(robots(), env().robotIndex(), robot().robotIndex(), "AllGround", rightFootSurface_)});
 }
 
 } // namespace mc_control

--- a/src/mc_control/samples/FSM/etc/FSM.in.conf
+++ b/src/mc_control/samples/FSM/etc/FSM.in.conf
@@ -170,8 +170,10 @@
       "useCoM": false,
       "contact":
       {
-        "r1Surface": "LeftFoot",
-        "r2Surface": "AllGround",
+        "r2": "jvrc1",
+        "r1": "ground",
+        "r1Surface": "AllGround",
+        "r2Surface": "LeftFoot",
         "isFixed": false
       }
     },
@@ -247,10 +249,10 @@
       "RemoveContacts":
       [
         {
-          "r1": "jvrc1",
-          "r2": "ground",
-          "r1Surface": "RightFoot",
-          "r2Surface": "AllGround"
+          "r1": "ground",
+          "r2": "jvrc1",
+          "r1Surface": "AllGround",
+          "r2Surface": "RightFoot"
         }
       ]
     },

--- a/src/mc_control/samples/FSM/src/mc_fsm_controller.cpp
+++ b/src/mc_control/samples/FSM/src/mc_fsm_controller.cpp
@@ -8,3 +8,20 @@ FSMController::FSMController(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rt
 : mc_control::fsm::Controller(rm, dt, config)
 {
 }
+
+void FSMController::reset(const mc_control::ControllerResetData & data)
+{
+  mc_control::fsm::Controller::reset(data);
+  auto check_contact = [this](const std::string & r1, const std::string & r2, const std::string & s1,
+                              const std::string & s2) {
+    if(!hasContact({r1, r2, s1, s2}))
+    {
+      mc_rtc::log::error_and_throw<std::runtime_error>("[FSM] Expected to find {}::{}/{}::{} contact", r1, s1, r2, s2);
+    }
+    if(!hasContact({r2, r1, s2, s1}))
+    {
+      mc_rtc::log::error_and_throw<std::runtime_error>("[FSM] Expected to find {}::{}/{}::{} contact", r2, s2, r1, s1);
+    }
+  };
+  check_contact("jvrc1", "ground", "LeftFoot", "AllGround");
+}

--- a/src/mc_control/samples/FSM/src/mc_fsm_controller.h
+++ b/src/mc_control/samples/FSM/src/mc_fsm_controller.h
@@ -12,6 +12,8 @@ struct MC_CONTROL_DLLAPI FSMController : public mc_control::fsm::Controller
 {
   FSMController(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & config);
 
+  void reset(const mc_control::ControllerResetData & data) override;
+
   void supported_robots(std::vector<std::string> & out) const override
   {
     out = {"jvrc1"};

--- a/src/mc_rbdyn/Contact.cpp
+++ b/src/mc_rbdyn/Contact.cpp
@@ -456,4 +456,21 @@ void Contact::friction(double friction)
   impl->friction = friction;
 }
 
+Contact Contact::swap(const mc_rbdyn::Robots & robots) const
+{
+  const auto & c = *this;
+  const auto & r1 = robots.robot(c.r1Index());
+  const auto & r2 = robots.robot(c.r2Index());
+  const auto & X_s1_s2 = c.X_r2s_r1s();
+  const auto & X_b1_s1 = c.X_b_s();
+  unsigned int r1BodyIndex = r1.bodyIndexByName(c.r1Surface()->bodyName());
+  unsigned int r2BodyIndex = r2.bodyIndexByName(c.r2Surface()->bodyName());
+  const auto & X_0_b1 = r1.mbc().bodyPosW[r1BodyIndex];
+  const auto & X_0_b2 = r2.mbc().bodyPosW[r2BodyIndex];
+  const auto & X_b2_b1 = X_0_b1 * (X_0_b2.inv());
+  sva::PTransformd X_b2_s2 = X_s1_s2 * X_b1_s1 * X_b2_b1;
+  return {robots,        c.r2Index(), c.r1Index(),  c.r2Surface()->name(), c.r1Surface()->name(),
+          X_s1_s2.inv(), X_b2_s2,     c.friction(), c.ambiguityId()};
+}
+
 } // namespace mc_rbdyn

--- a/src/mc_rbdyn/configuration_io.cpp
+++ b/src/mc_rbdyn/configuration_io.cpp
@@ -1248,8 +1248,14 @@ mc_rbdyn::Contact ConfigurationLoader<mc_rbdyn::Contact>::load(const mc_rtc::Con
   config("X_b_s", X_b_s);
   double friction = config("friction", mc_rbdyn::Contact::defaultFriction);
   int ambiguityId = config("ambiguityId", -1);
-  return mc_rbdyn::Contact(robots, r1Index, r2Index, config("r1Surface"), config("r2Surface"), X_r2s_r1s, X_b_s,
-                           friction, ambiguityId);
+  const auto & r1 = robots.robot(r1Index);
+  mc_rbdyn::Contact out(robots, r1Index, r2Index, config("r1Surface"), config("r2Surface"), X_r2s_r1s, X_b_s, friction,
+                        ambiguityId);
+  if(r1.mb().nrDof() == 0)
+  {
+    out = out.swap(robots);
+  }
+  return out;
 }
 
 mc_rtc::Configuration ConfigurationLoader<mc_rbdyn::Contact>::save(const mc_rbdyn::Contact & c)

--- a/src/mc_solver/QPSolver.cpp
+++ b/src/mc_solver/QPSolver.cpp
@@ -203,17 +203,7 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
     const auto & r1 = robots().robot(c.r1Index());
     if(r1.mb().nrDof() == 0)
     {
-      const auto & r2 = robots().robot(c.r2Index());
-      const auto & X_s1_s2 = c.X_r2s_r1s();
-      const auto & X_b1_s1 = c.X_b_s();
-      unsigned int r1BodyIndex = r1.bodyIndexByName(c.r1Surface()->bodyName());
-      unsigned int r2BodyIndex = r2.bodyIndexByName(c.r2Surface()->bodyName());
-      const auto & X_0_b1 = r1.mbc().bodyPosW[r1BodyIndex];
-      const auto & X_0_b2 = r2.mbc().bodyPosW[r2BodyIndex];
-      const auto & X_b2_b1 = X_0_b1 * (X_0_b2.inv());
-      sva::PTransformd X_b2_s2 = X_s1_s2 * X_b1_s1 * X_b2_b1;
-      contacts_.push_back({robots(), c.r2Index(), c.r1Index(), c.r2Surface()->name(), c.r1Surface()->name(),
-                           X_s1_s2.inv(), X_b2_s2, c.friction(), c.ambiguityId()});
+      contacts_.push_back(c.swap(robots()));
     }
     else
     {

--- a/tests/controllers/TestCoMTaskController.cpp
+++ b/tests/controllers/TestCoMTaskController.cpp
@@ -45,6 +45,11 @@ public:
     bool ret = MCController::run();
     BOOST_CHECK(ret);
     nrIter++;
+    if(nrIter == 500)
+    {
+      // Swap the contact order
+      solver().setContacts({{robots(), 1, 0, "AllGround", "LeftFoot"}, {robots(), 1, 0, "AllGround", "RightFoot"}});
+    }
     if(nrIter == 1000)
     {
       /* Check that the task is "finished" */


### PR DESCRIPTION
The formulation in Tasks is broken when the first robot in a contact has no dof (there is a sign issue)

This PR fixes it by swapping the two robots in that case.

Furthermore, the PR makes the FSM treats contact the same whether they are specified as `r1::s1/r2::s2` or `r2::s2/r1::s1`.

This is not strictly the case at the `mc_solver` level where you can add both contacts (but you can already add the same contact multiple times)