### PR TITLE
[global] Expose EnableController in the datastore

### DIFF
--- a/doc/_data/schemas/State/EnableController.json
+++ b/doc/_data/schemas/State/EnableController.json
@@ -1,0 +1,23 @@
+{
+  "allOf":
+  [
+    {
+      "title": "mc_control::fsm::EnableControllerState",
+      "description": "Switch to the given controller.<br/>Outputs \"OK\" in case of success, \"Failed\" otherwise.",
+      "type": "object",
+      "properties":
+      {
+        "NextController":
+        {
+          "type": "string",
+          "default": "",
+          "description": "Controller to switch to"
+        }
+      },
+      "required": []
+    },
+    {
+      "$ref": "/../../common/State.json"
+    }
+  ]
+}

--- a/doc/_examples/json/State/EnableController.json
+++ b/doc/_examples/json/State/EnableController.json
@@ -1,0 +1,4 @@
+{
+  "base": "EnableController",
+  "NextController": "CoM"
+}

--- a/doc/_examples/yaml/State/EnableController.yaml
+++ b/doc/_examples/yaml/State/EnableController.yaml
@@ -1,0 +1,2 @@
+base: EnableController
+NextController: CoM

--- a/include/mc_control/fsm/states/EnableController.h
+++ b/include/mc_control/fsm/states/EnableController.h
@@ -35,4 +35,3 @@ struct MC_CONTROL_FSM_STATE_DLLAPI EnableControllerState : State
 } // namespace fsm
 
 } // namespace mc_control
-

--- a/include/mc_control/fsm/states/EnableController.h
+++ b/include/mc_control/fsm/states/EnableController.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_control/fsm/State.h>
+
+namespace mc_control
+{
+
+namespace fsm
+{
+
+/** Implements a state that switchs to a given controller
+ *
+ * This state outputs "OK" if the switch succeeds but the next state only
+ * starts when you switch back to the controller that initiated the switch.
+ *
+ * It outputs "Failed" if the switch fails (switching to an non-enabled
+ * controller).
+ */
+struct MC_CONTROL_FSM_STATE_DLLAPI EnableControllerState : State
+{
+  void start(Controller &) override;
+
+  bool run(Controller &) override
+  {
+    return true;
+  }
+
+  void teardown(Controller &) override {}
+};
+
+} // namespace fsm
+
+} // namespace mc_control
+

--- a/include/mc_control/fsm/states/EnableController.h
+++ b/include/mc_control/fsm/states/EnableController.h
@@ -12,7 +12,7 @@ namespace mc_control
 namespace fsm
 {
 
-/** Implements a state that switchs to a given controller
+/** Implements a state that switches to a given controller
  *
  * This state outputs "OK" if the switch succeeds but the next state only
  * starts when you switch back to the controller that initiated the switch.

--- a/src/mc_control/fsm/states/CMakeLists.txt
+++ b/src/mc_control/fsm/states/CMakeLists.txt
@@ -46,6 +46,7 @@ add_fsm_state_simple(SlidingFootContact)
 add_fsm_state_simple(Meta)
 add_fsm_state_simple(Parallel)
 add_fsm_state_simple(StabilizerStandingState)
+add_fsm_state_simple(EnableController)
 
 # PythonState
 if(${PYTHON_BINDING})

--- a/src/mc_control/fsm/states/EnableController.cpp
+++ b/src/mc_control/fsm/states/EnableController.cpp
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#include <mc_control/fsm/Controller.h>
+#include <mc_control/fsm/states/EnableController.h>
+
+namespace mc_control
+{
+
+namespace fsm
+{
+
+void EnableControllerState::start(Controller & ctl)
+{
+  std::string next_controller = config_("NextController", std::string(""));
+  if(ctl.datastore().call<bool, const std::string &>("Global::EnableController", next_controller))
+  {
+    output("OK");
+  }
+  else
+  {
+    output("Failed");
+  }
+}
+
+} // namespace fsm
+
+} // namespace mc_control
+
+EXPORT_SINGLE_STATE("EnableController", mc_control::fsm::EnableControllerState)

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -1002,6 +1002,8 @@ bool MCGlobalController::AddController(const std::string & name)
                                                            config.controllers_configs[name]);
     }
     controllers[name]->name_ = name;
+    controllers[name]->datastore().make_call("Global::EnableController",
+                                             [this](const std::string & name) { return EnableController(name); });
     if(config.enable_log)
     {
       controllers[name]->logger().setup(config.log_policy, config.log_directory, config.log_template);


### PR DESCRIPTION
This allows to perform programmatic switches between controllers:
- By calling `datastore().call("Global::EnableController", "NextControllerName")` from your code
- By using the `mc_control::fsm::EnableControllerState` in your FSM

@gergondet What are we missing to get this merged? Mohamed and Ahmed would like to use it to switch between their controllers (teleoperated grasping and tossing).