### PR TITLE
[fsm] Load init_pos consistently for MainRobot and other robots

### DIFF
--- a/src/mc_control/fsm/Controller.cpp
+++ b/src/mc_control/fsm/Controller.cpp
@@ -69,6 +69,11 @@ Controller::Controller(std::shared_ptr<mc_rbdyn::RobotModule> rm, double dt, con
   idle_keep_state_ = config("IdleKeepState", false);
   /** Load additional robots from the configuration */
   {
+    if(config.has("init_pos"))
+    {
+      robot().posW(config("init_pos"));
+      realRobot().posW(robot().posW());
+    }
     auto config_robots = config("robots", std::map<std::string, mc_rtc::Configuration>{});
     for(const auto & cr : config_robots)
     {
@@ -236,11 +241,6 @@ bool Controller::run(mc_solver::FeedbackType fType)
 void Controller::reset(const ControllerResetData & data)
 {
   MCController::reset(data);
-  if(config().has("init_pos"))
-  {
-    robot().posW(config()("init_pos"));
-    realRobot().posW(robot().posW());
-  }
   auto startUpdateContacts = clock::now();
   updateContacts();
   updateContacts_dt_ = clock::now() - startUpdateContacts;


### PR DESCRIPTION
Currently, the initial pose of the robots is loaded slightly inconsitently:
- For the main robot is is loaded in `fsm::Controller::reset()`
- For additional robots it is loaded in `fsm::Controller::Controller()` constructor

In general this is not an issue, but this causes inconsitencies in `mc_mujoco` with only some robots loaded in the correct position. This PR loads `init_pos` for all robots in the constructor, which makes it more consistent and fixes the aforementioned issue.