### PR TITLE
Add non-throwing version of ZMP computations

### DIFF
--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -404,6 +404,27 @@ public:
                       double minimalNetNormalForce = 1.) const;
 
   /**
+   * @brief Actual ZMP computation from net total wrench and the ZMP plane
+   *
+   * @param zmpOut Output of the ZMP computation expressed in the requested frame
+   * @param netTotalWrench Total wrench for all links in contact
+   * @param plane_p Arbitrary point on the ZMP plane
+   * @param plane_n Normal to the ZMP plane (normalized)
+   * @param minimalNetNormalForce[N] Mininal force above which the ZMP computation
+   * is considered valid. Must be >0 (prevents a divide by zero).
+   *
+   * @return True if the computation was successful, false otherwise and \p zmpOut is untouched
+   *
+   * \see bool mc_rbdyn::zmp(Eigen::Vector3d & zmpOut, const sva::ForceVecd & netTotalWrench, const Eigen::Vector3d &
+   * plane_p, const Eigen::Vector3d & plane_n, double minimalNetNormalForce)
+   */
+  bool zmp(Eigen::Vector3d & zmpOut,
+           const sva::ForceVecd & netTotalWrench,
+           const Eigen::Vector3d & plane_p,
+           const Eigen::Vector3d & plane_n,
+           double minimalNetNormalForce = 1.) const noexcept;
+
+  /**
    * @brief ZMP computation from net total wrench and a frame
    *
    * See \ref zmpDoc
@@ -422,6 +443,27 @@ public:
                       const sva::PTransformd & zmpFrame,
                       double minimalNetNormalForce = 1.) const;
 
+  /**
+   * @brief ZMP computation from net total wrench and a frame
+   *
+   * See \ref zmpDoc
+   *
+   * \see Eigen::Vector3d mc_rbdyn::zmp(Eigen::Vector3d & zmpOut, const sva::ForceVecd & netTotalWrench, const
+   * sva::PTransformd & zmpFrame, double minimalNetNormalForce)
+   *
+   * @param zmpOut Output of the ZMP computation expressed in the plane defined by the zmpFrame frame
+   * @param netTotalWrench
+   * @param zmpFrame Frame used for ZMP computation. The convention here is
+   * that the contact frame should have its z-axis pointing in the normal
+   * direction of the contact towards the robot.
+   *
+   * @return True if the computation was successful, false otherwise and \p zmpOut is untouched
+   */
+  bool zmp(Eigen::Vector3d & zmpOut,
+           const sva::ForceVecd & netTotalWrench,
+           const sva::PTransformd & zmpFrame,
+           double minimalNetNormalForce = 1.) const noexcept;
+
   /** Computes the ZMP from sensor names and a plane
    *
    * See \ref zmpDoc
@@ -433,6 +475,18 @@ public:
                       const Eigen::Vector3d & plane_n,
                       double minimalNetNormalForce = 1.) const;
 
+  /** Computes the ZMP from sensor names and a plane
+   *
+   * See \ref zmpDoc
+   *
+   * @param sensorNames Names of all sensors attached to a link in contact with the environment
+   */
+  bool zmp(Eigen::Vector3d & zmpOut,
+           const std::vector<std::string> & sensorNames,
+           const Eigen::Vector3d & plane_p,
+           const Eigen::Vector3d & plane_n,
+           double minimalNetNormalForce = 1.) const noexcept;
+
   /**
    * @brief Computes the ZMP from sensor names and a frame
    *
@@ -443,6 +497,18 @@ public:
   Eigen::Vector3d zmp(const std::vector<std::string> & sensorNames,
                       const sva::PTransformd & zmpFrame,
                       double minimalNetNormalForce = 1.) const;
+
+  /**
+   * @brief Computes the ZMP from sensor names and a frame
+   *
+   * See \ref zmpDoc
+   *
+   * @param sensorNames Names of all sensors attached to a link in contact with the environment
+   */
+  bool zmp(Eigen::Vector3d & zmpOut,
+           const std::vector<std::string> & sensorNames,
+           const sva::PTransformd & zmpFrame,
+           double minimalNetNormalForce = 1.) const noexcept;
 
   /** Access the robot's angular lower limits (const) */
   const std::vector<std::vector<double>> & ql() const;

--- a/include/mc_rbdyn/ZMP.h
+++ b/include/mc_rbdyn/ZMP.h
@@ -30,6 +30,28 @@ Eigen::Vector3d MC_RBDYN_DLLAPI zmp(const sva::ForceVecd & netTotalWrench,
                                     double minimalNetNormalForce = 1.);
 
 /**
+ * @brief Actual ZMP computation from net total wrench and the ZMP plane
+ *
+ * See \ref zmpDoc
+ *
+ * @param zmpOut Output the updated ZMP
+ * @param netTotalWrench Total wrench for all links in contact
+ * @param plane_p Arbitrary point on the ZMP plane
+ * @param plane_n Normal to the ZMP plane (normalized)
+ * @param minimalNetNormalForce[N] Mininal force above which the ZMP computation
+ * is considered valid. Must be >0 (prevents a divide by zero).
+ *
+ * @return True if the ZMP was computed, otherwise \p zmpOut is left as-is and false is returned
+ *
+ * \anchor zmpDoc
+ */
+bool MC_RBDYN_DLLAPI zmp(Eigen::Vector3d & zmpOut,
+                         const sva::ForceVecd & netTotalWrench,
+                         const Eigen::Vector3d & plane_p,
+                         const Eigen::Vector3d & plane_n,
+                         double minimalNetNormalForce = 1.) noexcept;
+
+/**
  * @brief ZMP computation from net total wrench and a frame
  *
  * See \ref zmpDoc
@@ -38,6 +60,8 @@ Eigen::Vector3d MC_RBDYN_DLLAPI zmp(const sva::ForceVecd & netTotalWrench,
  * @param zmpFrame Frame used for ZMP computation. The convention here is
  * that the contact frame should have its z-axis pointing in the normal
  * direction of the contact towards the robot.
+ * @param minimalNetNormalForce[N] Mininal force above which the ZMP computation
+ * is considered valid. Must be >0 (prevents a divide by zero).
  *
  * @throws To prevent dividing by zero, throws if the projected force is below minimalNetNormalForce newton. This is
  * highly unlikely to happen and would likely indicate indicate that you are computing a ZMP from invalid forces (such
@@ -48,4 +72,25 @@ Eigen::Vector3d MC_RBDYN_DLLAPI zmp(const sva::ForceVecd & netTotalWrench,
 Eigen::Vector3d MC_RBDYN_DLLAPI zmp(const sva::ForceVecd & netTotalWrench,
                                     const sva::PTransformd & zmpFrame,
                                     double minimalNetNormalForce = 1.);
+
+/**
+ * @brief ZMP computation from net total wrench and a frame
+ *
+ * See \ref zmpDoc
+ *
+ * @param zmpOut Output the updated ZMP
+ * @param netTotalWrench
+ * @param zmpFrame Frame used for ZMP computation. The convention here is
+ * that the contact frame should have its z-axis pointing in the normal
+ * direction of the contact towards the robot.
+ * @param minimalNetNormalForce[N] Mininal force above which the ZMP computation
+ * is considered valid. Must be >0 (prevents a divide by zero).
+ *
+ * @return True if the ZMP was computed, otherwise \p zmpOut is left as-is and false is returned
+ */
+bool MC_RBDYN_DLLAPI zmp(Eigen::Vector3d & zmpOut,
+                         const sva::ForceVecd & netTotalWrench,
+                         const sva::PTransformd & zmpFrame,
+                         double minimalNetNormalForce = 1.) noexcept;
+
 } // namespace mc_rbdyn

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -828,11 +828,28 @@ Eigen::Vector3d Robot::zmp(const sva::ForceVecd & netTotalWrench,
   return mc_rbdyn::zmp(netTotalWrench, plane_p, plane_n, minimalNetNormalForce);
 }
 
+bool Robot::zmp(Eigen::Vector3d & zmpOut,
+                const sva::ForceVecd & netTotalWrench,
+                const Eigen::Vector3d & plane_p,
+                const Eigen::Vector3d & plane_n,
+                double minimalNetNormalForce) const noexcept
+{
+  return mc_rbdyn::zmp(zmpOut, netTotalWrench, plane_p, plane_n, minimalNetNormalForce);
+}
+
 Eigen::Vector3d Robot::zmp(const sva::ForceVecd & netWrench,
                            const sva::PTransformd & zmpFrame,
                            double minimalNetNormalForce) const
 {
   return mc_rbdyn::zmp(netWrench, zmpFrame, minimalNetNormalForce);
+}
+
+bool Robot::zmp(Eigen::Vector3d & zmpOut,
+                const sva::ForceVecd & netWrench,
+                const sva::PTransformd & zmpFrame,
+                double minimalNetNormalForce) const noexcept
+{
+  return mc_rbdyn::zmp(zmpOut, netWrench, zmpFrame, minimalNetNormalForce);
 }
 
 Eigen::Vector3d Robot::zmp(const std::vector<std::string> & sensorNames,
@@ -843,6 +860,15 @@ Eigen::Vector3d Robot::zmp(const std::vector<std::string> & sensorNames,
   return zmp(netWrench(sensorNames), plane_p, plane_n, minimalNetNormalForce);
 }
 
+bool Robot::zmp(Eigen::Vector3d & zmpOut,
+                const std::vector<std::string> & sensorNames,
+                const Eigen::Vector3d & plane_p,
+                const Eigen::Vector3d & plane_n,
+                double minimalNetNormalForce) const noexcept
+{
+  return zmp(zmpOut, netWrench(sensorNames), plane_p, plane_n, minimalNetNormalForce);
+}
+
 Eigen::Vector3d Robot::zmp(const std::vector<std::string> & sensorNames,
                            const sva::PTransformd & zmpFrame,
                            double minimalNetNormalForce) const
@@ -850,6 +876,16 @@ Eigen::Vector3d Robot::zmp(const std::vector<std::string> & sensorNames,
   Eigen::Vector3d n = zmpFrame.rotation().row(2);
   Eigen::Vector3d p = zmpFrame.translation();
   return zmp(sensorNames, p, n, minimalNetNormalForce);
+}
+
+bool Robot::zmp(Eigen::Vector3d & zmpOut,
+                const std::vector<std::string> & sensorNames,
+                const sva::PTransformd & zmpFrame,
+                double minimalNetNormalForce) const noexcept
+{
+  Eigen::Vector3d n = zmpFrame.rotation().row(2);
+  Eigen::Vector3d p = zmpFrame.translation();
+  return zmp(zmpOut, sensorNames, p, n, minimalNetNormalForce);
 }
 
 const std::vector<std::vector<double>> & Robot::ql() const

--- a/src/mc_rbdyn/ZMP.cpp
+++ b/src/mc_rbdyn/ZMP.cpp
@@ -5,6 +5,27 @@
 namespace mc_rbdyn
 {
 
+bool zmp(Eigen::Vector3d & zmpOut,
+         const sva::ForceVecd & netTotalWrench,
+         const Eigen::Vector3d & plane_p,
+         const Eigen::Vector3d & plane_n,
+         double minimalNetNormalForce) noexcept
+{
+  assert(minimalNetNormalForce > 0);
+  const Eigen::Vector3d & force = netTotalWrench.force();
+  const Eigen::Vector3d & moment_0 = netTotalWrench.couple();
+  Eigen::Vector3d moment_p = moment_0 - plane_p.cross(force);
+  double floorn_dot_force = plane_n.dot(force);
+  // Prevent potential division by zero
+  if(floorn_dot_force < minimalNetNormalForce)
+  {
+    mc_rtc::log::error("ZMP cannot be computed, projected force too small {}", floorn_dot_force);
+    return false;
+  }
+  zmpOut = plane_p + plane_n.cross(moment_p) / floorn_dot_force;
+  return true;
+}
+
 Eigen::Vector3d zmp(const sva::ForceVecd & netTotalWrench,
                     const Eigen::Vector3d & plane_p,
                     const Eigen::Vector3d & plane_n,
@@ -15,17 +36,12 @@ Eigen::Vector3d zmp(const sva::ForceVecd & netTotalWrench,
     mc_rtc::log::error_and_throw("ZMP cannot be computed: the minimalNetNormalForce must be >0 (divide by zero)");
   }
 
-  const Eigen::Vector3d & force = netTotalWrench.force();
-  const Eigen::Vector3d & moment_0 = netTotalWrench.couple();
-  Eigen::Vector3d moment_p = moment_0 - plane_p.cross(force);
-  double floorn_dot_force = plane_n.dot(force);
-  // Prevent potential division by zero
-  if(floorn_dot_force < minimalNetNormalForce)
+  Eigen::Vector3d zmpOut;
+  if(!zmp(zmpOut, netTotalWrench, plane_p, plane_n, minimalNetNormalForce))
   {
-    mc_rtc::log::error_and_throw("ZMP cannot be computed, projected force too small {}", floorn_dot_force);
+    mc_rtc::log::error_and_throw("ZMP cannot be computed");
   }
-  Eigen::Vector3d zmp = plane_p + plane_n.cross(moment_p) / floorn_dot_force;
-  return zmp;
+  return zmpOut;
 }
 
 Eigen::Vector3d zmp(const sva::ForceVecd & netWrench, const sva::PTransformd & zmpFrame, double minimalNetNormalForce)
@@ -33,6 +49,16 @@ Eigen::Vector3d zmp(const sva::ForceVecd & netWrench, const sva::PTransformd & z
   Eigen::Vector3d n = zmpFrame.rotation().row(2);
   Eigen::Vector3d p = zmpFrame.translation();
   return zmp(netWrench, p, n, minimalNetNormalForce);
+}
+
+bool zmp(Eigen::Vector3d & zmpOut,
+         const sva::ForceVecd & netWrench,
+         const sva::PTransformd & zmpFrame,
+         double minimalNetNormalForce) noexcept
+{
+  Eigen::Vector3d n = zmpFrame.rotation().row(2);
+  Eigen::Vector3d p = zmpFrame.translation();
+  return zmp(zmpOut, netWrench, p, n, minimalNetNormalForce);
 }
 
 } // namespace mc_rbdyn

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -732,12 +732,8 @@ void StabilizerTask::run()
   if(!inTheAir_)
   {
     measuredNetWrench_ = robots_.robot(robotIndex_).netWrench(contactSensors);
-    try
-    {
-      measuredZMP_ =
-          robots_.robot(robotIndex_).zmp(measuredNetWrench_, zmpFrame_, c_.safetyThresholds.MIN_NET_TOTAL_FORCE_ZMP);
-    }
-    catch(std::runtime_error & e)
+    if(!robots_.robot(robotIndex_)
+            .zmp(measuredZMP_, measuredNetWrench_, zmpFrame_, c_.safetyThresholds.MIN_NET_TOTAL_FORCE_ZMP))
     {
       mc_rtc::log::error("[{}] ZMP computation failed, keeping previous value {}", name(),
                          MC_FMT_STREAMED(measuredZMP_.transpose()));


### PR DESCRIPTION
With the introduction of stacktraces into the `mc_rtc::log::error_and_throw` it becomes very expensive to throw and catch exceptions (much more so than regular exceptions). The default ZMP computations throw on errors so this PR introduces variants that do not throw to communicate issues.

This variant is used in the StabilizerTask