### PR TITLE
[mc_tasks] add virtual to ImpedanceTask::addToSolver method

### DIFF
--- a/include/mc_tasks/ImpedanceTask.h
+++ b/include/mc_tasks/ImpedanceTask.h
@@ -258,7 +258,7 @@ protected:
 
   void update(mc_solver::QPSolver & solver) override;
 
-  void addToSolver(mc_solver::QPSolver & solver) override;
+  virtual void addToSolver(mc_solver::QPSolver & solver) override;
   void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
   void addToLogger(mc_rtc::Logger & logger) override;
 

--- a/include/mc_tasks/TrajectoryTaskGeneric.h
+++ b/include/mc_tasks/TrajectoryTaskGeneric.h
@@ -259,7 +259,7 @@ protected:
   std::shared_ptr<tasks::qp::TrajectoryTask> trajectoryT_ = nullptr;
 
 protected:
-  void addToSolver(mc_solver::QPSolver & solver) override;
+  virtual void addToSolver(mc_solver::QPSolver & solver) override;
 
 private:
   Eigen::VectorXd stiffness_;


### PR DESCRIPTION
By simple print check (https://github.com/jrl-umi3218/mc_rtc/commit/a60a94ec0ee791497e6d1d42371f5e54565d38d0), I found that `ImpedanceTask::addToSolver` is not called when the task is added. This PR fixes it.

This is not covered in this PR, but in most tasks, `addToSolver` is declared without `virtual`, so there may be similar issues.