### PR TITLE
Correct the CoM position to reflect DCM bias

### DIFF
--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -132,6 +132,8 @@ struct DCMBiasEstimatorConfiguration
   double biasDriftPerSecondStd = 0.02;
   /// Maximum bias in the sagital and lateral directions [m]
   Eigen::Vector2d biasLimit = {0.02, 0.02};
+  /// Maximum bias in the sagital and lateral directions used to correct the CoM, should be smaller than bisaLimit [m]
+  Eigen::Vector2d comBiasLimit = biasLimit;
   /// Whether the DCM bias estimator is enabled (default: false for backwards compatibility)
   bool withDCMBias = false;
   /// Whether the DCM filter is enabled
@@ -145,6 +147,7 @@ struct DCMBiasEstimatorConfiguration
     config("zmpMeasureErrorStd", zmpMeasureErrorStd);
     config("biasDriftPerSecondStd", biasDriftPerSecondStd);
     config("biasLimit", biasLimit);
+    config("comBiasLimit", comBiasLimit);
     config("withDCMBias", withDCMBias);
     config("correctCoMPos", correctCoMPos);
     config("withDCMFilter", withDCMFilter);
@@ -157,6 +160,7 @@ struct DCMBiasEstimatorConfiguration
     config.add("zmpMeasureErrorStd", zmpMeasureErrorStd);
     config.add("biasDriftPerSecondStd", biasDriftPerSecondStd);
     config.add("biasLimit", biasLimit);
+    config.add("comBiasLimit", comBiasLimit);
     config.add("withDCMBias", withDCMBias);
     config.add("correctCoMPos", correctCoMPos);
     config.add("withDCMFilter", withDCMFilter);

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -136,6 +136,8 @@ struct DCMBiasEstimatorConfiguration
   bool withDCMBias = false;
   /// Whether the DCM filter is enabled
   bool withDCMFilter = false;
+  /// Whether the absolution CoM position gets unbiased
+  bool correctCoMPos = false;
 
   void load(const mc_rtc::Configuration & config)
   {
@@ -144,6 +146,7 @@ struct DCMBiasEstimatorConfiguration
     config("biasDriftPerSecondStd", biasDriftPerSecondStd);
     config("biasLimit", biasLimit);
     config("withDCMBias", withDCMBias);
+    config("correctCoMPos", correctCoMPos);
     config("withDCMFilter", withDCMFilter);
   }
 
@@ -155,6 +158,7 @@ struct DCMBiasEstimatorConfiguration
     config.add("biasDriftPerSecondStd", biasDriftPerSecondStd);
     config.add("biasLimit", biasLimit);
     config.add("withDCMBias", withDCMBias);
+    config.add("correctCoMPos", correctCoMPos);
     config.add("withDCMFilter", withDCMFilter);
     return config;
   }

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -863,6 +863,7 @@ protected:
   Eigen::Vector3d measuredZMP_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d measuredDCM_ = Eigen::Vector3d::Zero(); /// Measured DCM (only used for logging)
   Eigen::Vector3d measuredDCMUnbiased_ = Eigen::Vector3d::Zero(); /// DCM unbiased (only used for logging)
+  Eigen::Vector3d measuredCoMUnbiased_ = Eigen::Vector3d::Zero(); /// CoM unbiased (only used for logging)
   sva::ForceVecd measuredNetWrench_ = sva::ForceVecd::Zero();
 
   bool zmpccOnlyDS_ = true; /**< Only apply ZMPCC in double support */

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -838,6 +838,16 @@ sva::ForceVecd StabilizerTask::computeDesiredWrench()
       comError.head<2>() -= dcmEstimator_.getBias();
       /// the unbiased dcm allows also to get the velocity of the CoM
       comdError.head<2>() = omega_ * (dcmError_.head<2>() - comError.head<2>());
+
+      measuredCoMUnbiased_.head<2>() = measuredCoM_.head<2>() + dcmEstimator_.getBias();
+      measuredCoMUnbiased_.z() = measuredCoM_.z();
+
+      if(c_.dcmBias.correctCoMPos)
+      {
+        /// correct the estimated CoM Position
+        measuredCoM_ = measuredCoMUnbiased_;
+      }
+
       measuredDCMUnbiased_ = dcmTarget_ - dcmError_;
     }
     else

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -22,6 +22,7 @@ namespace lipm_stabilizer
 
 using internal::Contact;
 using ::mc_filter::utils::clamp;
+using ::mc_filter::utils::clampInPlace;
 using ::mc_filter::utils::clampInPlaceAndWarn;
 namespace constants = ::mc_rtc::constants;
 
@@ -839,7 +840,10 @@ sva::ForceVecd StabilizerTask::computeDesiredWrench()
       /// the unbiased dcm allows also to get the velocity of the CoM
       comdError.head<2>() = omega_ * (dcmError_.head<2>() - comError.head<2>());
 
-      measuredCoMUnbiased_.head<2>() = measuredCoM_.head<2>() + dcmEstimator_.getBias();
+      Eigen::Vector2d comBias = dcmEstimator_.getBias();
+      clampInPlace(comBias, (-c_.dcmBias.comBiasLimit).eval(), c_.dcmBias.comBiasLimit);
+
+      measuredCoMUnbiased_.head<2>() = measuredCoM_.head<2>() + comBias;
       measuredCoMUnbiased_.z() = measuredCoM_.z();
 
       if(c_.dcmBias.correctCoMPos)

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -118,6 +118,9 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
                      "Enabled", [this]() { return c_.dcmBias.withDCMBias; },
                      [this]() { c_.dcmBias.withDCMBias = !c_.dcmBias.withDCMBias; }),
                  Checkbox(
+                     "Correct CoM Pos", [this]() { return c_.dcmBias.correctCoMPos; },
+                     [this]() { c_.dcmBias.correctCoMPos = !c_.dcmBias.correctCoMPos; }),
+                 Checkbox(
                      "Use Filtered DCM", [this]() { return c_.dcmBias.withDCMFilter; },
                      [this]() { c_.dcmBias.withDCMFilter = !c_.dcmBias.withDCMFilter; }));
   gui.addElement({"Tasks", name_, "Advanced", "DCM Bias"},
@@ -464,6 +467,7 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   MC_RTC_LOG_HELPER(name_ + "_realRobot_comd", measuredCoMd_);
   MC_RTC_LOG_HELPER(name_ + "_realRobot_dcm", measuredDCM_);
   MC_RTC_LOG_HELPER(name_ + "_realRobot_dcm_unbiased", measuredDCMUnbiased_);
+  MC_RTC_LOG_HELPER(name_ + "_realRobot_com_unbiased", measuredCoMUnbiased_);
   logger.addLogEntry(name_ + "_realRobot_posW", this,
                      [this]() -> const sva::PTransformd & { return realRobot().posW(); });
   logger.addLogEntry(name_ + "_realRobot_wrench", this,

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -149,6 +149,10 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
                        c_.dcmBias.biasLimit = v;
                        dcmEstimator_.setBiasLimit(v);
                      }),
+                 ArrayInput(
+                     "CoM bias Limit [m]", {"sagital", "lateral"},
+                     [this]() -> const Eigen::Vector2d & { return c_.dcmBias.comBiasLimit; },
+                     [this](const Eigen::Vector2d & v) { c_.dcmBias.comBiasLimit = v; }),
                  ArrayLabel("Local Bias", [this]() { return dcmEstimator_.getLocalBias(); }));
   gui.addElement({"Tasks", name_, "Advanced", "Ext Wrench"},
                  Checkbox(


### PR DESCRIPTION
This correction allows to correct the position of the CoM in case the DCM bias is coming from a modeling error in the position of the CoM. This has been shown to improve the performance but needs to be limited to avoid winding up in case of contact with the environment.

The option is disabled by default and should not affect existing robots.