### PR TITLE
Add controller reset

### DIFF
--- a/include/mc_control/mc_global_controller.h
+++ b/include/mc_control/mc_global_controller.h
@@ -138,13 +138,36 @@ public:
   void init(const std::vector<double> & initq, const sva::PTransformd & initAttitude);
 
   /**
-   * @brief Initializes controller, observers and plugins
+   * @brief Initialize multiple robots to the given configuration and attitude
    *
-   * Should only be called if init() has been called with initController=false.
+   * If some robots' configuration or position is not provided then the robot module data is used to initialize the
+   * robot.
    *
-   * The robot state must be properly initialized prior to calling this function.
+   * @param initqs Initial joints configuration for each robot, for each robot this data is expected in the
+   * corresponding ref_joint_order
+   *
+   * @param initAttitudes Initial world position for each robot
+   *
    */
-  void initController();
+  void init(const std::map<std::string, std::vector<double>> & initqs = {},
+            const std::map<std::string, sva::PTransformd> & initAttitudes = {});
+
+  /**
+   * @brief Fully reset the current controller to the given initial state
+   *
+   * This deletes then re-create the current controller so that it is started from scratch.
+   *
+   * If some robots' configuration or position is not provided then the robot module data is used to initialize the
+   * robot.
+   *
+   * @param initqs Initial joints configuration for each robot, for each robot this data is expected in the
+   * corresponding ref_joint_order
+   *
+   * @param initAttitudes Initial world position for each robot
+   *
+   */
+  void reset(const std::map<std::string, std::vector<double>> & resetqs = {},
+             const std::map<std::string, sva::PTransformd> & resetAttitudes = {});
 
   /** @name Sensing
    *
@@ -716,11 +739,35 @@ public:
   void refreshLog();
 
 private:
+  /** Initialize all robots */
+  void init(const std::map<std::string, std::vector<double>> & initqs,
+            const std::map<std::string, sva::PTransformd> & initAttitudes,
+            bool reset);
+
   /**
-   * @brief Initializes the robot from provided encoder values
+   * @brief Initializes a robot configuration from provided encoder values
+   *
+   * @param robot Robot that will be initialized
+   *
    * @param initq Encoder values for all actuated joints
    */
-  void initEncoders(const std::vector<double> & initq);
+  void initEncoders(mc_rbdyn::Robot & robot, const std::vector<double> & initq);
+
+  /**
+   * @brief Initializes a robot using its default configuration from the module
+   *
+   * @param robot Robot that will be initialized
+   */
+  void initEncoders(mc_rbdyn::Robot & robot);
+
+  /**
+   * @brief Initializes controller, observers and plugins
+   *
+   * The robot state must be properly initialized prior to calling this function.
+   *
+   * @param reset Should be true when called for reset
+   */
+  void initController(bool reset = false);
 
 public:
   /*! \brief Returns true if the controller is running

--- a/include/mc_observers/EncoderObserver.h
+++ b/include/mc_observers/EncoderObserver.h
@@ -82,6 +82,8 @@ protected:
   bool computeFK_ = true; ///< Whether to compute forward kinematics
   bool computeFV_ = true; ///< Whether to compute forward velocity
 
+  bool initialized_ = false; ///< True if the observer's memory has been initialized
+
   std::string robot_ = ""; ///< Robot estimated by this observer
   std::string updateRobot_ = ""; ///< Robot to update (defaults to robot_)
 

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -35,7 +35,7 @@ struct MC_RBDYN_DLLAPI FDQPWeights
     }
     if(config.has("net_wrench"))
     {
-      netWrenchSqrt = std::sqrt(static_cast<double>(config.has("net_wrench")));
+      netWrenchSqrt = std::sqrt(static_cast<double>(config("net_wrench")));
     }
     if(config.has("pressure"))
     {

--- a/include/mc_rtc/loader.h
+++ b/include/mc_rtc/loader.h
@@ -26,6 +26,7 @@
 #include <functional>
 #include <map>
 #include <memory>
+#include <mutex>
 #include <string>
 #include <vector>
 
@@ -50,6 +51,15 @@ public:
 
 private:
   std::string what_;
+};
+
+/*! \class LTDLMutex
+ *
+ * \brief Holds a global mutex for all LTDL operations
+ */
+struct MC_RTC_LOADER_DLLAPI LTDLMutex
+{
+  static std::mutex MTX;
 };
 
 /*! \class LTDLHandle

--- a/include/mc_rtc/loader.hpp
+++ b/include/mc_rtc/loader.hpp
@@ -20,6 +20,7 @@ SymT LTDLHandle::get_symbol(const std::string & name)
   {
     return nullptr;
   }
+  std::unique_lock<std::mutex> lock(LTDLMutex::MTX);
   SymT ret = (SymT)(lt_dlsym(handle_, name.c_str()));
   if(ret == nullptr)
   {

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -85,7 +85,10 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   mc_rtc::log::info("MCController(base) ready");
 }
 
-MCController::~MCController() {}
+MCController::~MCController()
+{
+  datastore().clear();
+}
 
 mc_rbdyn::Robot & MCController::loadRobot(mc_rbdyn::RobotModulePtr rm, const std::string & name)
 {

--- a/src/mc_control/fsm/Controller.cpp
+++ b/src/mc_control/fsm/Controller.cpp
@@ -207,6 +207,7 @@ Controller::Controller(std::shared_ptr<mc_rbdyn::RobotModule> rm, double dt, con
 Controller::~Controller()
 {
   executor_.teardown(*this);
+  datastore().clear();
 }
 
 bool Controller::run()

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -308,6 +308,7 @@ void MCGlobalController::reset(const std::map<std::string, std::vector<double>> 
   controllers.erase(current_ctrl);
   setup_logger_.erase(current_ctrl);
   pre_gripper_mbcs_.clear();
+  config.load_controllers_configs();
   AddController(current_ctrl);
   controller_ = controllers[current_ctrl].get();
   init(initqs, initAttitudes, true);

--- a/src/mc_control/mc_global_controller_configuration.cpp
+++ b/src/mc_control/mc_global_controller_configuration.cpp
@@ -416,6 +416,7 @@ void load_configs(const std::string & desc,
 
 void MCGlobalController::GlobalConfiguration::load_controllers_configs()
 {
+  controllers_configs.clear();
   // Load controller-specific configuration
   load_configs("controller", enabled_controllers, controller_module_paths,
 #ifndef WIN32


### PR DESCRIPTION
The main purpose of this PR is to introduce a multi-robot adapted `init` call for `MCGlobalController` and a `reset` call to restart a controller from a given state without bringing down the whole `MCGlobalController` instance.

This PR also includes three fixes:
- one of the stabilizer configuration entry was not read correctly (this wasn't noticed because this setting is usually left untouched)
- potential segfault on delete when the controller uses the datastore
- protecting calls around `lt_dl*` calls as those are not thread-safe (this would lead to segfault when running many instances of `MCGlobalController` in parallel)