### PR TITLE
[mc_rtc] Disable yes/no conversion to bool in YAML

### DIFF
--- a/src/mc_rtc/internals/yaml.h
+++ b/src/mc_rtc/internals/yaml.h
@@ -38,11 +38,7 @@ inline bool try_convert<bool>(const YAML::Node & node, bool & out)
 {
   if(YAML::convert<bool>::decode(node, out))
   {
-    // yaml-cpp accepts y, Y, n and N as valid bool representations we check if this was the case here
-    if(node.Scalar().size() != 1)
-    {
-      return true;
-    }
+    // yaml-cpp treats y, yes, n and no as valid bool (case insensitive) we check if this was the case here
     char scalar = node.Scalar()[0];
     return scalar != 'y' && scalar != 'Y' && scalar != 'n' && scalar != 'N';
   }

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -1083,6 +1083,10 @@ special:
   sDist: 0.04
 Y_is_string: Y
 N_is_string: N
+yes_is_string: yes
+no_is_string: no
+Yes_is_string: Yes
+No_is_string: No
 )";
 
 BOOST_AUTO_TEST_CASE(TestConfigurationYAMLTweaks)
@@ -1118,10 +1122,11 @@ BOOST_AUTO_TEST_CASE(TestConfigurationYAMLTweaks)
     double damping = special("damping");
     BOOST_REQUIRE_EQUAL(damping, 0.0);
   }
-  BOOST_REQUIRE(config.has("Y_is_string"));
-  std::string Y = config("Y_is_string");
-  BOOST_REQUIRE_EQUAL(Y, "Y");
-  BOOST_REQUIRE(config.has("N_is_string"));
-  std::string N = config("N_is_string");
-  BOOST_REQUIRE_EQUAL(N, "N");
+  for(const auto & k : {"Y", "N", "yes", "no", "Yes", "No"})
+  {
+    std::string key = fmt::format("{}_is_string", k);
+    BOOST_REQUIRE(config.has(key));
+    std::string value = config(key);
+    BOOST_REQUIRE_EQUAL(value, k);
+  }
 }


### PR DESCRIPTION
That shoud leave only 1/0 and true/false as valid bool representations

Closes #212