### PR TITLE
[BodySensor] Initialize default body sensor with a valid parent

### DIFF
--- a/src/mc_observers/BodySensorObserver.cpp
+++ b/src/mc_observers/BodySensorObserver.cpp
@@ -23,14 +23,12 @@ void BodySensorObserver::configure(const mc_control::MCController & ctl, const m
   {
     mc_rtc::log::error_and_throw("[{}] No robot named {}", name(), robot_);
   }
+  auto & robot = ctl.robot(robot_);
   if(!ctl.robots().hasRobot(updateRobot_))
   {
     mc_rtc::log::error_and_throw("[{}] No robot named {}", name(), updateRobot_);
   }
-  if(updateFrom_ == Update::Sensor && !ctl.robot(robot_).hasBodySensor(fbSensorName_))
-  {
-    mc_rtc::log::error_and_throw("[{}] No sensor named {} in robot {}", name(), fbSensorName_, robot_);
-  }
+
   auto updateConfig = config("method", std::string{"sensor"});
   if(!updateConfig.empty())
   {
@@ -41,6 +39,19 @@ void BodySensorObserver::configure(const mc_control::MCController & ctl, const m
     else
     {
       updateFrom_ = Update::Control;
+    }
+  }
+
+  if(updateFrom_ == Update::Sensor)
+  {
+    if(!robot.hasBodySensor(fbSensorName_))
+    {
+      mc_rtc::log::error_and_throw("[{}] No sensor named {} in robot {}", name(), fbSensorName_, robot_);
+    }
+    if(!robot.hasBody(robot.bodySensor(fbSensorName_).parent()))
+    {
+      mc_rtc::log::error_and_throw("[{}] BodySensor \"{}\" has no parent named \"{}\" in robot \"{}\"", name(),
+                                   fbSensorName_, robot.bodySensor(fbSensorName_).parent(), robot_);
     }
   }
 

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -446,6 +446,12 @@ Robot::Robot(NewRobotToken,
   for(size_t i = 0; i < bodySensors_.size(); ++i)
   {
     const auto & bS = bodySensors_[i];
+    if(mb().bodyIndexByName().count(bS.parentBody()) == 0)
+    {
+      mc_rtc::log::error_and_throw(
+          "BodySensor \"{}\" requires a parent body named \"{}\" but no such body was found in robot \"{}\"", bS.name(),
+          bS.parentBody(), name);
+    }
     bodySensorsIndex_[bS.name()] = i;
     bodyBodySensors_[bS.parentBody()] = i;
   }

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -441,7 +441,7 @@ Robot::Robot(NewRobotToken,
   // Add a single default sensor if no sensor on the robot
   if(bodySensors_.size() == 0)
   {
-    bodySensors_.emplace_back();
+    bodySensors_.emplace_back("Default", mb().body(0).name(), sva::PTransformd::Identity());
   }
   for(size_t i = 0; i < bodySensors_.size(); ++i)
   {


### PR DESCRIPTION
When creating a robot module with no body sensor (e.g Panda), a default one is added. However, this sensor has neither a name nor a parent, which causes issues down the line, notably with observers assuming that sensors have a valid parent link.

Thus we:
- Ensure that all `BodySensors` have a valid parent
- Create a valid `BodySensor` (attached to the base link) in the case were none were provided by the robot module