### PR TITLE
Improve log extract

### DIFF
--- a/doc/tutorials/tools/mc_log_ui.md
+++ b/doc/tutorials/tools/mc_log_ui.md
@@ -94,6 +94,13 @@ The style menu lets you set many styling options for your graph, it has several 
 
 _Note: style options are also saved when you save a user plot_
 
+### Tools menu
+
+The tools menu lets you access some tools to work with the log:
+
+- `Extract keys...` is a front-end for the `mc_bin_utils extract --keys` command introduced in the [log manipulation tutorial](mc_log_utils.html);
+- `Dump qOut to seqplay` can output a file compatible with the seqplay component of [hrprys-base](https://github.com/fkanehiro/hrpsys-base) based on the `qOut` entry in the log;
+
 ### Shortcuts
 
 The following keyboard shortcuts can be used within the interface:

--- a/doc/tutorials/tools/mc_log_utils.md
+++ b/doc/tutorials/tools/mc_log_utils.md
@@ -5,7 +5,7 @@ toc: true
 
 In this document we will assume you have a log at `~/my_log.bin`.
 
-### `mc_bin_utils`: a general manipulation tool
+## General manipulation tool `mc_bin_utils`
 
 `mc_bin_utils` lets you perform a number of operations on a binary log:
 
@@ -24,11 +24,13 @@ Use mc_bin_utils <command> --help for usage of each command
 
 We will covert the `extract` and `convert` commands. `show` and `split` are self-explanatory.
 
-#### `mc_bin_utils extract`
+### `mc_bin_utils extract`
 
-`mc_bin_utils extract` has two operation mode.
+`mc_bin_utils extract` has three operation modes.
 
-The first one extract all parts of a log where a given key is present:
+#### Extract based on key presence `--key`
+
+The first mode extracts all parts of a log where a given key is present:
 
 ```bash
 $ mc_bin_utils extract ~/my_log.bin my_log_out --key com_task_target
@@ -36,7 +38,9 @@ $ mc_bin_utils extract ~/my_log.bin my_log_out --key com_task_target
 
 This will generate one log for each section where the key `com_task_target` was present. For example, if the key was present at the 5 seconds mark until the 15 seconds mark and again from the 30 seconds mark to the 60 seconds mark you will get `my_log_out_1.bin` and `my_log_out_2.bin`.
 
-The second form lets directly extract a time-range based on the `t` entry:
+#### Extract based on a time range `--from --to`
+
+The second mode extracts a time-range based on the `t` entry:
 
 ```bash
 $ mc_bin_utils extract ~/my_log.bin my_log_out --from 50 --to 100
@@ -44,7 +48,25 @@ $ mc_bin_utils extract ~/my_log.bin my_log_out --from 50 --to 100
 
 This example will generate `my_log_out.bin` with time `t` ranging from 50 seconds to 100 seconds. You can omit either `from` or `to` in which case the output log will start at 0 second and end at the end of the log respectively.
 
-#### `mc_bin_utils convert`
+#### Extract a selection of keys `--keys`
+
+The third mode extracts a set of selected keys from the log:
+
+```bash
+$ mc_bin_utils extract ~/my_log.bin my_log_out --keys RightFootForceSensor com_target com_eval
+```
+
+This example will generate a `.bin` file which only contains data for the specified keys -- as well as the `t` key which is always added. It will create multiple files if there is a range in the provided log file that does not have any of the provided key.
+
+The command also supports wildcards:
+
+```bash
+$ mc_bin_utils extract ~/my_log.bin my_log_out --keys com_*
+```
+
+This example will extract every key that starts with `com_`.
+
+### `mc_bin_utils convert`
 
 This tool will let you convert a `.bin` log to one of three formats (two without ROS support)
 
@@ -52,7 +74,45 @@ This tool will let you convert a `.bin` log to one of three formats (two without
 - `.csv` is a well-known data format that is understood by a lot of tools (notably MATLAB and Excel) and can be convenient to share data with external collaborators;
 - `.bag` is the format expected by the `rosbag` tool;
 
-### Opening the log in Python
+Stand-alone tools are also always to perform the same conversions:
+
+- `mc_bin_to_flat` converts a `.bin` file to a `.flat` file;
+- `mc_bin_to_log` converts a `.bin` file to a `.csv` file;
+- `mc_bin_to_rosbag` converts a `.bin` file to a `.bag` file;
+
+## Performance at a glance `mc_bin_perf`
+
+`mc_bin_perf` can be used to quickly grab statistics about mc_rtc performances. It will look at all the entries starting with `perf_` in the log and output their average value and its standard deviation as well as the minimum and maximum values.
+
+For example:
+
+```bash
+$ mc_bin_perf /tmp/mc-control-CoM-latest.bin
+----------------------------------------------------------------
+|                     |  Average |    StdEv |      Min |   Max |
+----------------------------------------------------------------
+|       ControllerRun |    0.451 |   0.0639 |    0.378 |  1.14 |
+|       FrameworkCost |     7.64 |     2.81 |     2.55 |  52.8 |
+|           GlobalRun |    0.488 |   0.0703 |    0.401 |  1.18 |
+|                 Gui |   0.0035 |  0.00941 | 0.000543 | 0.322 |
+|                 Log |  0.00732 |  0.00476 |  0.00563 | 0.163 |
+|        ObserversRun | 6.79e-05 | 0.000215 |  2.4e-05 | 0.014 |
+|   Plugins_ROS_after |   0.0137 |   0.0124 |  0.00202 | 0.172 |
+| SolverBuildAndSolve |    0.422 |   0.0607 |    0.354 |  1.11 |
+|         SolverSolve |     0.32 |   0.0498 |    0.268 |     1 |
+----------------------------------------------------------------
+```
+
+All times are presented in milliseconds -- except `FrameworkCost` as explained below.
+
+Of the entries presented by default the following should be more interesting to the regular user of mc_rtc:
+
+- `GlobalRun` is the total time spent in `mc_control::MCGlobalController::run()`, i.e. the time to run everything in mc_rtc: global plugins, observer pipelines, controller, logging and GUI. It is roughly equal to `Plugins_* + ObserversRun + ControllerRun + Gui + Log`;
+- `ControllerRun` is the time spent in the controller run function. It is roughly equal to `SolverBuildAndSolve + (time spent in controller code)`;
+- `SolverBuildAndSolve` and `SolverSolve` are the time spent in `Tasks` -- `SolverSolve` is included in `SolverBuildAndSolve` it is measuring the time spent solving the underlying QP problem;
+- `FrameworkCost` is the ratio of time spent outside of `Tasks`, i.e. `(GlobalRun - SolverBuildAndSolve) / GlobalRun`;
+
+## Opening the log in Python
 
 You can also open the log in Python:
 
@@ -63,6 +123,6 @@ log = mc_log_ui.read_log('/tmp/mylog.bin')
 
 Then `log` is a Python dictionary where the keys are the entries you see in the tree of mc\_log\_ui (e.g. if you logged an `Eigen::Vector3d` called `v3d` then you get `v3d_x`, `v3d_y` and `v3d_z`) and the values are numpy arrays so you can do anything with it.
 
-### The `mc_rtc::FlatLog` class
+## The `mc_rtc::log::FlatLog` class
 
-The `mc_rtc::FlatLog` class is part of the `mc_rtc_utils` library. It lets you open a log and iterate through the data using their original type. For example, if you have logged a force sensor's reading as an `sva::ForceVecd` object you can retrieve it as-is through the `mc_rtc::FlatLog`. See the class documentation for more details on the usage and API. This is only available in C++.
+The {% doxygen mc_rtc::log::FlatLog %} class is part of the `mc_rtc_utils` library. It lets you open a log and iterate through the data using their original type. For example, if you have logged a force sensor's reading as an `sva::ForceVecd` object you can retrieve it as-is through the `mc_rtc::log::FlatLog`. See the class documentation for more details on the usage and API. This is only available in C++.

--- a/include/mc_rtc/log/FlatLog.h
+++ b/include/mc_rtc/log/FlatLog.h
@@ -28,11 +28,11 @@ struct MC_RTC_UTILS_DLLAPI FlatLog
   /** Load a file into the log */
   FlatLog(const std::string & fpath);
 
-  /** Delete copy constructor */
   FlatLog(const FlatLog &) = delete;
-
-  /** Delete copy assignment */
   FlatLog & operator=(const FlatLog &) = delete;
+
+  FlatLog(FlatLog &&) = default;
+  FlatLog & operator=(FlatLog &&) = default;
 
   /** Load a file into the log, erase the current content of the flat log */
   void load(const std::string & fpath);
@@ -54,6 +54,9 @@ struct MC_RTC_UTILS_DLLAPI FlatLog
 
   /** Get the first non None type for an entry */
   LogType type(const std::string & entry) const;
+
+  /** Get the type at index i */
+  LogType type(const std::string & entry, size_t i) const;
 
   /** Get a type record entry.
    *

--- a/include/mc_rtc/log/Logger.h
+++ b/include/mc_rtc/log/Logger.h
@@ -86,8 +86,23 @@ public:
    *
    * \param resume If true, start the time entry at the current value,
    * otherwise, start at 0
+   *
+   * \param start_t Start at the specified time, only used if resume is false
    */
-  void start(const std::string & ctl_name, double timestep, bool resume = false);
+  void start(const std::string & ctl_name, double timestep, bool resume = false, double start_t = 0.0);
+
+  /*! \brief Open a new file for logging
+   *
+   * This is similar to \ref start but disregard the log directory and template. Instead the logging happens in the
+   * provided file: \p file.
+   *
+   * \param file File where data is going to be written
+   *
+   * \param timestep Time increment for the log time entry
+   *
+   * \param start_t Start the log at the specified time
+   */
+  void open(const std::string & file, double timestep, double start_t = 0.0);
 
   /*! \brief Log controller's data
    *
@@ -240,7 +255,7 @@ public:
 
   /** Access the file opened by this Logger
    *
-   * \note This is empty before \ref start has been called
+   * \note This is empty before \ref start or \ref open has been called
    */
   const std::string & path() const;
 

--- a/src/mc_rtc/FlatLog.cpp
+++ b/src/mc_rtc/FlatLog.cpp
@@ -213,6 +213,22 @@ LogType FlatLog::type(const std::string & entry) const
   return mc_rtc::log::LogType::None;
 }
 
+LogType FlatLog::type(const std::string & entry, size_t i) const
+{
+  if(!has(entry))
+  {
+    log::error("No entry named {} in the loaded log", entry);
+    return LogType::None;
+  }
+  const auto & records = at(entry);
+  if(i >= records.size())
+  {
+    log::error("Requested data ({}) out of available range ({}, available: {})", entry, i, records.size());
+    return LogType::None;
+  }
+  return records[i].type;
+}
+
 const std::vector<FlatLog::record> & FlatLog::at(const std::string & entry) const
 {
   for(const auto & d : data_)

--- a/utils/mc_bin_utils.in.cpp
+++ b/utils/mc_bin_utils.in.cpp
@@ -535,7 +535,7 @@ int extract(int argc, char * argv[])
       return out;
     };
     std::vector<TypedKey> prev_keys_in_log;
-    mc_rtc::Logger logger(mc_rtc::Logger::Policy::THREADED, "", "");
+    mc_rtc::Logger logger(mc_rtc::Logger::Policy::NON_THREADED, "", "");
     double timestep = *log.getRaw<double>("t", 1) - *log.getRaw<double>("t", 0);
     for(size_t i = 0; i < log.size(); ++i)
     {


### PR DESCRIPTION
Add --keys option to mc_bin_utils extract
    
This new option allows to extract a set of keys from a log file
    
- Automatically adds t
- Only creates a new file when there is a gap in all the keys
    
New API were added to suppor this:
- FlatLog::getType(k, i) <-- Gets the type at iteration i for the provided  key
- Logger::open opens the provided file (no timestamp, no symlinks)
- Logger::start and Logger::open can start at an arbitrary time

The tool can also be invoked from `mc_log_ui`

ToDo:
- [ ] Add to the documentation