### PR TITLE
[ROS] Ensure that quaternions are normalized

### DIFF
--- a/plugins/ROS/src/mc_rtc_ros/ros.cpp
+++ b/plugins/ROS/src/mc_rtc_ros/ros.cpp
@@ -36,6 +36,7 @@ inline geometry_msgs::TransformStamped PT2TF(const sva::PTransformd & X,
   msg.child_frame_id = to;
 
   Eigen::Vector4d q = Eigen::Quaterniond(X.rotation()).inverse().coeffs();
+  q.normalize();
   const Eigen::Vector3d & t = X.translation();
 
   msg.transform.translation.x = t.x();


### PR DESCRIPTION
This PR simply ensures that the rotation of transforms published over ROS is properly normalized. In most cases this is not needed, but there are some odd cases such as https://github.com/isri-aist/mc_hrp4cr/pull/11 (left handed force sensor frame) where unnormalized quaternion gets published. This down the line leads to many ROS tools complaining ;)