### PR TITLE
Topic/fixing controller switching

### DIFF
--- a/src/mc_control/fsm/states/StabilizerStandingState.cpp
+++ b/src/mc_control/fsm/states/StabilizerStandingState.cpp
@@ -186,6 +186,15 @@ void StabilizerStandingState::start(Controller & ctl)
                             [this](double w) { stabilizerTask_->comWeight(w); });
   ctl.datastore().make_call("StabilizerStandingState::setCoMStiffness",
                             [this](const Eigen::Vector3d & s) { stabilizerTask_->comStiffness(s); });
+  ctl.datastore().make_call("StabilizerStandingState::setExternalWrenches",
+                            [this](const std::vector<std::string> & surfaceNames,
+				   const std::vector<sva::ForceVecd> & targetWrenches,
+				   const std::vector<sva::MotionVecd> & gains) {
+			      stabilizerTask_->setExternalWrenches(surfaceNames, targetWrenches, gains);
+			    });
+  ctl.datastore().make_call("StabilizerStandingState::getCoPAdmittance",
+			    [this](){ return stabilizerTask_->config().copAdmittance; });
+  ctl.datastore().make_call("StabilizerStandingState::setCoPAdmittance", [this](const Eigen::Vector2d & copAdmittance){ stabilizerTask_->copAdmittance(copAdmittance);});
 }
 
 void StabilizerStandingState::targetCoP(const Eigen::Vector3d & cop)
@@ -265,6 +274,9 @@ void StabilizerStandingState::teardown(Controller & ctl)
   ctl.datastore().remove("StabilizerStandingState::setTorsoStiffness");
   ctl.datastore().remove("StabilizerStandingState::setCoMWeight");
   ctl.datastore().remove("StabilizerStandingState::setCoMStiffness");
+  ctl.datastore().remove("StabilizerStandingState::setExternalWrenches");
+  ctl.datastore().remove("StabilizerStandingState::getCoPAdmittance");
+  ctl.datastore().remove("StabilizerStandingState::setCoPAdmittance");
   if(ownsAnchorFrameCallback_)
   {
     ctl.datastore().remove(anchorFrameFunction_);

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -702,6 +702,7 @@ bool MCGlobalController::run()
       {
         fs.wrench(controller_->realRobot().forceSensor(fs.name()).wrench());
       }
+      next_controller_->realRobot().mbc() = controller_->realRobot().mbc();
     }
     if(!running)
     {

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -123,6 +123,8 @@ void StabilizerTask::reset()
 
   omega_ = std::sqrt(constants::gravity.z() / robot().com().z());
   commitConfig();
+
+  setContacts({ContactState::Left, ContactState::Right});
 }
 
 void StabilizerTask::dimWeight(const Eigen::VectorXd & /* dim */)


### PR DESCRIPTION
Updating the observers 

Reset the Stabilizer task properly when it has already been created in a controller

Plus an extra older commit that adds calls in the datastore to set the external wrenches in the stabilizer task from other states
