### PR TITLE
Fix additional loading of surfaces from RSDF and load additional frames in the FSM configuration

### DIFF
--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -163,6 +163,15 @@ public:
    */
   RobotFrame & makeFrame(const std::string & name, RobotFrame & parent, sva::PTransformd X_p_f, bool baked = false);
 
+  /**
+   * Create new frames attached to this robot
+   *
+   * \param frames Description of the frames
+   *
+   * \throws If any of the frames' \p parent does not belong to this robot or if \p name already exists in this robot
+   */
+  void makeFrames(std::vector<mc_rbdyn::RobotModule::FrameDescription> frames);
+
   /** Returns the joint index of joint named \name
    *
    * \throws If the joint does not exist within the robot.

--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -1032,8 +1032,25 @@ protected:
   /** Copy loaded data from this robot to a new robot **/
   void copyLoadedData(Robot & destination) const;
 
-  /** Used to set the surfaces' X_b_s correctly and create frames from RobotModule */
+  /**
+   * Used to set all robot surfaces' X_b_s correctly
+   *
+   * This updates all surfaces in surfaces_ vector and should only be called
+   * once
+   */
   void fixSurfaces();
+
+  /**
+   * Used to set the specified surfaces' X_b_s correctly
+   *
+   * This function should only be called once per surface.
+   *
+   * @param surfaces Surfaces that need to be modified
+   **/
+  void fixSurfaces(const std::vector<SurfacePtr> & surfaces);
+
+  /** Used to create frames from the robot module */
+  void createModuleFrames();
 
   /** Used to set the collision transforms correctly */
   void fixCollisionTransforms();

--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -1050,16 +1050,13 @@ protected:
   void fixSurfaces();
 
   /**
-   * Used to set the specified surfaces' X_b_s correctly
+   * Used to set the specified surface X_b_s correctly
    *
    * This function should only be called once per surface.
    *
-   * @param surfaces Surfaces that need to be modified
+   * @param surfaces Surface that need to be modified
    **/
-  void fixSurfaces(const std::vector<SurfacePtr> & surfaces);
-
-  /** Used to create frames from the robot module */
-  void createModuleFrames();
+  void fixSurface(Surface & surface);
 
   /** Used to set the collision transforms correctly */
   void fixCollisionTransforms();

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -1249,12 +1249,23 @@ void Robot::fixCollisionTransforms()
 void Robot::loadRSDFFromDir(const std::string & surfaceDir)
 {
   std::vector<SurfacePtr> surfacesIn = readRSDFFromDir(surfaceDir);
+  std::vector<SurfacePtr> loadedSurfaces;
+  loadedSurfaces.reserve(surfacesIn.size());
   for(const auto & sp : surfacesIn)
   {
     /* Check coherence of surface with mb */
     if(hasBody(sp->bodyName()))
     {
-      surfaces_[sp->name()] = sp;
+      if(hasSurface(sp->name()))
+      {
+        mc_rtc::log::warning("This robot already has a surface named {}, ignoring loading from {}", sp->name(),
+                             surfaceDir);
+      }
+      else
+      {
+        surfaces_[sp->name()] = sp;
+        loadedSurfaces.push_back(sp);
+      }
     }
     else
     {
@@ -1263,7 +1274,7 @@ void Robot::loadRSDFFromDir(const std::string & surfaceDir)
                            sp->name(), sp->bodyName(), name());
     }
   }
-  fixSurfaces(surfacesIn);
+  fixSurfaces(loadedSurfaces);
 }
 
 std::map<std::string, std::vector<double>> Robot::stance() const

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -1197,7 +1197,11 @@ void Robot::fixSurfaces(const std::vector<SurfacePtr> & surfaces)
 
 void Robot::createModuleFrames()
 {
-  auto frames = module().frames();
+  makeFrames(module().frames());
+}
+
+void Robot::makeFrames(std::vector<mc_rbdyn::RobotModule::FrameDescription> frames)
+{
   size_t added_frames = 0;
   do
   {


### PR DESCRIPTION
Changes introduced by #247 break controllers that rely on calling `Robot::loadRSDFFromDir` themselves.
This is because this function calls `fixSurfaces()`, that in the new implementation also attempts to create `Frames` for all surfaces in the controller. Since most of these frames already exist, this fails.

This PR fixes the behaviour by:
- Decoupling `fixSurfaces` from frames creation
- Only loading the surfaces that haven't already been loaded (and displaying a warning if the surfaces already exist)
- Independently creating the frames from the robot module in a new function `Robot::createModuleFrames()`

Additionally, I've added a mechanism to load additional frames from the FSM configuration, which is a common use case. For example:
```yaml
# Additional robots to load
robots:
  panda_femur:
    init_pos:
      translation: [0,0,0]
    frames:
      - name: FemurHead
        parent: panda_link8 
        X_p_f:
          translation: [0, 0, 0.15]
          rotation: [0, 0, 0]
  panda_tibia:
    module: PandaProsthesis::Tibia
    frames:
      - name: TibiaHead
        parent: panda_link8 
        X_p_f:
          translation: [0, 0, 0.2]
          rotation: [-1.57, 0, 0]
```

For consistency, this deprecates use of a global `init_pos` entry in favor of the robot specific ones `robots/<main robot>/init_pos`. I don't think any controller was relying on loading the same `init_pos` for multiple `MainRobot`, and with the new approach it's nowl possible to define different `init_pos` for multiple main robots (one only has to ommit the `module` entry).