### PR TITLE
Fix issues with robot removal

### DIFF
--- a/include/mc_control/fsm/Controller.h
+++ b/include/mc_control/fsm/Controller.h
@@ -261,9 +261,6 @@ private:
   void teardownIdleState();
 
 protected:
-  /** Map robots' names to index */
-  std::map<std::string, size_t> robots_idx_;
-
   /** Holds dynamics, kinematics and contact constraints that are added
    * from the start by the controller */
   std::vector<mc_solver::ConstraintSetPtr> constraints_;

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -143,6 +143,17 @@ mc_rbdyn::Robot & MCController::loadRobot(mc_rbdyn::RobotModulePtr rm,
 void MCController::removeRobot(const std::string & name)
 {
   robots().removeRobot(name);
+  realRobots().removeRobot(name);
+  if(gui_)
+  {
+    gui_->removeElement({"Robots"}, name);
+    auto data = gui_->data();
+    std::vector<std::string> robots = data("robots");
+    robots.erase(std::find(robots.begin(), robots.end(), name));
+    data.add("robots", robots);
+    data("bodies").remove(name);
+    data("surfaces").remove(name);
+  }
   solver().updateNrVars();
 }
 

--- a/src/mc_rbdyn/Robots.cpp
+++ b/src/mc_rbdyn/Robots.cpp
@@ -217,6 +217,7 @@ void Robots::removeRobot(const std::string & name)
   if(!hasRobot(name))
   {
     mc_rtc::log::error("Did not find a robot named {} to remove", name);
+    return;
   }
   removeRobot(robotNameToIndex_.at(name));
 }


### PR DESCRIPTION
This PR fixes two issues with robots removal in a controller:
- Remove the robot from GUI and GUI data
- Get rid of the robot name to index map maintained in the FSM controller; this map was not correctly updated and it serves no purpose since the same map is now (correctly) maintained in `mc_rbdyn::Robots`)