### PR TITLE
Simplify GUI cleanup

### DIFF
--- a/doc/_i18n/en/tutorials/usage/gui.md
+++ b/doc/_i18n/en/tutorials/usage/gui.md
@@ -31,6 +31,13 @@ gui()->addElement({"a", "b"},
   mc_rtc::gui::Button("Button 2", []() { return; }),
   mc_rtc::gui::Button("Button 3", []() { return; })
 );
+
+// A source can also be specified when adding elements to tag the added elements
+gui()->addElement(this, {"a", "b"},
+  mc_rtc::gui::Button("Button 1", []() { return; }),
+  mc_rtc::gui::Button("Button 2", []() { return; }),
+  mc_rtc::gui::Button("Button 3", []() { return; })
+);
 ```
 
 ##### A note on data
@@ -285,4 +292,10 @@ Two functions are provided to remove elements from the GUI:
 gui()->removeElement({"a", "b"}, "element");
 // Remove a category and all its sub-categories
 gui()->removeCategory({"a", "b"});
+// Remove all elements added by source pointer this
+gui()->removeElements(this);
+// Remove all elements added by source pointer this in, and only in, the provided category
+gui()->removeElements({"a", "b"}, this);
+// Remove all elements added by source pointer this in the provided category and its sub categories
+gui()->removeElements({"a", "b"}, this, true);
 ```

--- a/doc/_i18n/jp/tutorials/usage/gui.md
+++ b/doc/_i18n/jp/tutorials/usage/gui.md
@@ -20,8 +20,6 @@ GUIはカテゴリーごとに整理されているため、同じカテゴリ�
 
 要素を追加するには、カテゴリーと1つ以上の要素を指定して`gui()->addElement(...)`を呼び出します。例:
 
-{% comment %}FIXME Comment is not translated{% endcomment %}
-
 ```cpp
 // a/bカテゴリに"Push"と名付けられたボタンを追加
 gui()->addElement({"a", "b"},
@@ -35,7 +33,7 @@ gui()->addElement({"a", "b"},
   mc_rtc::gui::Button("Button 3", []() { return; })
 );
 
-// A source can also be specified when adding elements to tag the added elements
+// 要素を追加する際に、追加された要素をタグするためにソースを追加することもできる
 gui()->addElement(this, {"a", "b"},
   mc_rtc::gui::Button("Button 1", []() { return; }),
   mc_rtc::gui::Button("Button 2", []() { return; }),
@@ -290,15 +288,13 @@ Form("Button name",
 
 GUIから要素を削除するための2つの関数が用意されています。
 
-{% comment %}FIXME Comment is not translated{% endcomment %}
-
 ```cpp
 // 単一の要素を名前で指定して削除
 gui()->removeElement({"a", "b"}, "element");
 // あるカテゴリ及びその全ての子カテゴリを削除
 gui()->removeCategory({"a", "b"});
-// Remove all elements added by source pointer this in, and only in, the provided category
+// 指定されたカテゴリ内でのみ、ソースポインタthisにより追加された全ての要素を削除する
 gui()->removeElements({"a", "b"}, this);
-// Remove all elements added by source pointer this in the provided category and its sub categories
+// 指定されたカテゴリとその子カテゴリで、ソースポインタthisにより追加された全ての要素を削除する
 gui()->removeElements({"a", "b"}, this, true);
 ```

--- a/doc/_i18n/jp/tutorials/usage/gui.md
+++ b/doc/_i18n/jp/tutorials/usage/gui.md
@@ -20,6 +20,8 @@ GUIはカテゴリーごとに整理されているため、同じカテゴリ�
 
 要素を追加するには、カテゴリーと1つ以上の要素を指定して`gui()->addElement(...)`を呼び出します。例:
 
+{% comment %}FIXME Comment is not translated{% endcomment %}
+
 ```cpp
 // a/bカテゴリに"Push"と名付けられたボタンを追加
 gui()->addElement({"a", "b"},
@@ -28,6 +30,13 @@ gui()->addElement({"a", "b"},
 
 // 複数の要素を一括で追加することも可能。この場合、追加された要素は追加された順番に表示される
 gui()->addElement({"a", "b"},
+  mc_rtc::gui::Button("Button 1", []() { return; }),
+  mc_rtc::gui::Button("Button 2", []() { return; }),
+  mc_rtc::gui::Button("Button 3", []() { return; })
+);
+
+// A source can also be specified when adding elements to tag the added elements
+gui()->addElement(this, {"a", "b"},
   mc_rtc::gui::Button("Button 1", []() { return; }),
   mc_rtc::gui::Button("Button 2", []() { return; }),
   mc_rtc::gui::Button("Button 3", []() { return; })
@@ -281,9 +290,15 @@ Form("Button name",
 
 GUIから要素を削除するための2つの関数が用意されています。
 
+{% comment %}FIXME Comment is not translated{% endcomment %}
+
 ```cpp
 // 単一の要素を名前で指定して削除
 gui()->removeElement({"a", "b"}, "element");
 // あるカテゴリ及びその全ての子カテゴリを削除
 gui()->removeCategory({"a", "b"});
+// Remove all elements added by source pointer this in, and only in, the provided category
+gui()->removeElements({"a", "b"}, this);
+// Remove all elements added by source pointer this in the provided category and its sub categories
+gui()->removeElements({"a", "b"}, this, true);
 ```

--- a/include/mc_rtc/gui/StateBuilder.h
+++ b/include/mc_rtc/gui/StateBuilder.h
@@ -43,7 +43,7 @@ struct MC_RTC_GUI_DLLAPI StateBuilder
 
   /** Add a given element
    *
-   * T must derive from Element
+   * \tparam T Must derive from Element
    *
    * \param category Category of the element
    *
@@ -51,6 +51,21 @@ struct MC_RTC_GUI_DLLAPI StateBuilder
    */
   template<typename T>
   void addElement(const std::vector<std::string> & category, T element);
+
+  /** Add a given element
+   *
+   * \tparam SourceT Type of the source pointer
+   *
+   * \tparam T Must derive from Element
+   *
+   * \param source Source attached to this object
+   *
+   * \param category Category of the element
+   *
+   * \param element Element added to the GUI
+   */
+  template<typename SourceT, typename T>
+  void addElement(SourceT * source, const std::vector<std::string> & category, T element);
 
   /** Add multiple elements to the same category at once
    *
@@ -62,6 +77,19 @@ struct MC_RTC_GUI_DLLAPI StateBuilder
    */
   template<typename T, typename... Args>
   void addElement(const std::vector<std::string> & category, T element, Args... args);
+
+  /** Add multiple elements to the same category at once
+   *
+   * \param source Source attached to this object
+   *
+   * \param category Category of the elements
+   *
+   * \param element Element added to the GUI
+   *
+   * \param args Other elements added to the GUI
+   */
+  template<typename SourceT, typename T, typename... Args>
+  void addElement(SourceT * source, const std::vector<std::string> & category, T element, Args... args);
 
   /** Add a given element and specify stacking
    *
@@ -76,6 +104,21 @@ struct MC_RTC_GUI_DLLAPI StateBuilder
   template<typename T>
   void addElement(const std::vector<std::string> & category, ElementsStacking stacking, T element);
 
+  /** Add a given element and specify stacking
+   *
+   * T must derive from Element
+   *
+   * \param source Source attached to this object
+   *
+   * \param category Category of the element
+   *
+   * \param stacking Stacking direction
+   *
+   * \param element Element added to the GUI
+   */
+  template<typename SourceT, typename T>
+  void addElement(SourceT * source, const std::vector<std::string> & category, ElementsStacking stacking, T element);
+
   /** Add multiple elements to the same category at once with a specific stacking
    *
    * \param category Category of the elements
@@ -88,6 +131,25 @@ struct MC_RTC_GUI_DLLAPI StateBuilder
    */
   template<typename T, typename... Args>
   void addElement(const std::vector<std::string> & category, ElementsStacking stacking, T element, Args... args);
+
+  /** Add multiple elements to the same category at once with a specific stacking
+   *
+   * \param source Source attached to this object
+   *
+   * \param category Category of the elements
+   *
+   * \param element Element added to the GUI
+   *
+   * \param stacking Stacking direction
+   *
+   * \param args Other elements added to the GUI
+   */
+  template<typename SourceT, typename T, typename... Args>
+  void addElement(SourceT * source,
+                  const std::vector<std::string> & category,
+                  ElementsStacking stacking,
+                  T element,
+                  Args... args);
 
   /** Checks if an element is already in the GUI
    *
@@ -106,6 +168,29 @@ struct MC_RTC_GUI_DLLAPI StateBuilder
 
   /** Remove a single element */
   void removeElement(const std::vector<std::string> & category, const std::string & name);
+
+  /** Remove all elements attached to the given source
+   *
+   * One should prefer to remove a category or target a specific category, otherwise the whole GUI has to be searched to
+   * find matching elements
+   *
+   * For example, if your source has added a category and a few elements in the root:
+   * gui()->removeCategory({"MyCategory"});
+   * gui()->removeElements({}, this);
+   * Should be used instead of:
+   * gui()->removeElements(this);
+   */
+  void removeElements(void * source);
+
+  /** Remove all elements attached to the given source in the specified category
+   *
+   * \param category Category where elements will be searched
+   *
+   * \param source Source that will be searched
+   *
+   * \param recurse Also search for elements in sub-categories of the given category
+   */
+  void removeElements(const std::vector<std::string> & category, void * source, bool recurse = false);
 
   /** Add a plot identified by the provided name
    *
@@ -269,7 +354,11 @@ struct MC_RTC_GUI_DLLAPI StateBuilder
 
 private:
   template<typename T>
-  void addElementImpl(const std::vector<std::string> & category, ElementsStacking stacking, T element, size_t rem = 0);
+  void addElementImpl(void * source,
+                      const std::vector<std::string> & category,
+                      ElementsStacking stacking,
+                      T element,
+                      size_t rem = 0);
 
   /** Holds static data for the GUI */
   mc_rtc::Configuration data_;
@@ -302,9 +391,10 @@ private:
     std::function<Element &()> element;
     void (*write)(Element &, mc_rtc::MessagePackBuilder &);
     bool (*handleRequest)(Element &, const mc_rtc::Configuration &);
+    void * source;
 
     template<typename T>
-    ElementStore(T self, const Category & category, ElementsStacking stacking);
+    ElementStore(T self, const Category & category, ElementsStacking stacking, void * source);
   };
   struct Category
   {
@@ -344,6 +434,9 @@ private:
 
   /** Update the GUI data state for a given category */
   void update(mc_rtc::MessagePackBuilder & builder, Category & category);
+
+  /** Remove all elements associated to the given in the given category */
+  void removeElements(Category & category, void * source);
 
   std::string cat2str(const std::vector<std::string> & category);
 

--- a/include/mc_rtc/gui/StateBuilder.h
+++ b/include/mc_rtc/gui/StateBuilder.h
@@ -331,18 +331,16 @@ private:
 
   /** Get a category
    *
-   * Returns false and parent category if the category does
-   * not exist, true and the request category otherwise
+   * Returns nullptr if the category does not exist
    *
    * \p category Requested category
    *
-   * \p getParent If true returns the parent category,
-   * otherwise returns the category
+   * \p depth Only consider the first \p depth elements in \p category (up-to category's size)
    */
-  std::pair<bool, Category &> getCategory(const std::vector<std::string> & category, bool getParent);
+  Category * getCategory(const std::vector<std::string> & category, size_t depth = std::numeric_limits<size_t>::max());
 
   /** Get a category, creates it if does not exist */
-  Category & getCategory(const std::vector<std::string> & category);
+  Category & getOrCreateCategory(const std::vector<std::string> & category);
 
   /** Update the GUI data state for a given category */
   void update(mc_rtc::MessagePackBuilder & builder, Category & category);

--- a/include/mc_rtc/gui/StateBuilder.hpp
+++ b/include/mc_rtc/gui/StateBuilder.hpp
@@ -32,7 +32,7 @@ void StateBuilder::addElementImpl(const std::vector<std::string> & category,
                                   size_t rem)
 {
   static_assert(std::is_base_of<Element, T>::value, "You can only add elements that derive from the Element class");
-  Category & cat = getCategory(category);
+  Category & cat = getOrCreateCategory(category);
   auto it = std::find_if(cat.elements.begin(), cat.elements.end(),
                          [&element](const ElementStore & el) { return el().name() == element.name(); });
   if(it != cat.elements.end())

--- a/include/mc_rtc/gui/StateBuilder.hpp
+++ b/include/mc_rtc/gui/StateBuilder.hpp
@@ -19,14 +19,30 @@ void StateBuilder::addElement(const std::vector<std::string> & category, T eleme
   addElement(category, ElementsStacking::Vertical, element);
 }
 
-template<typename T>
-void StateBuilder::addElement(const std::vector<std::string> & category, ElementsStacking stacking, T element)
+template<typename SourceT, typename T>
+void StateBuilder::addElement(SourceT * source, const std::vector<std::string> & category, T element)
 {
-  addElementImpl(category, stacking, element);
+  addElement(source, category, ElementsStacking::Vertical, element);
 }
 
 template<typename T>
-void StateBuilder::addElementImpl(const std::vector<std::string> & category,
+void StateBuilder::addElement(const std::vector<std::string> & category, ElementsStacking stacking, T element)
+{
+  addElementImpl(nullptr, category, stacking, element);
+}
+
+template<typename SourceT, typename T>
+void StateBuilder::addElement(SourceT * source,
+                              const std::vector<std::string> & category,
+                              ElementsStacking stacking,
+                              T element)
+{
+  addElementImpl(source, category, stacking, element);
+}
+
+template<typename T>
+void StateBuilder::addElementImpl(void * source,
+                                  const std::vector<std::string> & category,
                                   ElementsStacking stacking,
                                   T element,
                                   size_t rem)
@@ -41,7 +57,7 @@ void StateBuilder::addElementImpl(const std::vector<std::string> & category,
     log::warning("Discarding request to add this element");
     return;
   }
-  cat.elements.emplace_back(element, cat, stacking);
+  cat.elements.emplace_back(element, cat, stacking, source);
   if(rem == 0)
   {
     cat.id += 1;
@@ -54,6 +70,12 @@ void StateBuilder::addElement(const std::vector<std::string> & category, T eleme
   addElement(category, ElementsStacking::Vertical, element, args...);
 }
 
+template<typename SourceT, typename T, typename... Args>
+void StateBuilder::addElement(SourceT * source, const std::vector<std::string> & category, T element, Args... args)
+{
+  addElement(source, category, ElementsStacking::Vertical, element, args...);
+}
+
 template<typename T, typename... Args>
 void StateBuilder::addElement(const std::vector<std::string> & category,
                               ElementsStacking stacking,
@@ -61,12 +83,24 @@ void StateBuilder::addElement(const std::vector<std::string> & category,
                               Args... args)
 {
   size_t rem = stacking == ElementsStacking::Vertical ? 0 : sizeof...(args);
-  addElementImpl(category, stacking, element, rem);
+  addElementImpl(nullptr, category, stacking, element, rem);
+  addElement(category, stacking, args...);
+}
+
+template<typename SourceT, typename T, typename... Args>
+void StateBuilder::addElement(SourceT * source,
+                              const std::vector<std::string> & category,
+                              ElementsStacking stacking,
+                              T element,
+                              Args... args)
+{
+  size_t rem = stacking == ElementsStacking::Vertical ? 0 : sizeof...(args);
+  addElementImpl(source, category, stacking, element, rem);
   addElement(category, stacking, args...);
 }
 
 template<typename T>
-StateBuilder::ElementStore::ElementStore(T self, const Category & category, ElementsStacking stacking)
+StateBuilder::ElementStore::ElementStore(T self, const Category & category, ElementsStacking stacking, void * source)
 {
   self.id(category.id);
   // FIXME In C++14 we could have T && self and move it into the lambda
@@ -97,6 +131,7 @@ StateBuilder::ElementStore::ElementStore(T self, const Category & category, Elem
     T & el_ = static_cast<T &>(el);
     return el_.handleRequest(data);
   };
+  this->source = source;
 }
 
 template<typename... Args>

--- a/src/mc_rtc/gui/StateBuilder.cpp
+++ b/src/mc_rtc/gui/StateBuilder.cpp
@@ -83,26 +83,36 @@ void StateBuilder::removeCategory(const std::vector<std::string> & category)
     mc_rtc::log::warning("Call clear() if this was your intent");
     return;
   }
-  std::pair<bool, Category &> cat = getCategory(category, true);
-  if(cat.first)
+  size_t depth = category.size() - 1;
+  auto cat = getCategory(category, depth);
+  while(cat)
   {
-    auto it = cat.second.find(category.back());
-    if(it == cat.second.sub.end())
+    auto it = cat->find(category[depth]);
+    if(it == cat->sub.end())
     {
       return;
     }
-    cat.second.sub.erase(it);
+    cat->sub.erase(it);
+    if(cat->elements.size() == 0 && cat->sub.size() == 0 && depth > 0)
+    {
+      depth -= 1;
+      cat = getCategory(category, depth);
+    }
+    else
+    {
+      cat = nullptr;
+    }
   }
 }
 
 bool StateBuilder::hasElement(const std::vector<std::string> & category, const std::string & name)
 {
-  auto cat_ = getCategory(category, false);
-  if(!cat_.first)
+  auto cat_ = getCategory(category);
+  if(!cat_)
   {
     return false;
   }
-  const auto & cat = cat_.second;
+  const auto & cat = *cat_;
   auto it = std::find_if(cat.elements.begin(), cat.elements.end(),
                          [&name](const ElementStore & el) { return el().name() == name; });
   return it != cat.elements.end();
@@ -110,18 +120,21 @@ bool StateBuilder::hasElement(const std::vector<std::string> & category, const s
 
 void StateBuilder::removeElement(const std::vector<std::string> & category, const std::string & name)
 {
-  bool found;
-  std::reference_wrapper<Category> cat_(elements_);
-  std::tie(found, cat_) = getCategory(category, false);
-  Category & cat = cat_;
-  if(found)
+  auto cat_ = getCategory(category);
+  if(!cat_)
   {
-    auto it = std::find_if(cat.elements.begin(), cat.elements.end(),
-                           [&name](const ElementStore & el) { return el().name() == name; });
-    if(it != cat.elements.end())
-    {
-      cat.elements.erase(it);
-    }
+    return;
+  }
+  auto & cat = *cat_;
+  auto it = std::find_if(cat.elements.begin(), cat.elements.end(),
+                         [&name](const ElementStore & el) { return el().name() == name; });
+  if(it != cat.elements.end())
+  {
+    cat.elements.erase(it);
+  }
+  if(cat.elements.size() == 0 && cat.sub.size() == 0)
+  {
+    removeCategory(category);
   }
 }
 
@@ -179,15 +192,13 @@ bool StateBuilder::handleRequest(const std::vector<std::string> & category,
                                  const std::string & name,
                                  const mc_rtc::Configuration & data)
 {
-  bool found;
-  std::reference_wrapper<Category> cat_(elements_);
-  std::tie(found, cat_) = getCategory(category, false);
-  if(!found)
+  auto cat_ = getCategory(category);
+  if(!cat_)
   {
     mc_rtc::log::error("No category {}", cat2str(category));
     return false;
   }
-  Category & cat = cat_;
+  Category & cat = *cat_;
   auto it = std::find_if(cat.elements.begin(), cat.elements.end(),
                          [&name](const ElementStore & el) { return el().name() == name; });
   if(it == cat.elements.end())
@@ -215,31 +226,24 @@ mc_rtc::Configuration StateBuilder::data()
   return data_;
 }
 
-std::pair<bool, StateBuilder::Category &> StateBuilder::getCategory(const std::vector<std::string> & category,
-                                                                    bool getParent)
+auto StateBuilder::getCategory(const std::vector<std::string> & category, size_t depth) -> Category *
 {
-  std::reference_wrapper<Category> cat_(elements_);
-  size_t limit = category.size();
-  if(getParent)
-  {
-    assert(limit > 0);
-    limit -= 1;
-  }
+  Category * cat_ = &elements_;
+  size_t limit = std::min(depth, category.size());
   for(size_t i = 0; i < limit; ++i)
   {
     const auto & c = category[i];
-    Category & cat = cat_;
-    auto it = cat.find(c);
-    if(it == cat.sub.end())
+    auto it = cat_->find(c);
+    if(it == cat_->sub.end())
     {
-      return {false, cat_};
+      return nullptr;
     }
-    cat_ = *it;
+    cat_ = &(*it);
   }
-  return {true, cat_};
+  return cat_;
 }
 
-StateBuilder::Category & StateBuilder::getCategory(const std::vector<std::string> & category)
+StateBuilder::Category & StateBuilder::getOrCreateCategory(const std::vector<std::string> & category)
 {
   std::reference_wrapper<Category> cat_(elements_);
   for(const auto & c : category)

--- a/tests/testGUIStateBuilder.cpp
+++ b/tests/testGUIStateBuilder.cpp
@@ -18,11 +18,18 @@ BOOST_AUTO_TEST_CASE(TestGUIStateBuilder)
 {
   DummyProvider provider;
   mc_rtc::gui::StateBuilder builder;
+  std::vector<char> buffer;
+  auto empty_size = builder.update(buffer);
   builder.addElement({"dummy", "provider"}, mc_rtc::gui::Label("value", [&provider] { return provider.value; }));
   builder.addElement({"dummy", "provider"}, mc_rtc::gui::ArrayLabel("point", [&provider] { return provider.point; }));
-  std::vector<char> buffer;
-  auto s = builder.update(buffer);
-  std::cout << "state size " << s << "\n";
-  auto state = mc_rtc::Configuration::fromMessagePack(buffer.data(), s);
-  std::cout << state.dump(true) << "\n";
+  {
+    auto s = builder.update(buffer);
+    BOOST_REQUIRE(s != empty_size);
+  }
+  builder.removeElement({"dummy", "provider"}, "value");
+  builder.removeElement({"dummy", "provider"}, "point");
+  {
+    auto s = builder.update(buffer);
+    BOOST_REQUIRE(s == empty_size);
+  }
 }

--- a/tests/testGUIStateBuilder.cpp
+++ b/tests/testGUIStateBuilder.cpp
@@ -19,15 +19,93 @@ BOOST_AUTO_TEST_CASE(TestGUIStateBuilder)
   DummyProvider provider;
   mc_rtc::gui::StateBuilder builder;
   std::vector<char> buffer;
+  // Size of the GUI message when the GUI is empty
   auto empty_size = builder.update(buffer);
+  builder.addElement({"dummy", "provider"}, mc_rtc::gui::Label("value", [&provider] { return provider.value; }));
+  builder.addElement({"dummy", "provider"}, mc_rtc::gui::ArrayLabel("point", [&provider] { return provider.point; }));
+  // Check that after adding elements we have a different size, ref_size is our full message
+  auto ref_size = builder.update(buffer);
+  {
+    BOOST_REQUIRE(ref_size != empty_size);
+  }
+  builder.removeElement({"dummy", "provider"}, "value");
+  builder.removeElement({"dummy", "provider"}, "point");
+  // Removing all elements manually sends us back to the empty state
+  {
+    auto s = builder.update(buffer);
+    BOOST_REQUIRE(s == empty_size);
+  }
+  // Add the elements back
   builder.addElement({"dummy", "provider"}, mc_rtc::gui::Label("value", [&provider] { return provider.value; }));
   builder.addElement({"dummy", "provider"}, mc_rtc::gui::ArrayLabel("point", [&provider] { return provider.point; }));
   {
     auto s = builder.update(buffer);
+    BOOST_REQUIRE(s == ref_size);
+  }
+  // Removing through the category should clean up the full GUI
+  builder.removeCategory({"dummy", "provider"});
+  {
+    auto s = builder.update(buffer);
+    BOOST_REQUIRE(s == empty_size);
+  }
+  // Now we add them with explicit sources
+  builder.addElement(&provider, {"dummy", "provider"},
+                     mc_rtc::gui::Label("value", [&provider] { return provider.value; }));
+  builder.addElement(&provider, {"dummy", "provider"},
+                     mc_rtc::gui::ArrayLabel("point", [&provider] { return provider.point; }));
+  {
+    auto s = builder.update(buffer);
+    BOOST_REQUIRE(s == ref_size);
+  }
+  // We remove by providing the source only
+  builder.removeElements(&provider);
+  {
+    auto s = builder.update(buffer);
+    BOOST_REQUIRE(s == empty_size);
+  }
+  builder.addElement(&provider, {"dummy"}, mc_rtc::gui::Label("value", [&provider] { return provider.value; }));
+  // New ref_size for the GUI with one element
+  ref_size = builder.update(buffer);
+  BOOST_REQUIRE(ref_size != empty_size);
+  builder.addElement(&provider, {"dummy", "provider"},
+                     mc_rtc::gui::ArrayLabel("point", [&provider] { return provider.point; }));
+  {
+    auto s = builder.update(buffer);
+    BOOST_REQUIRE(s != ref_size && s != empty_size);
+  }
+  // Remove elements within a category using a source
+  builder.removeElements({"dummy", "provider"}, &provider);
+  {
+    auto s = builder.update(buffer);
+    BOOST_REQUIRE(s == ref_size);
+  }
+  builder.removeElements({"dummy"}, &provider);
+  {
+    auto s = builder.update(buffer);
+    BOOST_REQUIRE(s == empty_size);
+  }
+  // Update ref_size
+  builder.addElement(&provider, {"dummy"}, mc_rtc::gui::Label("value", [&provider] { return provider.value; }));
+  builder.addElement(&provider, {"dummy", "provider"},
+                     mc_rtc::gui::ArrayLabel("point", [&provider] { return provider.point; }));
+  ref_size = builder.update(buffer);
+  {
+    BOOST_REQUIRE(ref_size != empty_size);
+  }
+  // Remove only the elements of a given category (no recursion)
+  builder.removeElements({"dummy"}, &provider, false);
+  {
+    auto s = builder.update(buffer);
     BOOST_REQUIRE(s != empty_size);
   }
-  builder.removeElement({"dummy", "provider"}, "value");
-  builder.removeElement({"dummy", "provider"}, "point");
+  // Restore the message
+  builder.addElement(&provider, {"dummy"}, mc_rtc::gui::Label("value", [&provider] { return provider.value; }));
+  {
+    auto s = builder.update(buffer);
+    BOOST_REQUIRE(s == ref_size);
+  }
+  // Remove the elements of a given category with recursion
+  builder.removeElements({"dummy"}, &provider, true);
   {
     auto s = builder.update(buffer);
     BOOST_REQUIRE(s == empty_size);


### PR DESCRIPTION
This PR allows simpler cleanup when multiple elements are added to a category.

For example, for the root category, the following:
```cpp
gui()->addElement({}, Elem1, Elem2, Elem3);
gui()->removeElement({}, Elem1);
gui()->removeElement({}, Elem2);
gui()->removeElement({}, Elem3);
```

Can be replaced with:
```cpp
gui()->addElement(this, {}, Elem1, Elem2, Elem3);
gui()->removeElements({}, this);
```

By default, the `removeElements(category, source)` function is not recursive (i.e. it only removes elements at the provided category) as the goal is to "targeted" removals. However, this can be tweaked via a flag.

The PR also contains changes that ensures the GUI message is cleaned up when elements are removed (previously empty categories could persist forever)

This new capability is not used inside mc_rtc itself since GUI cleanup is either done through category removal or targeted to specific elements.