### PR TITLE
Publish JointSensors on ROS

### DIFF
--- a/plugins/ROS/src/mc_rtc_ros/ros.cpp
+++ b/plugins/ROS/src/mc_rtc_ros/ros.cpp
@@ -177,9 +177,9 @@ void RobotPublisherImpl::init(const mc_rbdyn::Robot & robot, bool use_real)
   for(const auto & js : robot.jointSensors())
   {
     data.j_sensors.name.emplace_back(js.joint());
-    data.j_sensors.motor_temperature.emplace_back(0);
-    data.j_sensors.driver_temperature.emplace_back(0);
-    data.j_sensors.motor_current.emplace_back(0);
+    data.j_sensors.motor_temperature.emplace_back(std::numeric_limits<double>::quiet_NaN());
+    data.j_sensors.driver_temperature.emplace_back(std::numeric_limits<double>::quiet_NaN());
+    data.j_sensors.motor_current.emplace_back(std::numeric_limits<double>::quiet_NaN());
   }
 
   data.odom.header.frame_id = "robot_map";


### PR DESCRIPTION
This PR (along with https://github.com/rohanpsingh/mc_rtc_msgs/commit/ee76a5b882ceb0c346d0a23183a10e0c816f1cc6) will create a new ROS topic to publish `JointSensor` readings. I think it is useful to publish the `JointSensor` info over ROS (beside having them in the logs) to possibly trigger beeps/alarms or other safety mechanisms.

It's a draft currently because I'm unable to figure how to publish the topic name under `/mc_rtc` namespace, instead of `/real` and `/control` prefixes. 

Currently, I assume `mc_rtc_msgs/JointSensors` to have the following structure:
```
std_msgs/Header header
  uint32 seq
  time stamp
  string frame_id
string[] name
float64[] motor_temperature
float64[] driver_temperature
float64[] motor_current
```
But a possible variation could be to have two structures, with `mc_rtc_msgs/JointSensor` as:
```
time stamp
string name
float64 motor_temperature
float64 driver_temperature
float64 motor_current
```
and `mc_rtc_msgs/JointSensors` as:
```
mc_rtc_msgs/JointSensor[] joint_sensors
```

I'm not sure which way is better so I kept it similar to `sensor_msgs/JointState`.