### PR TITLE
Improve controller base

### DIFF
--- a/debian/libmc-rtc-dev.install
+++ b/debian/libmc-rtc-dev.install
@@ -5,6 +5,7 @@ usr/include/mc_rbdyn/*
 usr/include/mc_robots/*
 usr/include/mc_rtc/gui/*
 usr/include/mc_rtc/log/*
+usr/include/mc_rtc/clock.h
 usr/include/mc_rtc/config.h
 usr/include/mc_rtc/Configuration.h
 usr/include/mc_rtc/ConfigurationHelpers.h

--- a/include/mc_control/Contact.h
+++ b/include/mc_control/Contact.h
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_control/api.h>
+
+#include <mc_rbdyn/Contact.h>
+
+#include <mc_rtc/Configuration.h>
+
+namespace mc_control
+{
+
+struct MCController;
+
+/** \class Contact
+ *
+ * A lightweight variant of mc_rbdyn::Contact meant to simplify contact manipulations
+ *
+ */
+struct MC_CONTROL_DLLAPI Contact
+{
+  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
+
+  Contact(const std::string & r1,
+          const std::string & r2,
+          const std::string & r1Surface,
+          const std::string & r2Surface,
+          double friction = mc_rbdyn::Contact::defaultFriction,
+          const Eigen::Vector6d & dof = Eigen::Vector6d::Ones())
+  : r1(r1), r2(r2), r1Surface(r1Surface), r2Surface(r2Surface), friction(friction), dof(dof)
+  {
+  }
+
+  std::string r1;
+  std::string r2;
+  std::string r1Surface;
+  std::string r2Surface;
+  mutable double friction;
+  mutable Eigen::Vector6d dof;
+
+  bool operator==(const Contact & rhs) const
+  {
+    return (r1 == rhs.r1 && r2 == rhs.r2 && r1Surface == rhs.r1Surface && r2Surface == rhs.r2Surface)
+           || (r1 == rhs.r2 && r2 == rhs.r1 && r1Surface == rhs.r2Surface && r2Surface == rhs.r1Surface);
+  }
+
+  bool operator!=(const Contact & rhs) const
+  {
+    return !(*this == rhs);
+  }
+
+  /** Default constructor, invalid contact */
+  Contact() = default;
+
+  /** Conversion from mc_rbdyn::Contact */
+  static Contact from_mc_rbdyn(const MCController &, const mc_rbdyn::Contact &);
+};
+
+using ContactSet =
+    std::unordered_set<Contact, std::hash<Contact>, std::equal_to<Contact>, Eigen::aligned_allocator<Contact>>;
+
+} // namespace mc_control
+
+namespace std
+{
+
+template<>
+struct hash<mc_control::Contact>
+{
+  std::size_t operator()(const mc_control::Contact & c) const noexcept
+  {
+    // Same as boost::hash_combine
+    auto hash_combine = [](const std::string & robot, const std::string & surface) {
+      auto h = std::hash<std::string>{}(robot);
+      h ^= std::hash<std::string>{}(surface) + 0x9e3779b9 + (h << 6) + (h >> 2);
+      return h;
+    };
+    return hash_combine(c.r1, c.r1Surface) ^ hash_combine(c.r2, c.r2Surface);
+  }
+};
+
+} // namespace std
+
+namespace mc_rtc
+{
+
+template<>
+struct MC_CONTROL_DLLAPI ConfigurationLoader<mc_control::Contact>
+{
+  static mc_control::Contact load(const mc_rtc::Configuration & config);
+};
+
+} // namespace mc_rtc

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -526,6 +526,7 @@ protected:
   ContactSet contacts_;
   /** True if contacts were changed in the previous round */
   bool contacts_changed_;
+  /** Data shown in the contacts' table: R1, R1Surface, R2, R2Surface, DoF, Friction */
   using ContactTableDataT = std::tuple<std::string, std::string, std::string, std::string, std::string, double>;
   /** Used in GUI display */
   std::vector<ContactTableDataT> contacts_table_;

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -229,6 +229,9 @@ public:
    */
   void removeContact(const Contact & c);
 
+  /** Remove all contacts */
+  void clearContacts();
+
   /** Access the current contacts */
   const ContactSet & contacts() const;
 

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -526,8 +526,9 @@ protected:
   ContactSet contacts_;
   /** True if contacts were changed in the previous round */
   bool contacts_changed_;
+  using ContactTableDataT = std::tuple<std::string, std::string, std::string, std::string, std::string, double>;
   /** Used in GUI display */
-  std::string contacts_str_;
+  std::vector<ContactTableDataT> contacts_table_;
 
   using duration_ms = std::chrono::duration<double, std::milli>;
   /** Monitor updateContacts runtime */

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -1,10 +1,11 @@
 /*
- * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL, BIT
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #pragma once
 
 #include <mc_control/Configuration.h>
+#include <mc_control/Contact.h>
 
 #include <mc_observers/ObserverPipeline.h>
 
@@ -188,6 +189,54 @@ public:
    * \throws if the main robot is not supported (see supported_robots())
    */
   virtual void reset(const ControllerResetData & reset_data);
+
+  /** Add collisions-pair between two robots
+   *
+   * If the r1-r2 collision manager does not exist yet, it is created and
+   * added to the solver.
+   */
+  void addCollisions(const std::string & r1,
+                     const std::string & r2,
+                     const std::vector<mc_rbdyn::Collision> & collisions);
+
+  /** Remove collisions-pair between two robots
+   *
+   * If the r1-r2 collision manager does not exist yet, this has no
+   * effect.
+   */
+  void removeCollisions(const std::string & r1,
+                        const std::string & r2,
+                        const std::vector<mc_rbdyn::Collision> & collisions);
+
+  /** Remove all collision-pair between two robots
+   *
+   * If the r1-r2 collision manager does not exist yet, this has no
+   * effect.
+   */
+  void removeCollisions(const std::string & r1, const std::string & r2);
+
+  /** Add a contact between two robots
+   *
+   * No effect if the contact is already present.
+   *
+   */
+  void addContact(const Contact & c);
+
+  /** Remove a contact between two robots
+   *
+   * No effect if the contact is already absent.
+   *
+   */
+  void removeContact(const Contact & c);
+
+  /** Access the current contacts */
+  const ContactSet & contacts() const;
+
+  /** Check if a contact is already present */
+  bool hasContact(const Contact & c) const;
+
+  /** Returns true if the robot is part of the controller */
+  bool hasRobot(const std::string & robot) const;
 
   /** Return the main robot (first robot provided in the constructor)
    * \anchor mc_controller_robot_const_doc
@@ -437,6 +486,9 @@ protected:
                               mc_rbdyn::Robots & robots,
                               bool updateNrVars = true);
 
+  /** Update the contacts (or their DoFs) if needed */
+  void updateContacts();
+
 protected:
   /** QP solver */
   std::shared_ptr<mc_solver::QPSolver> qpsolver;
@@ -455,6 +507,28 @@ protected:
   /** DataStore to share variables/objects between different parts of the
    * framework (states...) */
   mc_rtc::DataStore datastore_;
+
+  /** Holds dynamics, kinematics and contact constraints that are added
+   * from the start by the controller */
+  std::vector<mc_solver::ConstraintSetPtr> constraints_;
+
+  /** Keep track of the contact constraint */
+  std::shared_ptr<mc_solver::ContactConstraint> contact_constraint_ = nullptr;
+
+  /** Collision managers for robot-pair (r1, r2), if r1 == r2 this is
+   * effectively a self-collision manager */
+  std::map<std::pair<std::string, std::string>, std::shared_ptr<mc_solver::CollisionsConstraint>> collision_constraints_;
+
+  /** FSM contacts */
+  ContactSet contacts_;
+  /** True if contacts were changed in the previous round */
+  bool contacts_changed_;
+  /** Used in GUI display */
+  std::string contacts_str_;
+
+  using duration_ms = std::chrono::duration<double, std::milli>;
+  /** Monitor updateContacts runtime */
+  duration_ms updateContacts_dt_{0};
 
 public:
   /** Controller timestep */

--- a/include/mc_control/fsm/Controller.h
+++ b/include/mc_control/fsm/Controller.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #pragma once
@@ -19,73 +19,11 @@ namespace fsm
 
 struct Controller;
 
-/** \class Contact
- *
- * A lightweight variant of mc_rbdyn::Contact meant to simplify contact
- * manipulation in the FSM
- *
- */
-struct MC_CONTROL_FSM_DLLAPI Contact
-{
-  EIGEN_MAKE_ALIGNED_OPERATOR_NEW
-
-  Contact(const std::string & r1,
-          const std::string & r2,
-          const std::string & r1Surface,
-          const std::string & r2Surface,
-          double friction = mc_rbdyn::Contact::defaultFriction,
-          const Eigen::Vector6d & dof = Eigen::Vector6d::Ones())
-  : r1(r1), r2(r2), r1Surface(r1Surface), r2Surface(r2Surface), friction(friction), dof(dof)
-  {
-  }
-
-  std::string r1;
-  std::string r2;
-  std::string r1Surface;
-  std::string r2Surface;
-  mutable double friction;
-  mutable Eigen::Vector6d dof;
-
-  bool operator==(const Contact & rhs) const
-  {
-    return (r1 == rhs.r1 && r2 == rhs.r2 && r1Surface == rhs.r1Surface && r2Surface == rhs.r2Surface)
-           || (r1 == rhs.r2 && r2 == rhs.r1 && r1Surface == rhs.r2Surface && r2Surface == rhs.r1Surface);
-  }
-
-  bool operator!=(const Contact & rhs) const
-  {
-    return !(*this == rhs);
-  }
-
-  /** Default constructor, invalid contact */
-  Contact() = default;
-
-  static Contact from_mc_rbdyn(const Controller &, const mc_rbdyn::Contact &);
-};
+using Contact = mc_control::Contact;
 
 } // namespace fsm
 
 } // namespace mc_control
-
-namespace std
-{
-
-template<>
-struct hash<mc_control::fsm::Contact>
-{
-  std::size_t operator()(const mc_control::fsm::Contact & c) const noexcept
-  {
-    // Same as boost::hash_combine
-    auto hash_combine = [](const std::string & robot, const std::string & surface) {
-      auto h = std::hash<std::string>{}(robot);
-      h ^= std::hash<std::string>{}(surface) + 0x9e3779b9 + (h << 6) + (h >> 2);
-      return h;
-    };
-    return hash_combine(c.r1, c.r1Surface) ^ hash_combine(c.r2, c.r2Surface);
-  }
-};
-
-} // namespace std
 
 namespace mc_control
 {
@@ -93,8 +31,7 @@ namespace mc_control
 namespace fsm
 {
 
-using ContactSet =
-    std::unordered_set<Contact, std::hash<Contact>, std::equal_to<Contact>, Eigen::aligned_allocator<Contact>>;
+using ContactSet = mc_control::ContactSet;
 
 /** \class Controller
  *
@@ -158,44 +95,6 @@ struct MC_CONTROL_FSM_DLLAPI Controller : public MCController
    */
   bool resume(const std::string & state);
 
-  /** Add collisions-pair between two robots
-   *
-   * If the r1-r2 collision manager does not exist yet, it is created and
-   * added to the solver.
-   */
-  void addCollisions(const std::string & r1,
-                     const std::string & r2,
-                     const std::vector<mc_rbdyn::Collision> & collisions);
-
-  /** Remove collisions-pair between two robots
-   *
-   * If the r1-r2 collision manager does not exist yet, this has no
-   * effect.
-   */
-  void removeCollisions(const std::string & r1,
-                        const std::string & r2,
-                        const std::vector<mc_rbdyn::Collision> & collisions);
-
-  /** Remove all collision-pair between two robots
-   *
-   * If the r1-r2 collision manager does not exist yet, this has no
-   * effect.
-   */
-  void removeCollisions(const std::string & r1, const std::string & r2);
-
-  /** Returns true if the robot is part of the controller */
-  bool hasRobot(const std::string & robot) const;
-
-  using MCController::robot;
-
-  /** Access robot by name
-   *
-   * \param name Name of the robot
-   *
-   * \throws If hasRobot(name) returns false
-   */
-  mc_rbdyn::Robot & robot(const std::string & name);
-
   /** Get the posture task associated to a robot
    *
    * Returns a nullptr if the task does not exist (i.e. robot is not
@@ -203,26 +102,6 @@ struct MC_CONTROL_FSM_DLLAPI Controller : public MCController
    *
    */
   std::shared_ptr<mc_tasks::PostureTask> getPostureTask(const std::string & robot);
-
-  /** Add a contact between two robots
-   *
-   * No effect if the contact is already present.
-   *
-   */
-  void addContact(const Contact & c);
-
-  /** Remove a contact between two robots
-   *
-   * No effect if the contact is already absent.
-   *
-   */
-  void removeContact(const Contact & c);
-
-  /** Access the current contacts */
-  const ContactSet & contacts() const;
-
-  /** Check if a contact is already present */
-  bool hasContact(const Contact & c) const;
 
   /** Access contact constraint */
   mc_solver::ContactConstraint & contactConstraint()
@@ -251,9 +130,6 @@ private:
   /** Reset all posture tasks */
   void resetPostures();
 
-  /** Update the contacts (or their DoFs) if needed */
-  void updateContacts();
-
   /** Start the idle state */
   void startIdleState();
 
@@ -261,17 +137,6 @@ private:
   void teardownIdleState();
 
 protected:
-  /** Holds dynamics, kinematics and contact constraints that are added
-   * from the start by the controller */
-  std::vector<mc_solver::ConstraintSetPtr> constraints_;
-
-  /** Keep track of the contact constraint */
-  std::shared_ptr<mc_solver::ContactConstraint> contact_constraint_ = nullptr;
-
-  /** Collision managers for robot-pair (r1, r2), if r1 == r2 this is
-   * effectively a self-collision manager */
-  std::map<std::pair<std::string, std::string>, std::shared_ptr<mc_solver::CollisionsConstraint>> collision_constraints_;
-
   /** Creates a posture task for each actuated robots
    * (i.e. robot.dof() - robot.joint(0).dof() > 0 ) */
   std::map<std::string, std::shared_ptr<mc_tasks::PostureTask>> posture_tasks_;
@@ -280,11 +145,6 @@ protected:
   /** Creates a free-flyer end-effector task for each robot with a free flyer */
   std::map<std::string, std::shared_ptr<mc_tasks::EndEffectorTask>> ff_tasks_;
 
-  /** FSM contacts */
-  ContactSet contacts_;
-  /** True if contacts were changed in the previous round */
-  bool contacts_changed_;
-
   /** State factory */
 #ifndef MC_RTC_BUILD_STATIC
   StateFactory factory_;
@@ -292,30 +152,14 @@ protected:
   static std::unique_ptr<StateFactory> factory_ptr_;
   StateFactory & factory_;
 #endif
-
   /** Behaviour during idle */
   bool idle_keep_state_ = false;
   /** True if not idle */
   bool running_ = false;
   /** Main executor */
   Executor executor_;
-
-  using duration_ms = std::chrono::duration<double, std::milli>;
-  /** Monitor updateContacts runtime */
-  duration_ms updateContacts_dt_{0};
 };
 
 } // namespace fsm
 
 } // namespace mc_control
-
-namespace mc_rtc
-{
-
-template<>
-struct MC_CONTROL_FSM_DLLAPI ConfigurationLoader<mc_control::fsm::Contact>
-{
-  static mc_control::fsm::Contact load(const mc_rtc::Configuration & config);
-};
-
-} // namespace mc_rtc

--- a/include/mc_rtc/clock.h
+++ b/include/mc_rtc/clock.h
@@ -1,0 +1,18 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <chrono>
+#include <type_traits>
+
+namespace mc_rtc
+{
+
+/** mc_rtc::clock is a clock that is always steady and thus suitable for performance measurements */
+using clock = typename std::conditional<std::chrono::high_resolution_clock::is_steady,
+                                        std::chrono::high_resolution_clock,
+                                        std::chrono::steady_clock>::type;
+
+} // namespace mc_rtc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -500,6 +500,7 @@ mc_control/mc_global_controller.cpp
 mc_control/mc_global_controller_configuration.cpp
 mc_control/mc_global_controller_gui.cpp
 mc_control/mc_global_controller_services.cpp
+mc_solver/QPSolver_setContacts.cpp
 )
 
 if(MC_RTC_BUILD_STATIC)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -511,6 +511,7 @@ set(mc_control_HDR
 ../include/mc_control/api.h
 ../include/mc_control/CompletionCriteria.h
 ../include/mc_control/Configuration.h
+../include/mc_control/Contact.h
 ../include/mc_control/ControllerServer.h
 ../include/mc_control/GlobalPlugin.h
 ../include/mc_control/GlobalPluginMacros.h

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -9,12 +9,16 @@
 #include <mc_rtc/constants.h>
 
 #include <mc_rtc/ConfigurationHelpers.h>
+#include <mc_rtc/clock.h>
 #include <mc_rtc/config.h>
+#include <mc_rtc/deprecated.h>
 #include <mc_rtc/gui/Schema.h>
 #include <mc_rtc/io_utils.h>
 #include <mc_rtc/logging.h>
 
 #include <mc_tasks/MetaTaskLoader.h>
+
+#include <mc_solver/ConstraintSetLoader.h>
 
 #include <RBDyn/FK.h>
 #include <RBDyn/FV.h>
@@ -22,8 +26,26 @@
 #include <array>
 #include <fstream>
 
+namespace mc_rtc
+{
+
+mc_control::Contact ConfigurationLoader<mc_control::Contact>::load(const mc_rtc::Configuration & config)
+{
+  return mc_control::Contact(config("r1"), config("r2"), config("r1Surface"), config("r2Surface"),
+                             config("friction", mc_rbdyn::Contact::defaultFriction),
+                             config("dof", Eigen::Vector6d::Ones().eval()));
+}
+
+} // namespace mc_rtc
+
 namespace mc_control
 {
+
+Contact Contact::from_mc_rbdyn(const MCController & ctl, const mc_rbdyn::Contact & contact)
+{
+  return {ctl.robots().robot(contact.r1Index()).name(), ctl.robots().robot(contact.r2Index()).name(),
+          contact.r1Surface()->name(), contact.r2Surface()->name(), contact.friction()};
+}
 
 MCController::MCController(std::shared_ptr<mc_rbdyn::RobotModule> robot, double dt) : MCController(robot, dt, {}) {}
 
@@ -78,6 +100,129 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   selfCollisionConstraint.addCollisions(solver(), robots_modules[0]->minimalSelfCollisions());
   compoundJointConstraint.reset(new mc_solver::CompoundJointConstraint(robots(), 0, timeStep));
   postureTask = std::make_shared<mc_tasks::PostureTask>(solver(), 0, 10.0, 5.0);
+  /** Load additional robots from the configuration */
+  {
+    auto init_robot = [&](const std::string & robotName, const mc_rtc::Configuration & config) {
+      if(!hasRobot(robotName)) return;
+      auto & robot = robots().robot(robotName);
+      auto & realRobot = realRobots().robot(robotName);
+      /** Set initial robot base pose */
+      if(config.has("init_pos"))
+      {
+        robot.posW(config("init_pos"));
+        realRobot.posW(robot.posW());
+      }
+      /** Load additional frames */
+      {
+        auto frames = config("frames", std::vector<mc_rbdyn::RobotModule::FrameDescription>{});
+        robot.makeFrames(frames);
+        realRobot.makeFrames(frames);
+      }
+    };
+    if(config.has("init_pos"))
+    {
+      mc_rtc::log::deprecated("mc_control::fsm::Controller", "init_pos",
+                              fmt::format("robots/{}/init_pos", robot().name()));
+      init_robot(robot().name(), config);
+    }
+    auto config_robots = config("robots", std::map<std::string, mc_rtc::Configuration>{});
+    for(const auto & cr : config_robots)
+    {
+      if(cr.first == robot().name())
+      {
+        if(config.has("init_pos") && cr.second.has("init_pos"))
+        {
+          mc_rtc::log::error_and_throw("You have both a global \"init_pos\" entry and a \"robots/{}/init_pos\" entry "
+                                       "in your FSM configuration. Please use \"robots/{}/init_pos\" only.",
+                                       robot().name(), robot().name());
+        }
+        init_robot(cr.first, cr.second);
+      }
+      else if(!cr.second.has("module"))
+      {
+        // This is not the main robot but the configuration does not have a
+        // robot module specified. This can happen if the user intended his
+        // controller to run with multiple main robots each requiring a
+        // different configuration. In this case, the configuration is simply
+        // ignored as it does not correspond to any robot currently loaded
+        // within this controller.
+      }
+      else
+      {
+        const auto & name = cr.first;
+        std::string module = cr.second("module");
+        auto params = cr.second("params", std::vector<std::string>{});
+        mc_rbdyn::RobotModulePtr rm = nullptr;
+        if(params.size() == 0)
+        {
+          rm = mc_rbdyn::RobotLoader::get_robot_module(module);
+        }
+        else if(params.size() == 1)
+        {
+          rm = mc_rbdyn::RobotLoader::get_robot_module(module, params.at(0));
+        }
+        else if(params.size() == 2)
+        {
+          rm = mc_rbdyn::RobotLoader::get_robot_module(module, params.at(0), params.at(1));
+        }
+        else
+        {
+          mc_rtc::log::error_and_throw("Controller only handles robot modules that require two parameters at most");
+        }
+        if(!rm)
+        {
+          mc_rtc::log::error_and_throw("Failed to load {} as specified in configuration", name);
+        }
+        loadRobot(rm, name);
+        init_robot(name, cr.second);
+      }
+    }
+    mc_rtc::log::info("Robots loaded in controller:");
+    for(const auto & r : robots())
+    {
+      mc_rtc::log::info("- {}", r.name());
+    }
+  }
+  /** Load global constraints (robots' kinematics/dynamics constraints and contact constraint */
+  {
+    auto config_constraints = config("constraints", std::vector<mc_rtc::Configuration>{});
+    for(const auto & cc : config_constraints)
+    {
+      constraints_.emplace_back(mc_solver::ConstraintSetLoader::load(solver(), cc));
+      if(static_cast<std::string>(cc("type")) == "contact")
+      {
+        contact_constraint_ = std::static_pointer_cast<mc_solver::ContactConstraint>(constraints_.back());
+      }
+      /*FIXME Add a name mechanism in ConstraintSet to get information here */
+      solver().addConstraintSet(*constraints_.back());
+    }
+    if(!contact_constraint_)
+    {
+      mc_rtc::log::warning("No contact constraint loaded from the configuration");
+    }
+  }
+  /** Load collision managers */
+  {
+    auto config_collisions = config("collisions", std::vector<mc_rtc::Configuration>{});
+    for(auto & config_cc : config_collisions)
+    {
+      if(!config_cc.has("type"))
+      {
+        config_cc.add("type", "collision");
+      }
+      auto cc = mc_solver::ConstraintSetLoader::load<mc_solver::CollisionsConstraint>(solver(), config_cc);
+      auto & r1 = robots().robot(cc->r1Index);
+      auto & r2 = robots().robot(cc->r2Index);
+      collision_constraints_[{r1.name(), r2.name()}] = cc;
+      solver().addConstraintSet(*cc);
+    }
+  }
+  /** Create contacts */
+  if(config.has("contacts"))
+  {
+    contacts_ = config("contacts");
+  }
+  contacts_changed_ = true;
   mc_rtc::log::info("MCController(base) ready");
 }
 
@@ -438,6 +583,9 @@ bool MCController::run()
 
 bool MCController::run(mc_solver::FeedbackType fType)
 {
+  auto startUpdateContacts = mc_rtc::clock::now();
+  updateContacts();
+  updateContacts_dt_ = mc_rtc::clock::now() - startUpdateContacts;
   if(!qpsolver->run(fType))
   {
     mc_rtc::log::error("QP failed to run()");
@@ -467,6 +615,219 @@ void MCController::reset(const ControllerResetData & reset_data)
   postureTask->posture(reset_data.q);
   robot().forwardKinematics();
   robot().forwardVelocity();
+  updateContacts();
+  if(gui_)
+  {
+    gui_->addElement({"Contacts"},
+                     mc_rtc::gui::Label("Contacts", [this]() -> const std::string & { return contacts_str_; }));
+    gui_->addElement({"Contacts", "Add"},
+                     mc_rtc::gui::Form(
+                         "Add contact",
+                         [this](const mc_rtc::Configuration & data) {
+                           std::string r0 = data("R0");
+                           std::string r1 = data("R1");
+                           std::string r0Surface = data("R0 surface");
+                           std::string r1Surface = data("R1 surface");
+                           double friction = data("Friction", mc_rbdyn::Contact::defaultFriction);
+                           Eigen::Vector6d dof = data("dof", Eigen::Vector6d::Ones().eval());
+                           addContact({r0, r1, r0Surface, r1Surface, friction, dof});
+                         },
+                         mc_rtc::gui::FormDataComboInput{"R0", true, {"robots"}},
+                         mc_rtc::gui::FormDataComboInput{"R0 surface", true, {"surfaces", "$R0"}},
+                         mc_rtc::gui::FormDataComboInput{"R1", true, {"robots"}},
+                         mc_rtc::gui::FormDataComboInput{"R1 surface", true, {"surfaces", "$R1"}},
+                         mc_rtc::gui::FormNumberInput("Friction", false, mc_rbdyn::Contact::defaultFriction),
+                         mc_rtc::gui::FormArrayInput<Eigen::Vector6d>("dof", false, Eigen::Vector6d::Ones())));
+    gui_->addElement({"Contacts", "Add"},
+                     mc_rtc::gui::Form(
+                         "Add contact",
+                         [this](const mc_rtc::Configuration & data) {
+                           std::string r0 = data("R0");
+                           std::string r1 = data("R1");
+                           std::string r0Surface = data("R0 surface");
+                           std::string r1Surface = data("R1 surface");
+                           double friction = data("Friction", mc_rbdyn::Contact::defaultFriction);
+                           Eigen::Vector6d dof = data("dof", Eigen::Vector6d::Ones().eval());
+                           addContact({r0, r1, r0Surface, r1Surface, friction, dof});
+                         },
+                         mc_rtc::gui::FormDataComboInput{"R0", true, {"robots"}},
+                         mc_rtc::gui::FormDataComboInput{"R0 surface", true, {"surfaces", "$R0"}},
+                         mc_rtc::gui::FormDataComboInput{"R1", true, {"robots"}},
+                         mc_rtc::gui::FormDataComboInput{"R1 surface", true, {"surfaces", "$R1"}},
+                         mc_rtc::gui::FormNumberInput("Friction", false, mc_rbdyn::Contact::defaultFriction),
+                         mc_rtc::gui::FormArrayInput<Eigen::Vector6d>("dof", false, Eigen::Vector6d::Ones())));
+  }
+  logger().addLogEntry("perf_UpdateContacts", [this]() { return updateContacts_dt_.count(); });
+}
+
+void MCController::updateContacts()
+{
+  if(contacts_changed_ && contact_constraint_)
+  {
+    std::vector<mc_rbdyn::Contact> contacts;
+    contact_constraint_->contactConstr->resetDofContacts();
+
+    auto ensureValidContact = [this](const std::string & robotName, const std::string & surfaceName) {
+      if(!hasRobot(robotName))
+      {
+        const auto availableRobots =
+            mc_rtc::io::to_string(robots(), [](const mc_rbdyn::Robot & r) { return r.name(); });
+        mc_rtc::log::error_and_throw("Failed to add contact: no robot named {} (available robots: {})", robotName,
+                                     availableRobots);
+      }
+      if(!robot(robotName).hasSurface(surfaceName))
+      {
+        mc_rtc::log::error_and_throw("Failed to add contact: no surface named {} in robot {}", surfaceName, robotName);
+      }
+    };
+    contacts_str_ = "";
+    for(const auto & c : contacts_)
+    {
+      ensureValidContact(c.r1, c.r1Surface);
+      ensureValidContact(c.r2, c.r2Surface);
+      auto r1Index = robot(c.r1).robotIndex();
+      auto r2Index = robot(c.r2).robotIndex();
+      contacts.emplace_back(robots(), r1Index, r2Index, c.r1Surface, c.r2Surface, c.friction);
+      auto cId = contacts.back().contactId(robots());
+      contact_constraint_->contactConstr->addDofContact(cId, c.dof.asDiagonal());
+      contacts_str_ +=
+          fmt::format("{}::{}/{}::{} | {} | {}\n", c.r1, c.r1Surface, c.r2, c.r2Surface, c.dof.transpose(), c.friction);
+    }
+    if(contacts_str_.size())
+    {
+      contacts_str_.pop_back();
+    }
+    solver().setContacts(contacts);
+    if(gui_)
+    {
+      gui_->removeCategory({"Contacts", "Remove"});
+      for(const auto & c : contacts_)
+      {
+        std::string bName = c.r1 + "::" + c.r1Surface + " & " + c.r2 + "::" + c.r2Surface;
+        gui_->addElement({"Contacts", "Remove"}, mc_rtc::gui::Button(bName, [this, &c]() { removeContact(c); }));
+      }
+    }
+    contact_constraint_->contactConstr->updateDofContacts();
+  }
+  contacts_changed_ = false;
+}
+
+void MCController::addCollisions(const std::string & r1,
+                                 const std::string & r2,
+                                 const std::vector<mc_rbdyn::Collision> & collisions)
+{
+  if(r1 != r2 && collision_constraints_.count({r2, r1}))
+  {
+    std::vector<mc_rbdyn::Collision> swapped;
+    swapped.reserve(collisions.size());
+    for(const auto & c : collisions)
+    {
+      swapped.push_back({c.body2, c.body1, c.iDist, c.sDist, c.damping});
+    }
+    addCollisions(r2, r1, swapped);
+    return;
+  }
+  if(!collision_constraints_.count({r1, r2}))
+  {
+    if(!hasRobot(r1) || !hasRobot(r2))
+    {
+      mc_rtc::log::error("Try to add collision for robot {} and {} which are not involved in this controller", r1, r2);
+      return;
+    }
+    auto r1Index = robot(r1).robotIndex();
+    auto r2Index = robot(r2).robotIndex();
+    collision_constraints_[{r1, r2}] =
+        std::make_shared<mc_solver::CollisionsConstraint>(robots(), r1Index, r2Index, solver().dt());
+    solver().addConstraintSet(*collision_constraints_[{r1, r2}]);
+  }
+  auto & cc = collision_constraints_[{r1, r2}];
+  mc_rtc::log::info("Add collisions {}/{}", r1, r2);
+  for(const auto & c : collisions)
+  {
+    mc_rtc::log::info("- {}::{}/{}::{}", r1, c.body1, r2, c.body2);
+  }
+  cc->addCollisions(solver(), collisions);
+}
+
+void MCController::removeCollisions(const std::string & r1,
+                                    const std::string & r2,
+                                    const std::vector<mc_rbdyn::Collision> & collisions)
+{
+  if(!collision_constraints_.count({r1, r2}))
+  {
+    return;
+  }
+  auto & cc = collision_constraints_[{r1, r2}];
+  mc_rtc::log::info("Remove collisions {}/{}", r1, r2);
+  for(const auto & c : collisions)
+  {
+    mc_rtc::log::info("- {}::{}/{}::{}", r1, c.body1, r2, c.body2);
+  }
+  cc->removeCollisions(solver(), collisions);
+}
+
+void MCController::removeCollisions(const std::string & r1, const std::string & r2)
+{
+  if(!collision_constraints_.count({r1, r2}))
+  {
+    return;
+  }
+  auto & cc = collision_constraints_[{r1, r2}];
+  mc_rtc::log::info("Remove all collisions {}/{}", r1, r2);
+  cc->reset();
+}
+
+bool MCController::hasRobot(const std::string & robot) const
+{
+  return robots().hasRobot(robot);
+}
+
+void MCController::addContact(const Contact & c)
+{
+  bool inserted;
+  ContactSet::iterator it;
+  std::tie(it, inserted) = contacts_.insert(c);
+  contacts_changed_ |= inserted;
+  if(!inserted)
+  {
+    if(it->dof != c.dof)
+    {
+      mc_rtc::log::info("Changed contact DoF {}::{}/{}::{} to {}", c.r1, c.r1Surface, c.r2, c.r2Surface,
+                        c.dof.transpose());
+      it->dof = c.dof;
+      contacts_changed_ = true;
+    }
+    if(it->friction != c.friction)
+    {
+      mc_rtc::log::info("Changed contact friction {}::{}/{}::{} to {}", c.r1, c.r1Surface, c.r2, c.r2Surface,
+                        c.friction);
+      it->friction = c.friction;
+      contacts_changed_ = true;
+    }
+  }
+  else
+  {
+    mc_rtc::log::info("Add contact {}::{}/{}::{} (DoF: {})", c.r1, c.r1Surface, c.r2, c.r2Surface, c.dof.transpose());
+  }
+}
+
+void MCController::removeContact(const Contact & c)
+{
+  contacts_changed_ |= static_cast<bool>(contacts_.erase(c));
+  if(contacts_changed_)
+  {
+    mc_rtc::log::info("Remove contact {}::{}/{}::{}", c.r1, c.r1Surface, c.r2, c.r2Surface);
+  }
+}
+
+const ContactSet & MCController::contacts() const
+{
+  return contacts_;
+}
+
+bool MCController::hasContact(const Contact & c) const
+{
+  return std::find(contacts_.begin(), contacts_.end(), c) != contacts_.end();
 }
 
 const mc_rbdyn::Robots & MCController::robots() const

--- a/src/mc_control/fsm/Controller.cpp
+++ b/src/mc_control/fsm/Controller.cpp
@@ -7,27 +7,10 @@
 #include <mc_rbdyn/RobotLoader.h>
 #include <mc_rbdyn/configuration_io.h>
 
-#include <mc_solver/ConstraintSetLoader.h>
-
-#include <mc_tasks/MetaTaskLoader.h>
-
-#include <mc_rtc/deprecated.h>
 #include <mc_rtc/gui/Button.h>
 #include <mc_rtc/gui/Form.h>
 #include <mc_rtc/gui/Label.h>
 #include <mc_rtc/io_utils.h>
-
-namespace mc_rtc
-{
-
-mc_control::fsm::Contact ConfigurationLoader<mc_control::fsm::Contact>::load(const mc_rtc::Configuration & config)
-{
-  return mc_control::fsm::Contact(config("r1"), config("r2"), config("r1Surface"), config("r2Surface"),
-                                  config("friction", mc_rbdyn::Contact::defaultFriction),
-                                  config("dof", Eigen::Vector6d::Ones().eval()));
-}
-
-} // namespace mc_rtc
 
 namespace mc_control
 {
@@ -35,23 +18,9 @@ namespace mc_control
 namespace fsm
 {
 
-namespace
-{
-/** Always pick a steady clock */
-using clock = typename std::conditional<std::chrono::high_resolution_clock::is_steady,
-                                        std::chrono::high_resolution_clock,
-                                        std::chrono::steady_clock>::type;
-} // namespace
-
 #ifdef MC_RTC_BUILD_STATIC
 std::unique_ptr<StateFactory> Controller::factory_ptr_;
 #endif
-
-Contact Contact::from_mc_rbdyn(const Controller & ctl, const mc_rbdyn::Contact & contact)
-{
-  return {ctl.robots().robot(contact.r1Index()).name(), ctl.robots().robot(contact.r2Index()).name(),
-          contact.r1Surface()->name(), contact.r2Surface()->name(), contact.friction()};
-}
 
 Controller::Controller(std::shared_ptr<mc_rbdyn::RobotModule> rm, double dt, const mc_rtc::Configuration & config)
 : MCController(std::vector<mc_rbdyn::RobotModulePtr>{rm}, dt, config),
@@ -68,126 +37,6 @@ Controller::Controller(std::shared_ptr<mc_rbdyn::RobotModule> rm, double dt, con
   factory_.set_verbosity(config("VerboseStateFactory", false));
 #endif
   idle_keep_state_ = config("IdleKeepState", false);
-
-  auto init_robot = [&](const std::string & robotName, const mc_rtc::Configuration & config) {
-    if(!hasRobot(robotName)) return;
-    auto & robot = robots().robot(robotName);
-    auto & realRobot = realRobots().robot(robotName);
-    /** Set initial robot base pose */
-    if(config.has("init_pos"))
-    {
-      robot.posW(config("init_pos"));
-      realRobot.posW(robot.posW());
-    }
-    /** Load additional frames */
-    {
-      auto frames = config("frames", std::vector<mc_rbdyn::RobotModule::FrameDescription>{});
-      robot.makeFrames(frames);
-      realRobot.makeFrames(frames);
-    }
-  };
-
-  if(config.has("init_pos"))
-  {
-    mc_rtc::log::deprecated("mc_control::fsm::Controller", "init_pos",
-                            fmt::format("robots/{}/init_pos", robot().name()));
-    init_robot(robot().name(), config);
-  }
-
-  /** Load additional robots from the configuration */
-  {
-    auto config_robots = config("robots", std::map<std::string, mc_rtc::Configuration>{});
-    for(const auto & cr : config_robots)
-    {
-      if(cr.first == robot().name())
-      {
-        if(config.has("init_pos") && cr.second.has("init_pos"))
-        {
-          mc_rtc::log::error_and_throw("You have both a global \"init_pos\" entry and a \"robots/{}/init_pos\" entry "
-                                       "in your FSM configuration. Please use \"robots/{}/init_pos\" only.",
-                                       robot().name(), robot().name());
-        }
-        init_robot(cr.first, cr.second);
-      }
-      else if(!cr.second.has("module"))
-      {
-        // This is not the main robot but the configuration does not have a
-        // robot module specified. This can happen if the user intended his
-        // controller to run with multiple main robots each requiring a
-        // different configuration. In this case, the configuration is simply
-        // ignored as it does not correspond to any robot currently loaded
-        // within this controller.
-      }
-      else
-      {
-        const auto & name = cr.first;
-        std::string module = cr.second("module");
-        auto params = cr.second("params", std::vector<std::string>{});
-        mc_rbdyn::RobotModulePtr rm = nullptr;
-        if(params.size() == 0)
-        {
-          rm = mc_rbdyn::RobotLoader::get_robot_module(module);
-        }
-        else if(params.size() == 1)
-        {
-          rm = mc_rbdyn::RobotLoader::get_robot_module(module, params.at(0));
-        }
-        else if(params.size() == 2)
-        {
-          rm = mc_rbdyn::RobotLoader::get_robot_module(module, params.at(0), params.at(1));
-        }
-        else
-        {
-          mc_rtc::log::error_and_throw("FSM controller only handles robot modules that require two parameters at most");
-        }
-        if(!rm)
-        {
-          mc_rtc::log::error_and_throw("Failed to load {} as specified in configuration", name);
-        }
-        loadRobot(rm, name);
-        init_robot(name, cr.second);
-      }
-      mc_rtc::log::info("Robots loaded in FSM controller:");
-      for(const auto & r : robots())
-      {
-        mc_rtc::log::info("- {}", r.name());
-      }
-    }
-  }
-  /** Load global constraints (robots' kinematics/dynamics constraints and contact constraint */
-  {
-    auto config_constraints = config("constraints", std::vector<mc_rtc::Configuration>{});
-    for(const auto & cc : config_constraints)
-    {
-      constraints_.emplace_back(mc_solver::ConstraintSetLoader::load(solver(), cc));
-      if(static_cast<std::string>(cc("type")) == "contact")
-      {
-        contact_constraint_ = std::static_pointer_cast<mc_solver::ContactConstraint>(constraints_.back());
-      }
-      /*FIXME Add a name mechanism in ConstraintSet to get information here */
-      solver().addConstraintSet(*constraints_.back());
-    }
-    if(!contact_constraint_)
-    {
-      mc_rtc::log::warning("No contact constraint loaded from the FSM configuration");
-    }
-  }
-  /** Load collision managers */
-  {
-    auto config_collisions = config("collisions", std::vector<mc_rtc::Configuration>{});
-    for(auto & config_cc : config_collisions)
-    {
-      if(!config_cc.has("type"))
-      {
-        config_cc.add("type", "collision");
-      }
-      auto cc = mc_solver::ConstraintSetLoader::load<mc_solver::CollisionsConstraint>(solver(), config_cc);
-      auto & r1 = robots().robot(cc->r1Index);
-      auto & r2 = robots().robot(cc->r2Index);
-      collision_constraints_[{r1.name(), r2.name()}] = cc;
-      solver().addConstraintSet(*cc);
-    }
-  }
   /** Create posture task for actuated robots */
   for(auto & robot : robots())
   {
@@ -228,12 +77,6 @@ Controller::Controller(std::shared_ptr<mc_rbdyn::RobotModule> rm, double dt, con
       ff_tasks_[robot.name()] = t;
     }
   }
-  /** Create contacts */
-  if(config.has("contacts"))
-  {
-    contacts_ = config("contacts");
-  }
-  contacts_changed_ = true;
   /** Load more states if they are provided in the configuration */
   if(config.has("states"))
   {
@@ -256,9 +99,6 @@ bool Controller::run()
 
 bool Controller::run(mc_solver::FeedbackType fType)
 {
-  auto startUpdateContacts = clock::now();
-  updateContacts();
-  updateContacts_dt_ = clock::now() - startUpdateContacts;
   executor_.run(*this, idle_keep_state_);
   if(!executor_.running())
   {
@@ -282,53 +122,13 @@ bool Controller::run(mc_solver::FeedbackType fType)
 void Controller::reset(const ControllerResetData & data)
 {
   MCController::reset(data);
-  auto startUpdateContacts = clock::now();
-  updateContacts();
-  updateContacts_dt_ = clock::now() - startUpdateContacts;
-
   /** GUI information */
   if(gui_)
   {
     auto all_states = factory_.states();
     std::sort(all_states.begin(), all_states.end());
     gui_->data().add("states", all_states);
-    gui_->removeElement({"FSM"}, "Contacts");
-    gui_->addElement({"FSM"}, mc_rtc::gui::Label("Contacts", [this]() {
-                       std::string ret;
-                       for(const auto & c : contacts_)
-                       {
-                         std::stringstream ss;
-                         ss << c.r1Surface << "/" << c.r2Surface << " | " << c.dof.transpose() << " | " << c.friction
-                            << "\n";
-                         ret += ss.str();
-                       }
-                       if(ret.size())
-                       {
-                         ret.pop_back();
-                       }
-                       return ret;
-                     }));
-    gui_->removeElement({"Contacts", "Add"}, "Add contact");
-    gui_->addElement({"Contacts", "Add"},
-                     mc_rtc::gui::Form(
-                         "Add contact",
-                         [this](const mc_rtc::Configuration & data) {
-                           std::string r0 = data("R0");
-                           std::string r1 = data("R1");
-                           std::string r0Surface = data("R0 surface");
-                           std::string r1Surface = data("R1 surface");
-                           double friction = data("Friction", mc_rbdyn::Contact::defaultFriction);
-                           Eigen::Vector6d dof = data("dof", Eigen::Vector6d::Ones().eval());
-                           addContact({r0, r1, r0Surface, r1Surface, friction, dof});
-                         },
-                         mc_rtc::gui::FormDataComboInput{"R0", true, {"robots"}},
-                         mc_rtc::gui::FormDataComboInput{"R0 surface", true, {"surfaces", "$R0"}},
-                         mc_rtc::gui::FormDataComboInput{"R1", true, {"robots"}},
-                         mc_rtc::gui::FormDataComboInput{"R1 surface", true, {"surfaces", "$R1"}},
-                         mc_rtc::gui::FormNumberInput("Friction", false, mc_rbdyn::Contact::defaultFriction),
-                         mc_rtc::gui::FormArrayInput<Eigen::Vector6d>("dof", false, Eigen::Vector6d::Ones())));
   }
-  logger().addLogEntry("perf_FSM_UpdateContacts", [this]() { return updateContacts_dt_.count(); });
   startIdleState();
 }
 
@@ -372,126 +172,6 @@ void Controller::teardownIdleState()
   }
 }
 
-void Controller::updateContacts()
-{
-  if(contacts_changed_ && contact_constraint_)
-  {
-    std::vector<mc_rbdyn::Contact> contacts;
-    contact_constraint_->contactConstr->resetDofContacts();
-
-    auto ensureValidContact = [this](const std::string & robotName, const std::string & surfaceName) {
-      if(!hasRobot(robotName))
-      {
-        const auto availableRobots =
-            mc_rtc::io::to_string(robots(), [](const mc_rbdyn::Robot & r) { return r.name(); });
-        mc_rtc::log::error_and_throw("Failed to add contact: no robot named {} (available robots: {})", robotName,
-                                     availableRobots);
-      }
-      if(!robot(robotName).hasSurface(surfaceName))
-      {
-        mc_rtc::log::error_and_throw("Failed to add contact: no surface named {} in robot {}", surfaceName, robotName);
-      }
-    };
-    for(const auto & c : contacts_)
-    {
-      ensureValidContact(c.r1, c.r1Surface);
-      ensureValidContact(c.r2, c.r2Surface);
-      auto r1Index = robot(c.r1).robotIndex();
-      auto r2Index = robot(c.r2).robotIndex();
-      contacts.emplace_back(robots(), r1Index, r2Index, c.r1Surface, c.r2Surface, c.friction);
-      auto cId = contacts.back().contactId(robots());
-      contact_constraint_->contactConstr->addDofContact(cId, c.dof.asDiagonal());
-    }
-    solver().setContacts(contacts);
-    if(gui_)
-    {
-      gui_->removeCategory({"Contacts", "Remove"});
-      for(const auto & c : contacts_)
-      {
-        std::string bName = c.r1 + "::" + c.r1Surface + " & " + c.r2 + "::" + c.r2Surface;
-        gui_->addElement({"Contacts", "Remove"}, mc_rtc::gui::Button(bName, [this, &c]() { removeContact(c); }));
-      }
-    }
-    contact_constraint_->contactConstr->updateDofContacts();
-  }
-  contacts_changed_ = false;
-}
-
-void Controller::addCollisions(const std::string & r1,
-                               const std::string & r2,
-                               const std::vector<mc_rbdyn::Collision> & collisions)
-{
-  if(r1 != r2 && collision_constraints_.count({r2, r1}))
-  {
-    std::vector<mc_rbdyn::Collision> swapped;
-    swapped.reserve(collisions.size());
-    for(const auto & c : collisions)
-    {
-      swapped.push_back({c.body2, c.body1, c.iDist, c.sDist, c.damping});
-    }
-    addCollisions(r2, r1, swapped);
-    return;
-  }
-  if(!collision_constraints_.count({r1, r2}))
-  {
-    if(!hasRobot(r1) || !hasRobot(r2))
-    {
-      mc_rtc::log::error("Try to add collision for robot {} and {} which are not involved in this FSM", r1, r2);
-      return;
-    }
-    auto r1Index = robot(r1).robotIndex();
-    auto r2Index = robot(r2).robotIndex();
-    collision_constraints_[{r1, r2}] =
-        std::make_shared<mc_solver::CollisionsConstraint>(robots(), r1Index, r2Index, solver().dt());
-    solver().addConstraintSet(*collision_constraints_[{r1, r2}]);
-  }
-  auto & cc = collision_constraints_[{r1, r2}];
-  mc_rtc::log::info("[FSM] Add collisions {}/{}", r1, r2);
-  for(const auto & c : collisions)
-  {
-    mc_rtc::log::info("[FSM] - {}::{}/{}::{}", r1, c.body1, r2, c.body2);
-  }
-  cc->addCollisions(solver(), collisions);
-}
-
-void Controller::removeCollisions(const std::string & r1,
-                                  const std::string & r2,
-                                  const std::vector<mc_rbdyn::Collision> & collisions)
-{
-  if(!collision_constraints_.count({r1, r2}))
-  {
-    return;
-  }
-  auto & cc = collision_constraints_[{r1, r2}];
-  mc_rtc::log::info("[FSM] Remove collisions {}/{}", r1, r2);
-  for(const auto & c : collisions)
-  {
-    mc_rtc::log::info("[FSM] - {}::{}/{}::{}", r1, c.body1, r2, c.body2);
-  }
-  cc->removeCollisions(solver(), collisions);
-}
-
-void Controller::removeCollisions(const std::string & r1, const std::string & r2)
-{
-  if(!collision_constraints_.count({r1, r2}))
-  {
-    return;
-  }
-  auto & cc = collision_constraints_[{r1, r2}];
-  mc_rtc::log::info("[FSM] Remove all collisions {}/{}", r1, r2);
-  cc->reset();
-}
-
-bool Controller::hasRobot(const std::string & robot) const
-{
-  return robots().hasRobot(robot);
-}
-
-mc_rbdyn::Robot & Controller::robot(const std::string & name)
-{
-  return robots().robot(name);
-}
-
 std::shared_ptr<mc_tasks::PostureTask> Controller::getPostureTask(const std::string & robot)
 {
   if(posture_tasks_.count(robot))
@@ -499,62 +179,6 @@ std::shared_ptr<mc_tasks::PostureTask> Controller::getPostureTask(const std::str
     return posture_tasks_.at(robot);
   }
   return nullptr;
-}
-
-void Controller::addContact(const Contact & c)
-{
-  bool inserted;
-  ContactSet::iterator it;
-  std::tie(it, inserted) = contacts_.insert(c);
-  contacts_changed_ |= inserted;
-  if(!inserted)
-  {
-    if(it->dof != c.dof)
-    {
-      mc_rtc::log::info("[FSM] Changed contact DoF {}::{}/{}::{} to {}", c.r1, c.r1Surface, c.r2, c.r2Surface,
-                        c.dof.transpose());
-      it->dof = c.dof;
-      contacts_changed_ = true;
-    }
-    if(it->friction != c.friction)
-    {
-      mc_rtc::log::info("[FSM] Changed contact friction {}::{}/{}::{} to {}", c.r1, c.r1Surface, c.r2, c.r2Surface,
-                        c.friction);
-      it->friction = c.friction;
-      contacts_changed_ = true;
-    }
-  }
-  else
-  {
-    mc_rtc::log::info("[FSM] Add contact {}::{}/{}::{} (DoF: {})", c.r1, c.r1Surface, c.r2, c.r2Surface,
-                      c.dof.transpose());
-  }
-}
-
-void Controller::removeContact(const Contact & c)
-{
-  contacts_changed_ |= static_cast<bool>(contacts_.erase(c));
-  if(contacts_changed_)
-  {
-    mc_rtc::log::info("[FSM] Remove contact {}::{}/{}::{}", c.r1, c.r1Surface, c.r2, c.r2Surface);
-  }
-}
-
-const ContactSet & Controller::contacts() const
-{
-  return contacts_;
-}
-
-bool Controller::hasContact(const Contact & c) const
-{
-  for(const auto & co : contacts_)
-  {
-    if(co == c)
-    {
-      return true;
-    }
-  }
-  return false;
 }
 
 bool Controller::resume(const std::string & state)

--- a/src/mc_solver/QPSolver.cpp
+++ b/src/mc_solver/QPSolver.cpp
@@ -194,7 +194,7 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
       const std::string & r1S = contact.r1Surface()->name();
       const std::string & r2 = robots().robot(contact.r2Index()).name();
       const std::string & r2S = contact.r2Surface()->name();
-      gui_->removeElement({"Contacts"}, fmt::format("{}::{}/{}::{}", r1, r1S, r2, r2S));
+      gui_->removeElement({"Contacts", "Forces"}, fmt::format("{}::{}/{}::{}", r1, r1S, r2, r2S));
     }
   }
   contacts_ = contacts;
@@ -226,7 +226,7 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
       const std::string & r1S = contact.r1Surface()->name();
       const std::string & r2 = robots().robot(contact.r2Index()).name();
       const std::string & r2S = contact.r2Surface()->name();
-      gui_->addElement({"Contacts"},
+      gui_->addElement({"Contacts", "Forces"},
                        mc_rtc::gui::Force(
                            fmt::format("{}::{}/{}::{}", r1, r1S, r2, r2S),
                            [this, &contact]() { return desiredContactForce(contact); },
@@ -238,17 +238,6 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
   uniContacts.clear();
   biContacts.clear();
   qpRes.contacts.clear();
-
-  if(gui_)
-  {
-    gui_->removeCategory({"Contacts", "Remove"});
-  }
-  auto allBut = [](const std::vector<mc_rbdyn::Contact> & cs, const mc_rbdyn::Contact & c) {
-    std::vector<mc_rbdyn::Contact> ret = cs;
-    auto it = std::find(ret.begin(), ret.end(), c);
-    ret.erase(it);
-    return ret;
-  };
 
   for(const mc_rbdyn::Contact & c : contacts_)
   {
@@ -264,14 +253,6 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
       biContacts.push_back(tasks::qp::BilateralContact(*qcptr.bilateralContact));
       delete qcptr.bilateralContact;
       qcptr.bilateralContact = 0;
-    }
-    if(gui_)
-    {
-      std::string bName = robot(c.r1Index()).name() + "::" + c.r1Surface()->name() + " & " + robot(c.r2Index()).name()
-                          + "::" + c.r2Surface()->name();
-      auto nContacts = allBut(contacts_, c);
-      gui_->addElement({"Contacts", "Remove"},
-                       mc_rtc::gui::Button(bName, [nContacts, this]() { setContacts(nContacts); }));
     }
   }
 
@@ -689,39 +670,6 @@ void QPSolver::gui(std::shared_ptr<mc_rtc::gui::StateBuilder> gui)
     {
       addTaskToGUI(t);
     }
-    gui_->addElement({"Contacts", "Add"},
-                     mc_rtc::gui::Form(
-                         "Add contact",
-                         [this](const mc_rtc::Configuration & data) {
-                           mc_rtc::log::info("Add contact {}::{}/{}::{}", data("R0"), data("R0 surface"), data("R1"),
-                                             data("R1 surface"));
-                           auto str2idx = [this](const std::string & rName) {
-                             for(const auto & r : robots())
-                             {
-                               if(r.name() == rName)
-                               {
-                                 return r.robotIndex();
-                               }
-                             }
-                             mc_rtc::log::error("The robot name you provided does not match any in the solver");
-                             return static_cast<unsigned int>(robots().size());
-                           };
-                           unsigned int r0Index = str2idx(data("R0"));
-                           unsigned int r1Index = str2idx(data("R1"));
-                           std::string r0Surface = data("R0 surface");
-                           std::string r1Surface = data("R1 surface");
-                           double friction = data("Friction", mc_rbdyn::Contact::defaultFriction);
-                           if(r0Index < robots().size() && r1Index < robots().size())
-                           {
-                             contacts_.push_back({robots(), r0Index, r1Index, r0Surface, r1Surface, friction});
-                             setContacts(contacts_);
-                           }
-                         },
-                         mc_rtc::gui::FormDataComboInput{"R0", true, {"robots"}},
-                         mc_rtc::gui::FormDataComboInput{"R0 surface", true, {"surfaces", "$R0"}},
-                         mc_rtc::gui::FormDataComboInput{"R1", true, {"robots"}},
-                         mc_rtc::gui::FormDataComboInput{"R1 surface", true, {"surfaces", "$R1"}},
-                         mc_rtc::gui::FormNumberInput("Friction", false, mc_rbdyn::Contact::defaultFriction)));
   }
 }
 

--- a/src/mc_solver/QPSolver.cpp
+++ b/src/mc_solver/QPSolver.cpp
@@ -173,7 +173,7 @@ Eigen::VectorXd QPSolver::lambdaVec(int cIndex) const
   return solver.lambdaVec(cIndex);
 }
 
-void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
+void QPSolver::setContacts(ControllerToken, const std::vector<mc_rbdyn::Contact> & contacts)
 {
   if(logger_)
   {

--- a/src/mc_solver/QPSolver_setContacts.cpp
+++ b/src/mc_solver/QPSolver_setContacts.cpp
@@ -9,7 +9,8 @@ void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
 {
   if(controller_)
   {
-    mc_rtc::log::warning("[MC_RTC_DEPRECATED] Prefer using addContact/removeContact for contacts manipulation");
+    mc_rtc::log::warning("[MC_RTC_DEPRECATED] Prefer using addContact/removeContact for contacts manipulation instead "
+                         "of QPSolver::setContacts");
     controller_->clearContacts();
     for(const auto & c : contacts)
     {

--- a/src/mc_solver/QPSolver_setContacts.cpp
+++ b/src/mc_solver/QPSolver_setContacts.cpp
@@ -1,0 +1,25 @@
+#include <mc_solver/QPSolver.h>
+
+#include <mc_control/MCController.h>
+
+namespace mc_solver
+{
+
+void QPSolver::setContacts(const std::vector<mc_rbdyn::Contact> & contacts)
+{
+  if(controller_)
+  {
+    mc_rtc::log::warning("[MC_RTC_DEPRECATED] Prefer using addContact/removeContact for contacts manipulation");
+    controller_->clearContacts();
+    for(const auto & c : contacts)
+    {
+      controller_->addContact(mc_control::Contact::from_mc_rbdyn(*controller_, c));
+    }
+  }
+  else
+  {
+    setContacts(ControllerToken{}, contacts);
+  }
+}
+
+} // namespace mc_solver


### PR DESCRIPTION
The main purpose of this PR is to bring in the helpers from the FSM controller into the regular controller class

This is essentially:
- renaming `mc_control::fsm::Contact` to `mc_control::Contact` (keeping an alias in the `fsm` namespace)
- moving code from the FSM controller to the regular controller
- Tightening the relationship between contacts in `mc_solver::QPSolver` and the contacts in the controller
- Improving the presentation of contacts in the GUI