### PR TITLE
[StabilizerTask] distribute moment around CoM instead of world origin

### DIFF
--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -971,7 +971,7 @@ void StabilizerTask::distributeWrench(const sva::ForceVecd & desiredWrench)
   const sva::PTransformd & X_0_rc = rightContact.surfacePose();
   const sva::PTransformd & X_0_lankle = leftContact.anklePose();
   const sva::PTransformd & X_0_rankle = rightContact.anklePose();
-  sva::PTransformd X_0_com(comTarget_);
+  sva::PTransformd X_0_zmp(zmpTarget_);
 
   constexpr unsigned NB_VAR = 6 + 6;
   constexpr unsigned COST_DIM = 6 + NB_VAR + 1;
@@ -983,9 +983,9 @@ void StabilizerTask::distributeWrench(const sva::ForceVecd & desiredWrench)
   // |w_l_0 + w_r_0 - desiredWrench|^2
   auto A_net = A.block<6, 12>(0, 0);
   auto b_net = b.segment<6>(0);
-  A_net.block<6, 6>(0, 0) = X_0_com.dualMatrix();
-  A_net.block<6, 6>(0, 6) = X_0_com.dualMatrix();
-  b_net = X_0_com.dualMul(desiredWrench).vector();
+  A_net.block<6, 6>(0, 0) = X_0_zmp.dualMatrix();
+  A_net.block<6, 6>(0, 6) = X_0_zmp.dualMatrix();
+  b_net = X_0_zmp.dualMul(desiredWrench).vector();
 
   // |ankle torques|^2
   auto A_lankle = A.block<6, 6>(6, 0);

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -980,7 +980,9 @@ void StabilizerTask::distributeWrench(const sva::ForceVecd & desiredWrench)
   A.setZero(COST_DIM, NB_VAR);
   b.setZero(COST_DIM);
 
-  // |w_l_0 + w_r_0 - desiredWrench|^2
+  // |w_l_zmp + w_r_zmp - desiredWrench|^2
+  // We handle moments around the ZMP instead of the world origin to avoid numerical errors due to large moment values.
+  // https://github.com/jrl-umi3218/mc_rtc/pull/285
   auto A_net = A.block<6, 12>(0, 0);
   auto b_net = b.segment<6>(0);
   A_net.block<6, 6>(0, 0) = X_0_zmp.dualMatrix();

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -971,6 +971,7 @@ void StabilizerTask::distributeWrench(const sva::ForceVecd & desiredWrench)
   const sva::PTransformd & X_0_rc = rightContact.surfacePose();
   const sva::PTransformd & X_0_lankle = leftContact.anklePose();
   const sva::PTransformd & X_0_rankle = rightContact.anklePose();
+  sva::PTransformd X_0_com(comTarget_);
 
   constexpr unsigned NB_VAR = 6 + 6;
   constexpr unsigned COST_DIM = 6 + NB_VAR + 1;
@@ -982,9 +983,9 @@ void StabilizerTask::distributeWrench(const sva::ForceVecd & desiredWrench)
   // |w_l_0 + w_r_0 - desiredWrench|^2
   auto A_net = A.block<6, 12>(0, 0);
   auto b_net = b.segment<6>(0);
-  A_net.block<6, 6>(0, 0) = Eigen::Matrix6d::Identity();
-  A_net.block<6, 6>(0, 6) = Eigen::Matrix6d::Identity();
-  b_net = desiredWrench.vector();
+  A_net.block<6, 6>(0, 0) = X_0_com.dualMatrix();
+  A_net.block<6, 6>(0, 6) = X_0_com.dualMatrix();
+  b_net = X_0_com.dualMul(desiredWrench).vector();
 
   // |ankle torques|^2
   auto A_lankle = A.block<6, 6>(6, 0);


### PR DESCRIPTION
I confirmed that this PR solves https://github.com/jrl-umi3218/mc_rtc/issues/177 for lipm_walking_controller with JVRC1 in choreonoid.

It represents the moment part of the equation (12) in [Stephane's paper](https://arxiv.org/pdf/1809.07073.pdf) around the robot CoM instead of the world origin. This seems to keep the numerical calculations stable by avoiding too large moment value when the robot moves away from the origin (but the QP should be equivalent, and I still don't know the exact reason why this is necessary).

I have confirmed that the robot can walk with lipm_walking_controller near and away from the origin, but be careful with merging as there may be unforeseen side effects.

For information, I've encountered the same behavior with my multi-contact motion stabilizer (i.e., the robot falls over when it moved away from the origin), and solved the problem by handling the moment around the CoM instead of around the world origin.
https://github.com/isri-aist/Motion6DoF/commit/6da2abeb89e27f7ae9a72a491945a9351f188b65
