### PR TITLE
[mc_control] Better handle "metric" grippers

### DIFF
--- a/include/mc_control/generic_gripper.h
+++ b/include/mc_control/generic_gripper.h
@@ -245,7 +245,7 @@ struct MC_RBDYN_DLLAPI Gripper
   /** Offset by which the gripper is released if overCommandDiffTrigger is
    * trigger for more than overCommandLimitIterN
    *
-   * @param offset offset angle in [rad]
+   * @param offset offset angle in [rad] or distance in [meter]
    **/
   void releaseSafetyOffset(double offset)
   {
@@ -269,6 +269,15 @@ struct MC_RBDYN_DLLAPI Gripper
    * \return True if gripper is not moving, False if it is moving
    */
   bool complete() const;
+
+  /*! \brief Returns true if a gripper is metric, i.e. all active joints are prismatic rather than revolute
+   *
+   * This only affects safety settings in the GUI
+   */
+  inline bool is_metric() const noexcept
+  {
+    return is_metric_;
+  }
 
 protected:
   /*! \brief Set the target opening of a single gripper joint by index
@@ -314,6 +323,9 @@ protected:
   /*! All joint indexes in mbc, -1 if absent */
   std::vector<int> joints_mbc_idx;
 
+  /*! True if all joints are primatic */
+  bool is_metric_;
+
   /*! Lower limits of active joints in the gripper (closed-gripper values) */
   std::vector<double> closeP;
   /*! Upper limits of active joints in the gripper (open-gripper values) */
@@ -332,6 +344,9 @@ protected:
   std::vector<double> targetQIn;
   /*! Current gripper target: NULL if target has been reached or safety was triggered */
   std::vector<double> * targetQ;
+
+  /*! Target reached threshold per-joint (0.001 rad for revolute and 0.0001 for prismatic joints) */
+  std::vector<double> reached_threshold_;
 
   /*! Joints' values from the encoders */
   std::vector<double> actualQ;

--- a/src/mc_control/mc_global_controller_gui.cpp
+++ b/src/mc_control/mc_global_controller_gui.cpp
@@ -51,18 +51,35 @@ void MCGlobalController::initGUI()
         }
 
         category.push_back("Safety");
-        gui->addElement(
-            category,
-            mc_rtc::gui::NumberInput(
-                "Actual command diff threshold [deg]",
-                [g_ptr]() { return mc_rtc::constants::toDeg(g_ptr->actualCommandDiffTrigger()); },
-                [g_ptr](double deg) { g_ptr->actualCommandDiffTrigger(mc_rtc::constants::toRad(deg)); }),
-            mc_rtc::gui::NumberInput(
-                "Over command limiter iterations", [g_ptr]() -> double { return g_ptr->overCommandLimitIterN(); },
-                [g_ptr](double N) { g_ptr->overCommandLimitIterN(static_cast<unsigned int>(N)); }),
-            mc_rtc::gui::NumberInput(
-                "Release offset [deg]", [g_ptr]() { return mc_rtc::constants::toDeg(g_ptr->releaseSafetyOffset()); },
-                [g_ptr](double deg) { g_ptr->releaseSafetyOffset(mc_rtc::constants::toRad(deg)); }));
+        if(g_ptr->is_metric())
+        {
+          gui->addElement(
+              category,
+              mc_rtc::gui::NumberInput(
+                  "Actual command diff threshold [m]", [g_ptr]() { return g_ptr->actualCommandDiffTrigger(); },
+                  [g_ptr](double m) { g_ptr->actualCommandDiffTrigger(m); }),
+              mc_rtc::gui::NumberInput(
+                  "Over command limiter iterations", [g_ptr]() -> double { return g_ptr->overCommandLimitIterN(); },
+                  [g_ptr](double N) { g_ptr->overCommandLimitIterN(static_cast<unsigned int>(N)); }),
+              mc_rtc::gui::NumberInput(
+                  "Release offset [m]", [g_ptr]() { return g_ptr->releaseSafetyOffset(); },
+                  [g_ptr](double m) { g_ptr->releaseSafetyOffset(m); }));
+        }
+        else
+        {
+          gui->addElement(
+              category,
+              mc_rtc::gui::NumberInput(
+                  "Actual command diff threshold [deg]",
+                  [g_ptr]() { return mc_rtc::constants::toDeg(g_ptr->actualCommandDiffTrigger()); },
+                  [g_ptr](double deg) { g_ptr->actualCommandDiffTrigger(mc_rtc::constants::toRad(deg)); }),
+              mc_rtc::gui::NumberInput(
+                  "Over command limiter iterations", [g_ptr]() -> double { return g_ptr->overCommandLimitIterN(); },
+                  [g_ptr](double N) { g_ptr->overCommandLimitIterN(static_cast<unsigned int>(N)); }),
+              mc_rtc::gui::NumberInput(
+                  "Release offset [deg]", [g_ptr]() { return mc_rtc::constants::toDeg(g_ptr->releaseSafetyOffset()); },
+                  [g_ptr](double deg) { g_ptr->releaseSafetyOffset(mc_rtc::constants::toRad(deg)); }));
+        }
       }
     }
     gui->removeCategory({"Global", "Change controller"});


### PR DESCRIPTION
`mc_control::Gripper` was written with the (unwritten) assumption that the gripper active joints are all revolute. In this PR we detect when this is not the case and improve the behavior when the active joints are prismatic.

- Choose a better reaching threshold for prismatic joints
- Don't do transformations when presenting the safety settings in the GUI