### PR TITLE
[mc_control] Properly apply contact DoF when using the deprecated method

### DIFF
--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -43,8 +43,20 @@ namespace mc_control
 
 Contact Contact::from_mc_rbdyn(const MCController & ctl, const mc_rbdyn::Contact & contact)
 {
-  return {ctl.robots().robot(contact.r1Index()).name(), ctl.robots().robot(contact.r2Index()).name(),
-          contact.r1Surface()->name(), contact.r2Surface()->name(), contact.friction()};
+
+  Eigen::Vector6d dof = Eigen::Vector6d::Ones();
+  const auto cId = contact.contactId(ctl.robots());
+  if(ctl.contactConstraint.contactConstr->hasDoFContact(cId))
+  {
+    dof = ctl.contactConstraint.contactConstr->dofContact(cId).diagonal();
+  }
+
+  return {ctl.robots().robot(contact.r1Index()).name(),
+          ctl.robots().robot(contact.r2Index()).name(),
+          contact.r1Surface()->name(),
+          contact.r2Surface()->name(),
+          contact.friction(),
+          dof};
 }
 
 MCController::MCController(std::shared_ptr<mc_rbdyn::RobotModule> robot, double dt) : MCController(robot, dt, {}) {}


### PR DESCRIPTION
Following #250, we noticed that the old method of setting contact DoF is no longer working.
For example:
```
  Eigen::Matrix6d dof = Eigen::Matrix6d::Identity(6, 6);
  dof(0, 0) = 0;
  dof(1, 1) = 0;
  dof(5, 5) = 0;
  // dof = Eigen::Matrix6d::Zero(6,6);
  tasks::qp::ContactId ContactId_R;
  tasks::qp::ContactId ContactId_L;
  ContactId_R = mc_rbdyn::Contact(robots(), 0, 1, "RightFoot", "AllGround").contactId(robots());
  ContactId_L = mc_rbdyn::Contact(robots(), 0, 1, "LeftFoot", "AllGround").contactId(robots());
  contactConstraint.contactConstr->addDofContact(ContactId_L, dof);
  contactConstraint.contactConstr->addDofContact(ContactId_R, dof);
  contactConstraint.contactConstr->updateDofContacts();
  solver().setContacts({{robots(), 0, 1, "LeftFoot", "AllGround"}, {robots(), 0, 1, "RightFoot", "AllGround"}});
```

results in two contacts set with full dof (`1 1 1 1 1 1`) instead of (`0 0 1 1 1 0`). This is because the `Contact::from_mc_rbdyn` doesn't take into account the contact's dof set in the constraint.

Requires https://github.com/jrl-umi3218/Tasks/pull/80