### PR TITLE
Make the getter for gui a const function in controller interface

### DIFF
--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -291,7 +291,7 @@ public:
   mc_rtc::Logger & logger();
 
   /** Returns mc_rtc::gui::StateBuilder ptr */
-  std::shared_ptr<mc_rtc::gui::StateBuilder> gui()
+  std::shared_ptr<mc_rtc::gui::StateBuilder> gui() const
   {
     return gui_;
   }


### PR DESCRIPTION
This PR allows to get a non const pointer to the GUI from a const controller. This enables to modify the GUI without needing the right to modify the controller (for example in a state-observer). 