### PR TITLE
[mc_rbdyn] Load robot from module with a custom name

### DIFF
--- a/include/mc_rbdyn/Robots.h
+++ b/include/mc_rbdyn/Robots.h
@@ -300,6 +300,11 @@ MC_RBDYN_DLLAPI RobotsPtr loadRobot(const RobotModule & module,
                                     sva::PTransformd * base = nullptr,
                                     const std::string & baseName = "");
 
+MC_RBDYN_DLLAPI RobotsPtr loadRobot(const RobotModule & module,
+                                    const std::string & name,
+                                    sva::PTransformd * base = nullptr,
+                                    const std::string & baseName = "");
+
 MC_RBDYN_DLLAPI RobotsPtr loadRobots(const std::vector<std::shared_ptr<RobotModule>> & modules);
 
 MC_RBDYN_DLLAPI RobotsPtr loadRobotAndEnv(const RobotModule & module,

--- a/include/mc_solver/QPSolver.h
+++ b/include/mc_solver/QPSolver.h
@@ -5,6 +5,7 @@
 #ifndef _H_MCCONTROLQPSOLVER_H_
 #define _H_MCCONTROLQPSOLVER_H_
 
+#include <mc_control/api.h>
 #include <mc_rbdyn/Contact.h>
 #include <mc_rbdyn/Robots.h>
 #include <mc_rtc/pragma.h>
@@ -82,11 +83,11 @@ MC_RTC_diagnostic_pop
  * Always ensure that the solver is up-to-date
  */
 
-struct MC_SOLVER_DLLAPI QPSolver
+struct QPSolver
 {
 public:
   /** This token is used to give mc_control::MCController access to some internals */
-  struct ControllerToken
+  struct MC_SOLVER_DLLAPI ControllerToken
   {
     friend struct mc_control::MCController;
     friend struct QPSolver;
@@ -101,28 +102,28 @@ public:
    *
    * \note The real robots will be created by copying the provided robots
    */
-  QPSolver(mc_rbdyn::RobotsPtr robots, double timeStep);
+  MC_SOLVER_DLLAPI QPSolver(mc_rbdyn::RobotsPtr robots, double timeStep);
 
   /** Constructor (the solver creates its own Robots instance)
    * \param timeStep Timestep of the solver
    */
-  QPSolver(double timeStep);
+  MC_SOLVER_DLLAPI QPSolver(double timeStep);
 
   /** Add a constraint set
    * \param cs Constraint set added to the solver
    */
-  void addConstraintSet(ConstraintSet & cs);
+  MC_SOLVER_DLLAPI void addConstraintSet(ConstraintSet & cs);
 
   /** Remove a constraint set
    * \param cs Constrain set removed from the solver
    */
-  void removeConstraintSet(ConstraintSet & cs);
+  MC_SOLVER_DLLAPI void removeConstraintSet(ConstraintSet & cs);
 
   /** Add a task to the solver
    * \param task Pointer to the added task, QPSolver does not take ownership of this pointer and the caller should make
    * sure the object remains valid until it is removed from the solver
    */
-  void addTask(tasks::qp::Task * task);
+  MC_SOLVER_DLLAPI void addTask(tasks::qp::Task * task);
 
   /** Add a task to the solver
    *
@@ -133,7 +134,7 @@ public:
    * automatically called before the optimization is solved.
    *
    */
-  void addTask(mc_tasks::MetaTask * task);
+  MC_SOLVER_DLLAPI void addTask(mc_tasks::MetaTask * task);
 
   /** Add a task to the solver
    *
@@ -158,7 +159,7 @@ public:
   /** Remove a task from the solver
    * \param task Pointer to the removed task. The task is not deleted after being removed
    */
-  void removeTask(tasks::qp::Task * task);
+  MC_SOLVER_DLLAPI void removeTask(tasks::qp::Task * task);
 
   /** Remove a task from the solver
    *
@@ -168,7 +169,7 @@ public:
    * updated anymore and memory should be released by the task's owner.
    *
    */
-  void removeTask(mc_tasks::MetaTask * task);
+  MC_SOLVER_DLLAPI void removeTask(mc_tasks::MetaTask * task);
 
   /** Remove a task from the solver
    *
@@ -217,35 +218,36 @@ public:
    * \return The tasks:qp::BilateralContact entity from the solver if id is valid, otherwise, the first element of the
    * pair is -1 and the reference is invalid
    */
-  std::pair<int, const tasks::qp::BilateralContact &> contactById(const tasks::qp::ContactId & id) const;
+  MC_SOLVER_DLLAPI std::pair<int, const tasks::qp::BilateralContact &> contactById(
+      const tasks::qp::ContactId & id) const;
 
   /** Gives access to a part to lambdaVec given a contact index
    * \param cIndex The index of the contact
    * \return The lambdaVec associated
    */
-  Eigen::VectorXd lambdaVec(int cIndex) const;
+  MC_SOLVER_DLLAPI Eigen::VectorXd lambdaVec(int cIndex) const;
 
   /** Reset all contacts in the solver and use the new set of contacts provided
    * \item contact Set of mc_rbdyn::Contact
    */
-  void setContacts(const std::vector<mc_rbdyn::Contact> & contacts = {});
+  MC_CONTROL_DLLAPI void setContacts(const std::vector<mc_rbdyn::Contact> & contacts = {});
 
   /* Called by the owning controller to actually set the contacts or internally by QPSolver when it has no owning
    * controller */
-  void setContacts(ControllerToken, const std::vector<mc_rbdyn::Contact> & contacts);
+  MC_SOLVER_DLLAPI void setContacts(ControllerToken, const std::vector<mc_rbdyn::Contact> & contacts);
 
   /** Returns the current set of contacts */
-  const std::vector<mc_rbdyn::Contact> & contacts() const;
+  MC_SOLVER_DLLAPI const std::vector<mc_rbdyn::Contact> & contacts() const;
 
   /** Returns the MetaTasks currently in the solver */
-  const std::vector<mc_tasks::MetaTask *> & tasks() const;
+  MC_SOLVER_DLLAPI const std::vector<mc_tasks::MetaTask *> & tasks() const;
 
   /** Desired resultant of contact force in robot surface frame
    * \param contact Contact for which the force is desired.
    * This contact must be one of the active contacts in the solver.
    * \return Contact force in robot surface frame
    */
-  const sva::ForceVecd desiredContactForce(const mc_rbdyn::Contact & id) const;
+  MC_SOLVER_DLLAPI const sva::ForceVecd desiredContactForce(const mc_rbdyn::Contact & id) const;
 
   /** Run one iteration of the QP.
    *
@@ -255,12 +257,12 @@ public:
    *
    * \return True if successful, false otherwise.
    */
-  bool run(FeedbackType fType = FeedbackType::None);
+  MC_SOLVER_DLLAPI bool run(FeedbackType fType = FeedbackType::None);
 
   /** Provides the result of run() for robots.robot()
    * \param curTime Unused
    */
-  const QPResultMsg & send(double curTime = 0);
+  MC_SOLVER_DLLAPI const QPResultMsg & send(double curTime = 0);
 
   /** Non-const access to QPResultMsg
    *
@@ -274,36 +276,36 @@ public:
   }
 
   /** Gives access to the main robot in the solver */
-  const mc_rbdyn::Robot & robot() const;
+  MC_SOLVER_DLLAPI const mc_rbdyn::Robot & robot() const;
   /** Gives access to the main robot in the solver */
-  mc_rbdyn::Robot & robot();
+  MC_SOLVER_DLLAPI mc_rbdyn::Robot & robot();
 
   /** Gives access to the robot with the given index in the solver */
-  mc_rbdyn::Robot & robot(unsigned int idx);
+  MC_SOLVER_DLLAPI mc_rbdyn::Robot & robot(unsigned int idx);
   /** Gives access to the robot with the given index in the solver */
-  const mc_rbdyn::Robot & robot(unsigned int idx) const;
+  MC_SOLVER_DLLAPI const mc_rbdyn::Robot & robot(unsigned int idx) const;
 
   /** Gives access to the environment robot in the solver (see mc_rbdyn::Robots) */
-  const mc_rbdyn::Robot & env() const;
+  MC_SOLVER_DLLAPI const mc_rbdyn::Robot & env() const;
   /** Gives access to the environment robot in the solver (see mc_rbdyn::Robots) */
-  mc_rbdyn::Robot & env();
+  MC_SOLVER_DLLAPI mc_rbdyn::Robot & env();
 
   /** Gives access to the robots controlled by this solver */
-  const mc_rbdyn::Robots & robots() const;
+  MC_SOLVER_DLLAPI const mc_rbdyn::Robots & robots() const;
   /** Gives access to the robots controlled by this solver */
-  mc_rbdyn::Robots & robots();
+  MC_SOLVER_DLLAPI mc_rbdyn::Robots & robots();
 
   /** Gives access to the real robots used by this solver */
-  const mc_rbdyn::Robots & realRobots() const;
+  MC_SOLVER_DLLAPI const mc_rbdyn::Robots & realRobots() const;
   /** Gives access to the real robots used by this solver */
-  mc_rbdyn::Robots & realRobots();
+  MC_SOLVER_DLLAPI mc_rbdyn::Robots & realRobots();
 
   /** Update number of variables
    *
    * This should be called when/if you add new robots into the scene after the
    * solver initialization, this is a costly operation.
    */
-  void updateNrVars();
+  MC_SOLVER_DLLAPI void updateNrVars();
 
   /** Update constraints matrix sizes
    *
@@ -311,39 +313,39 @@ public:
    * Tasks rather than those wrapped in this library, you probably do not need
    * to call this
    */
-  void updateConstrSize();
+  MC_SOLVER_DLLAPI void updateConstrSize();
 
   /** Returns the timestep of the solver
    * \return The timestep of the solver
    */
-  double dt() const;
+  MC_SOLVER_DLLAPI double dt() const;
 
   /** Returns the internal QP solver data
    * \return The data of the solver
    */
-  tasks::qp::SolverData & data();
+  MC_SOLVER_DLLAPI tasks::qp::SolverData & data();
 
   /** Use the dynamics constraint to fill torque in the main robot */
-  void fillTorque(const mc_solver::DynamicsConstraint & dynamicsConstraint);
+  MC_SOLVER_DLLAPI void fillTorque(const mc_solver::DynamicsConstraint & dynamicsConstraint);
 
-  boost::timer::cpu_times solveTime();
+  MC_SOLVER_DLLAPI boost::timer::cpu_times solveTime();
 
-  boost::timer::cpu_times solveAndBuildTime();
+  MC_SOLVER_DLLAPI boost::timer::cpu_times solveAndBuildTime();
 
   /** Return the solvers result vector.
    * \return The solvers result vector.
    */
-  const Eigen::VectorXd & result() const;
+  MC_SOLVER_DLLAPI const Eigen::VectorXd & result() const;
 
   /** Set the logger for this solver instance */
-  void logger(std::shared_ptr<mc_rtc::Logger> logger);
+  MC_SOLVER_DLLAPI void logger(std::shared_ptr<mc_rtc::Logger> logger);
   /** Access to the logger instance */
-  std::shared_ptr<mc_rtc::Logger> logger() const;
+  MC_SOLVER_DLLAPI std::shared_ptr<mc_rtc::Logger> logger() const;
 
   /** Set the GUI helper for this solver instance */
-  void gui(std::shared_ptr<mc_rtc::gui::StateBuilder> gui);
+  MC_SOLVER_DLLAPI void gui(std::shared_ptr<mc_rtc::gui::StateBuilder> gui);
   /** Access to the gui instance */
-  std::shared_ptr<mc_rtc::gui::StateBuilder> gui() const;
+  MC_SOLVER_DLLAPI std::shared_ptr<mc_rtc::gui::StateBuilder> gui() const;
 
   /** Set the controller that is owning this QPSolver instance */
   inline void controller(mc_control::MCController * ctl) noexcept
@@ -437,7 +439,7 @@ private:
 
 public:
   /** \deprecated{Default constructor, not made for general usage} */
-  QPSolver() {}
+  MC_SOLVER_DLLAPI QPSolver() {}
 };
 
 } // namespace mc_solver

--- a/src/mc_rbdyn/Robots.cpp
+++ b/src/mc_rbdyn/Robots.cpp
@@ -273,8 +273,16 @@ Robot & Robots::load(const std::string & name,
 
 RobotsPtr loadRobot(const RobotModule & module, sva::PTransformd * base, const std::string & baseName)
 {
+  return loadRobot(module, module.name, base, baseName);
+}
+
+RobotsPtr loadRobot(const RobotModule & module,
+                    const std::string & name,
+                    sva::PTransformd * base,
+                    const std::string & baseName)
+{
   auto robots = Robots::make();
-  robots->load(module.name, module, base, baseName);
+  robots->load(name, module, base, baseName);
   return robots;
 }
 

--- a/tests/controllers/mc_rtc.conf.in
+++ b/tests/controllers/mc_rtc.conf.in
@@ -14,7 +14,8 @@
   "LogTemplate" : "mc-rtc-test",
 
   "ClearControllerModulePath" : true,
-  "ControllerModulePaths" : ["@PYTHON_CONTROLLER_PATH@", "@TEST_CONTROLLER_PATH@"],
+  // Note: we have more paths than strictly needed here because we sometimes link with outside components and Windows does not have RPATH
+  "ControllerModulePaths" : ["@PYTHON_CONTROLLER_PATH@", "@OBSERVER_MODULE_PATH@", "@TEST_CONTROLLER_PATH@"],
   "ClearRobotModulePath" : true,
   "RobotModulePaths" : ["@ROBOT_MODULE_PATH@"],
   "ClearObserverModulePath": true,


### PR DESCRIPTION
This PR adds an overload to `Robots::loadRobot(...)` allowing to load a robot from a robot module, but using a custom name.

Required by https://github.com/jrl-umi3218/mc_state_observation/pull/13