### PR TITLE
[build_and_install] Fixes about python3 and catkin workspaces

### DIFF
--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["debian:buster", "ubuntu:focal"]
+        os: ["debian:buster"]
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,6 +51,12 @@ jobs:
       run: |
         sudo rm '/usr/local/bin/2to3'
       if: startsWith(runner.os, 'macOS')
+    - name: Install pip for Python 2 (Ubuntu 20.04)
+      run: |
+        curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py
+        sudo python2 get-pip.py
+        rm -f get-pip.py
+      if: matrix.os == 'ubuntu-20.04' && matrix.build-type != 'script'
     - name: Clear environment (script)
       uses: jrl-umi3218/github-actions/install-dependencies@master
       if: matrix.build-type == 'script'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-18.04, macos-latest, windows-latest]
+        os: [ubuntu-20.04, ubuntu-18.04, macos-latest, windows-latest]
         build-type: [Debug, RelWithDebInfo, script]
         compiler: [gcc, clang]
         exclude:
@@ -71,7 +71,7 @@ jobs:
         fi
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master
-      if: matrix.build-type != 'script'
+      if: matrix.build-type != 'script' && matrix.os != 'ubuntu-20.04'
       with:
         compiler: ${{ matrix.compiler }}
         build-type: ${{ matrix.build-type }}
@@ -116,14 +116,14 @@ jobs:
           - path: jrl-umi3218/eigen-quadprog
           - path: jrl-umi3218/state-observation
     - name: Build and test
-      if: matrix.build-type == 'RelWithDebInfo' || (matrix.build-type == 'Debug' && github.ref == 'refs/heads/master')
+      if: matrix.os != 'ubuntu-20.04' && matrix.build-type == 'RelWithDebInfo' || (matrix.build-type == 'Debug' && github.ref == 'refs/heads/master')
       uses: jrl-umi3218/github-actions/build-cmake-project@master
       with:
         compiler: ${{ matrix.compiler }}
         build-type: ${{ matrix.build-type }}
         windows-options: -DPYTHON_BINDING:BOOL=OFF
     - name: Build and test (Debug/Fast tests)
-      if: matrix.build-type == 'Debug' && github.ref != 'refs/heads/master'
+      if: matrix.os != 'ubuntu-20.04' && matrix.build-type == 'Debug' && github.ref != 'refs/heads/master'
       uses: jrl-umi3218/github-actions/build-cmake-project@master
       with:
         compiler: ${{ matrix.compiler }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       with:
         submodules: recursive
     - name: Linux cleanup
-      if: matrix.os == 'ubuntu-18.04'
+      if: matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04'
       run: |
         set -e
         echo "LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/x86_64-linux-gnu/:${LD_LIBRARY_PATH}" >> $GITHUB_ENV

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,7 +71,7 @@ jobs:
         fi
     - name: Install dependencies
       uses: jrl-umi3218/github-actions/install-dependencies@master
-      if: matrix.build-type != 'script' && matrix.os != 'ubuntu-20.04'
+      if: matrix.build-type != 'script'
       with:
         compiler: ${{ matrix.compiler }}
         build-type: ${{ matrix.build-type }}
@@ -116,21 +116,21 @@ jobs:
           - path: jrl-umi3218/eigen-quadprog
           - path: jrl-umi3218/state-observation
     - name: Build and test
-      if: matrix.os != 'ubuntu-20.04' && matrix.build-type == 'RelWithDebInfo' || (matrix.build-type == 'Debug' && github.ref == 'refs/heads/master')
+      if: matrix.build-type == 'RelWithDebInfo' || (matrix.build-type == 'Debug' && github.ref == 'refs/heads/master')
       uses: jrl-umi3218/github-actions/build-cmake-project@master
       with:
         compiler: ${{ matrix.compiler }}
         build-type: ${{ matrix.build-type }}
         windows-options: -DPYTHON_BINDING:BOOL=OFF
     - name: Build and test (Debug/Fast tests)
-      if: matrix.os != 'ubuntu-20.04' && matrix.build-type == 'Debug' && github.ref != 'refs/heads/master'
+      if: matrix.build-type == 'Debug' && github.ref != 'refs/heads/master'
       uses: jrl-umi3218/github-actions/build-cmake-project@master
       with:
         compiler: ${{ matrix.compiler }}
         build-type: ${{ matrix.build-type }}
         options: '-DENABLE_FAST_TESTS:BOOL=ON'
     - name: Build with ROS
-      if: (matrix.os == 'ubuntu-18.04') && matrix.build-type != 'script'
+      if: (matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04') && matrix.build-type != 'script'
       run: |
         set -e
         set -x

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -690,7 +690,7 @@ then
   fi
   CATKIN_DATA_WORKSPACE=$SOURCE_DIR/catkin_data_ws
   CATKIN_DATA_WORKSPACE_SRC=${CATKIN_DATA_WORKSPACE}/src
-  if [[ ! -f $CATKIN_DATA_WORKSPACE_SRC/devel/setup.bash ]]
+  if [[ ! -f $CATKIN_DATA_WORKSPACE/devel/setup.bash ]]
   then
     mkdir -p ${CATKIN_DATA_WORKSPACE_SRC}
     if $NOT_CLONE_ONLY
@@ -706,7 +706,7 @@ then
   fi
   CATKIN_WORKSPACE=$SOURCE_DIR/catkin_ws
   CATKIN_WORKSPACE_SRC=${CATKIN_WORKSPACE}/src
-  if [[ ! -f $CATKIN_WORKSPACE_SRC/devel/setup.bash ]]
+  if [[ ! -f $CATKIN_WORKSPACE/devel/setup.bash ]]
   then
     mkdir -p ${CATKIN_WORKSPACE_SRC}
     if $NOT_CLONE_ONLY

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -24,7 +24,7 @@ fi
 
 readonly this_dir=`cd $(dirname $0); pwd`
 readonly mc_rtc_dir=`cd $this_dir/..; pwd`
-readonly PYTHON_VERSION=`python -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))'`
+PYTHON_VERSION=`python -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))'`
 
 . "$this_dir/build_and_install_default_config.sh"
 
@@ -478,11 +478,24 @@ then
   mkdir -p $SOURCE_DIR
 fi
 
+
+if [ "x$PYTHON_FORCE_PYTHON2" == xON ] ; then
+  PYTHON_VERSION=`python2 -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))'`
+elif [ "x$PYTHON_FORCE_PYTHON3" == xON ] ; then
+  PYTHON_VERSION=`python3 -c 'import sys; print("{}.{}".format(sys.version_info.major, sys.version_info.minor))'`
+fi
+readonly PYTHON_VERSION
+
 export PATH=$INSTALL_PREFIX/bin:$PATH
 export LD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$LD_LIBRARY_PATH
 export DYLD_LIBRARY_PATH=$INSTALL_PREFIX/lib:$DYLD_LIBRARY_PATH
 export PKG_CONFIG_PATH=$INSTALL_PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH
 export PYTHONPATH=$INSTALL_PREFIX/lib/python$PYTHON_VERSION/site-packages:$PYTHONPATH
+echo_log "PATH: $PATH"
+echo_log "LD_LIBRARY_PATH: $LD_LIBRARY_PATH"
+echo_log "DYLD_LIBRARY_PATH: $DYLD_LIBRARY_PATH"
+echo_log "PKG_CONFIG_PATH: $PKG_CONFIG_PATH"
+echo_log "PYTHONPATH: $PYTHONPATH"
 
 #make settings readonly
 readonly INSTALL_PREFIX

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -385,7 +385,7 @@ install_apt()
   if [ "${TO_INSTALL}" != "" ]
   then
     exec_log sudo apt-get update
-    exec_log sudo apt-get -y install ${TO_INSTALL}
+    exec_log sudo apt-get -y install $*
   fi
   exit_if_error "-- [ERROR] Could not install one of the following packages ${TO_INSTALL}."
 }

--- a/utils/config_build_and_install.focal.sh
+++ b/utils/config_build_and_install.focal.sh
@@ -14,12 +14,4 @@ mc_rtc_extra_steps()
     # pip3 gets overwritten by the get-pip.py script, but the python3-pip package remains installed. This usures that pip3 remains cleanly installed.
     sudo apt-get install --reinstall -y python3-pip
   fi
-
-  if [ "x$PYTHON_FORCE_PYTHON2" == xON ]
-  then
-    export MC_LOG_UI_PYTHON_EXECUTABLE=python2
-  else
-    export MC_LOG_UI_PYTHON_EXECUTABLE=python3
-  fi
-
 }

--- a/utils/config_build_and_install.focal.sh
+++ b/utils/config_build_and_install.focal.sh
@@ -14,4 +14,5 @@ mc_rtc_extra_steps()
     # pip3 gets overwritten by the get-pip.py script, but the python3-pip package remains installed. This usures that pip3 remains cleanly installed.
     sudo apt-get install --reinstall -y python3-pip
   fi
+  export MC_LOG_UI_PYTHON_EXECUTABLE=python3
 }

--- a/utils/config_build_and_install.focal.sh
+++ b/utils/config_build_and_install.focal.sh
@@ -8,7 +8,8 @@ fi
 
 mc_rtc_extra_steps()
 {
-  if [ "x$PYTHON_FORCE_PYTHON2" == xON || "x$PYTHON_BUILD_PYTHON2_AND_PYTHON3" == xON]
+  PYTHON_VERSION_MAJOR=`python -c 'import sys; print("{}".format(sys.version_info.major))'`
+  if [ "x$PYTHON_FORCE_PYTHON2" == xON || "x$PYTHON_BUILD_PYTHON2_AND_PYTHON3" == xON || "x$PYTHON_VERSION_MAJOR" == x2 ]
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && sudo python2 get-pip.py && rm -f get-pip.py
     sudo pip install matplotlib
     # pip3 gets overwritten by the get-pip.py script, but the python3-pip package remains installed. This usures that pip3 remains cleanly installed.

--- a/utils/config_build_and_install.focal.sh
+++ b/utils/config_build_and_install.focal.sh
@@ -5,10 +5,17 @@ if $BUILD_BENCHMARKS
 then
   export APT_DEPENDENCIES="$APT_DEPENDENCIES libbenchmark-dev"
 fi
+export PYTHON_VERSION_MAJOR=`python -c 'import sys; print("{}".format(sys.version_info.major))'`
+if [ "x$PYTHON_VERSION_MAJOR" == x2 ]
+then
+  export APT_DEPENDENCIES="$APT_DEPENDENCIES python-is-python2"
+elif [ "x$PYTHON_VERSION_MAJOR" == x3 ]
+then
+  export APT_DEPENDENCIES="$APT_DEPENDENCIES python-is-python3"
+fi
 
 mc_rtc_extra_steps()
 {
-  PYTHON_VERSION_MAJOR=`python -c 'import sys; print("{}".format(sys.version_info.major))'`
   if [ "x$PYTHON_FORCE_PYTHON2" == xON || "x$PYTHON_BUILD_PYTHON2_AND_PYTHON3" == xON || "x$PYTHON_VERSION_MAJOR" == x2 ]
     curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && sudo python2 get-pip.py && rm -f get-pip.py
     sudo pip install matplotlib

--- a/utils/config_build_and_install.focal.sh
+++ b/utils/config_build_and_install.focal.sh
@@ -8,7 +8,18 @@ fi
 
 mc_rtc_extra_steps()
 {
-  curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && sudo python2 get-pip.py && rm -f get-pip.py
-  sudo pip install matplotlib
-  export MC_LOG_UI_PYTHON_EXECUTABLE=python3
+  if [ "x$PYTHON_FORCE_PYTHON2" == xON || "x$PYTHON_BUILD_PYTHON2_AND_PYTHON3" == xON]
+    curl https://bootstrap.pypa.io/pip/2.7/get-pip.py -o get-pip.py && sudo python2 get-pip.py && rm -f get-pip.py
+    sudo pip install matplotlib
+    # pip3 gets overwritten by the get-pip.py script, but the python3-pip package remains installed. This usures that pip3 remains cleanly installed.
+    sudo apt-get install --reinstall -y python3-pip
+  fi
+
+  if [ "x$PYTHON_FORCE_PYTHON2" == xON ]
+  then
+    export MC_LOG_UI_PYTHON_EXECUTABLE=python2
+  else
+    export MC_LOG_UI_PYTHON_EXECUTABLE=python3
+  fi
+
 }


### PR DESCRIPTION
This PR contains small fixes to the `build_and_install` script:
- The existance check for the catkin workspaces is currently broken (it checks for `<src>/catkin_ws/src/devel/setup.bash` instead of `<src>/catkin_ws/devel/setup.bash`). This causes the catkin workspaces to build before the update/installation.
- On Ubuntu 20.04:
  - When building with both python2 and python3 the pip2 boostrap script causes `pip3` to get uninstalled, even though the ubuntu package apears intact. This causes the python3 bindings generation to fail down the line. This is fixed by forcing a reinstallation of `python3-pip` after installing `pip2`.
  - When forcing the install with `python3`, the suggested python paths at the end of the script are wrong (pointing to the non-existing python2 install).

I also added the `build_and_install.sh` script build to the CI.