### PR TITLE
LIPMstabilizer : Correct the derivator gain and add dimensional gain on DCM feedback

### DIFF
--- a/include/mc_filter/LowPassCompose.h
+++ b/include/mc_filter/LowPassCompose.h
@@ -1,0 +1,144 @@
+#pragma once
+
+#include <mc_rtc/logging.h>
+#include <algorithm>
+
+namespace mc_filter
+{
+
+/**Compose filter of Low-pass and High-pass filter from two series of measurements.
+ *
+ * Expects T to have:
+ * - T::Zero() static method (e.g Eigen::Vector3d, etc)
+ */
+template<typename T>
+struct LowPassCompose
+{
+  /** Constructor with cutoff period.
+   *
+   * \param dt Sampling period.
+   *
+   * \param period Cutoff period.
+   *
+   */
+  LowPassCompose(double dt, double period = 0)
+  {
+    cutoffPeriod(period);
+    dt_ = dt;
+    reset(T::Zero());
+  }
+
+  /** Get cutoff period of the high pass filter. */
+  double cutoffPeriod() const
+  {
+    return cutoffPeriod_;
+  }
+
+  /** Set cutoff period.
+   *
+   * \param period New cutoff period.
+   *
+   * \note period is explicitely enforced to respect the Nyquist–Shannon sampling theorem, that is T is at least
+   * 2*timestep.
+   */
+  void cutoffPeriod(double period)
+  {
+    if(period < 2 * dt_)
+    {
+      mc_rtc::log::warning("Time constant must be at least twice the timestep (Nyquist–Shannon sampling theorem)");
+      period = 2 * dt_;
+    }
+    cutoffPeriod_ = period;
+  }
+
+  /** Reset position to an initial rest value.
+   *
+   * \param pos New position.
+   *
+   */
+  void reset(const T & value)
+  {
+    eval_ = value;
+    eval_hp_ = eval_;
+    eval_lp_ = eval_;
+  }
+
+  /** Update estimate from new two sources
+   *
+   * \param newValue_hp New observed value filtered throught high pass.
+   *
+   * \param newValue_lp New observed value filtered throught low pass.
+   *
+   */
+  void update(const T & newValue_hp, const T & newValue_lp)
+  {
+    double x = (cutoffPeriod_ <= dt_) ? 1. : dt_ / cutoffPeriod_;
+
+    // Update the low pass filter
+    eval_lp_ = x * newValue_lp + (1. - x) * eval_lp_;
+
+    // Update the high pass filter output
+    T eval_hp = (newValue_hp - eval_hp_);
+
+    // Summation of both components
+    eval_ = eval_hp + eval_lp_;
+
+    // Update high pass filter state
+    eval_hp_ = (x * newValue_hp + (1. - x) * eval_hp_);
+
+    // Use for logs
+    value_hp_ = newValue_hp;
+    value_lp_ = newValue_lp;
+  }
+
+  /** Get filtered velocity.
+   *
+   */
+  const T & eval() const
+  {
+    return eval_;
+  }
+
+  const T & input_lp() const
+  {
+    return value_lp_;
+  }
+  const T & input_hp() const
+  {
+    return value_hp_;
+  }
+
+  /** Get sampling period.
+   *
+   */
+  double dt() const
+  {
+    return dt_;
+  }
+
+  /** Set sampling period.
+   *
+   * \param dt Sampling period.
+   *
+   * \note the cutoff period is updated to satisfy the Nyquist–Shannon sampling theorem according the new sampling
+   * period.
+   */
+  void dt(double dt)
+  {
+    dt_ = dt;
+    cutoffPeriod(cutoffPeriod_);
+  }
+
+private:
+  T eval_;
+  T eval_lp_;
+  T eval_hp_;
+  T value_hp_;
+  T value_lp_;
+  double cutoffPeriod_ = 0.;
+
+protected:
+  double dt_ = 0.005; // [s]
+};
+
+} // namespace mc_filter

--- a/include/mc_filter/utils/clamp.h
+++ b/include/mc_filter/utils/clamp.h
@@ -168,6 +168,21 @@ inline void clampInPlace(VectorT & v, double lower, double upper)
  * \see clampInPlace(VectorT& v, const VectorT & lower, const VectorT & upper)
  */
 template<typename VectorT>
+inline void clampInPlaceAndWarn(VectorT & vector, double lower, double upper, const std::string & label)
+{
+  for(unsigned i = 0; i < vector.size(); i++)
+  {
+    clampInPlaceAndWarn(vector(i), lower, upper, label + " (" + std::to_string(i) + ")");
+  }
+}
+
+/**
+ * @brief Clamps in-place each component of a vector in a given interval,
+ * issuing a warning when bounds are hit
+ *
+ * \see clampInPlace(VectorT& v, const VectorT & lower, const VectorT & upper)
+ */
+template<typename VectorT>
 inline void clampInPlaceAndWarn(VectorT & vector,
                                 const VectorT & lower,
                                 const VectorT & upper,

--- a/include/mc_rbdyn/Gains.h
+++ b/include/mc_rbdyn/Gains.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <Eigen/Core>
+
+namespace mc_rbdyn
+{
+
+/** Wrapper around fixed-sized Eigen vectors that are used for gains in the framework
+ *
+ * Their purpose is to allow code such as:
+ * ```cpp
+ * my_task.gain = 3.0;
+ * ```
+ * Where `my_task.gain` is a fixed vector of size 2, to mean the same as:
+ * ```cpp
+ * my_task.gain = Eigen::Vector2d::Constant(3.0);
+ * ```
+ */
+template<int N>
+struct Gains : public Eigen::Matrix<double, N, 1>
+{
+  static_assert(N > 0, "This is only usable for fixed-size gains");
+
+  using Eigen::Matrix<double, N, 1>::Matrix;
+
+  Gains(double value)
+  {
+    this->setConstant(value);
+  }
+};
+
+using Gains2d = Gains<2>;
+using Gains3d = Gains<3>;
+using Gains6d = Gains<6>;
+
+} // namespace mc_rbdyn

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -377,9 +377,9 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   double dfzAdmittance = 1e-4; /**< Admittance for foot force difference control */
   double dfzDamping = 0.; /**< Damping term in foot force difference control */
 
-  double dcmPropGain = 1.; /**< Proportional gain on DCM error */
-  double dcmIntegralGain = 5.; /**< Integral gain on DCM error */
-  double dcmDerivGain = 0.; /**< Derivative gain on DCM error */
+  Eigen::Vector2d dcmPropGain = {1., 1.}; /**< Proportional gain on DCM error */
+  Eigen::Vector2d dcmIntegralGain = {5., 5.}; /**< Integral gain on DCM error */
+  Eigen::Vector2d dcmDerivGain = {0., 0.}; /**< Derivative gain on DCM error */
   double comdErrorGain = 1.; /**< Gain on CoMd error */
   double zmpdGain = 0.; /**< Gain on ZMPd */
   double dcmIntegratorTimeConstant =
@@ -431,9 +431,13 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     const auto & s = safetyThresholds;
     clampInPlaceAndWarn(copAdmittance.x(), 0., s.MAX_COP_ADMITTANCE, "CoP x-admittance");
     clampInPlaceAndWarn(copAdmittance.y(), 0., s.MAX_COP_ADMITTANCE, "CoP y-admittance");
-    clampInPlaceAndWarn(dcmDerivGain, 0., s.MAX_DCM_D_GAIN, "DCM deriv gain");
-    clampInPlaceAndWarn(dcmIntegralGain, 0., s.MAX_DCM_I_GAIN, "DCM integral gain");
-    clampInPlaceAndWarn(dcmPropGain, 0., s.MAX_DCM_P_GAIN, "DCM prop gain");
+    Eigen::Vector2d zero = Eigen::Vector2d::Zero();
+    Eigen::Vector2d max = s.MAX_DCM_D_GAIN * Eigen::Vector2d::Ones();
+    clampInPlaceAndWarn(dcmDerivGain, zero, max, "DCM deriv gain");
+    max = (s.MAX_DCM_I_GAIN * Eigen::Vector2d::Ones());
+    clampInPlaceAndWarn(dcmIntegralGain, zero, max, "DCM integral gain");
+    max = (s.MAX_DCM_P_GAIN * Eigen::Vector2d::Ones());
+    clampInPlaceAndWarn(dcmPropGain, zero, max, "DCM prop gain");
     clampInPlaceAndWarn(comdErrorGain, 0., s.MAX_COMD_GAIN, "CoMd gain");
     clampInPlaceAndWarn(zmpdGain, 0., s.MAX_ZMPD_GAIN, "ZMPd gain");
     clampInPlaceAndWarn(dfzAdmittance, 0., s.MAX_DFZ_ADMITTANCE, "DFz admittance");

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -384,8 +384,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   double zmpdGain = 0.; /**< Gain on ZMPd */
   double dcmIntegratorTimeConstant =
       15.; /**< Time window for exponential moving average filter of the DCM integrator */
-  double dcmDerivatorTimeConstant = 1.; /**< DEPRECATED, Use dcmDerivatorCutOffPeriod instead */
-  double dcmDerivatorCutOffPeriod = 1.; /**< Cutoff Period of the DCM derivator filter */
+  double dcmDerivatorTimeConstant = 1.; /**< Cutoff Period of the DCM derivator filter */
 
   std::vector<std::string> comActiveJoints; /**< Joints used by CoM IK task */
   Eigen::Vector3d comStiffness = {1000., 1000., 100.}; /**< Stiffness of CoM IK task */
@@ -483,7 +482,12 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
         dcmTracking("gains")("comdError", comdErrorGain);
         dcmTracking("gains")("zmpd", zmpdGain);
       }
-      dcmTracking("derivator_cutoff_period", dcmDerivatorCutOffPeriod);
+      if(dcmTracking.has("derivator_time_constant"))
+      {
+        mc_rtc::log::warning("derivator_time_constant is deprecated, use derivator_cutoff_period instead");
+        dcmTracking("derivator_time_constant", dcmDerivatorTimeConstant);
+      }
+      dcmTracking("derivator_cutoff_period", dcmDerivatorTimeConstant);
       dcmTracking("integrator_time_constant", dcmIntegratorTimeConstant);
     }
     if(config.has("dcm_bias"))
@@ -597,7 +601,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     conf("dcm_tracking")("gains").add("deriv", dcmDerivGain);
     conf("dcm_tracking")("gains").add("comdError", comdErrorGain);
     conf("dcm_tracking")("gains").add("zmpd", zmpdGain);
-    conf("dcm_tracking").add("derivator_cutoff_period", dcmDerivatorCutOffPeriod);
+    conf("dcm_tracking").add("derivator_cutoff_period", dcmDerivatorTimeConstant);
     conf("dcm_tracking").add("integrator_time_constant", dcmIntegratorTimeConstant);
 
     conf.add("dcm_bias", dcmBias);

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -384,7 +384,8 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   double zmpdGain = 0.; /**< Gain on ZMPd */
   double dcmIntegratorTimeConstant =
       15.; /**< Time window for exponential moving average filter of the DCM integrator */
-  double dcmDerivatorTimeConstant = 1.; /**< Time window for the stationary offset filter of the DCM derivator */
+  double dcmDerivatorTimeConstant = 1.; /**< DEPRECATED, Use dcmDerivatorCutOffPeriod instead */
+  double dcmDerivatorCutOffPeriod = 1.; /**< Cutoff Period of the DCM derivator filter */
 
   std::vector<std::string> comActiveJoints; /**< Joints used by CoM IK task */
   Eigen::Vector3d comStiffness = {1000., 1000., 100.}; /**< Stiffness of CoM IK task */
@@ -478,7 +479,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
         dcmTracking("gains")("comdError", comdErrorGain);
         dcmTracking("gains")("zmpd", zmpdGain);
       }
-      dcmTracking("derivator_time_constant", dcmDerivatorTimeConstant);
+      dcmTracking("derivator_cutoff_period", dcmDerivatorCutOffPeriod);
       dcmTracking("integrator_time_constant", dcmIntegratorTimeConstant);
     }
     if(config.has("dcm_bias"))
@@ -592,7 +593,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     conf("dcm_tracking")("gains").add("deriv", dcmDerivGain);
     conf("dcm_tracking")("gains").add("comdError", comdErrorGain);
     conf("dcm_tracking")("gains").add("zmpd", zmpdGain);
-    conf("dcm_tracking").add("derivator_time_constant", dcmDerivatorTimeConstant);
+    conf("dcm_tracking").add("derivator_cutoff_period", dcmDerivatorCutOffPeriod);
     conf("dcm_tracking").add("integrator_time_constant", dcmIntegratorTimeConstant);
 
     conf.add("dcm_bias", dcmBias);

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -3,9 +3,13 @@
  */
 
 #pragma once
-#include <mc_filter/utils/clamp.h>
+
+#include <mc_rbdyn/Gains.h>
 #include <mc_rbdyn/api.h>
 #include <mc_rbdyn/lipm_stabilizer/ZMPCCConfiguration.h>
+
+#include <mc_filter/utils/clamp.h>
+
 #include <mc_rtc/Configuration.h>
 #include <mc_rtc/logging.h>
 
@@ -377,9 +381,9 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   double dfzAdmittance = 1e-4; /**< Admittance for foot force difference control */
   double dfzDamping = 0.; /**< Damping term in foot force difference control */
 
-  Eigen::Vector2d dcmPropGain = {1., 1.}; /**< Proportional gain on DCM error */
-  Eigen::Vector2d dcmIntegralGain = {5., 5.}; /**< Integral gain on DCM error */
-  Eigen::Vector2d dcmDerivGain = {0., 0.}; /**< Derivative gain on DCM error */
+  mc_rbdyn::Gains2d dcmPropGain = 1.; /**< Proportional gain on DCM error */
+  mc_rbdyn::Gains2d dcmIntegralGain = 5.; /**< Integral gain on DCM error */
+  mc_rbdyn::Gains2d dcmDerivGain = 0.; /**< Derivative gain on DCM error */
   double comdErrorGain = 1.; /**< Gain on CoMd error */
   double zmpdGain = 0.; /**< Gain on ZMPd */
   double dcmIntegratorTimeConstant =
@@ -430,13 +434,9 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     const auto & s = safetyThresholds;
     clampInPlaceAndWarn(copAdmittance.x(), 0., s.MAX_COP_ADMITTANCE, "CoP x-admittance");
     clampInPlaceAndWarn(copAdmittance.y(), 0., s.MAX_COP_ADMITTANCE, "CoP y-admittance");
-    Eigen::Vector2d zero = Eigen::Vector2d::Zero();
-    Eigen::Vector2d max = s.MAX_DCM_D_GAIN * Eigen::Vector2d::Ones();
-    clampInPlaceAndWarn(dcmDerivGain, zero, max, "DCM deriv gain");
-    max = (s.MAX_DCM_I_GAIN * Eigen::Vector2d::Ones());
-    clampInPlaceAndWarn(dcmIntegralGain, zero, max, "DCM integral gain");
-    max = (s.MAX_DCM_P_GAIN * Eigen::Vector2d::Ones());
-    clampInPlaceAndWarn(dcmPropGain, zero, max, "DCM prop gain");
+    clampInPlaceAndWarn(dcmDerivGain, 0., s.MAX_DCM_D_GAIN, "DCM deriv gain");
+    clampInPlaceAndWarn(dcmIntegralGain, 0., s.MAX_DCM_I_GAIN, "DCM integral gain");
+    clampInPlaceAndWarn(dcmPropGain, 0., s.MAX_DCM_P_GAIN, "DCM prop gain");
     clampInPlaceAndWarn(comdErrorGain, 0., s.MAX_COMD_GAIN, "CoMd gain");
     clampInPlaceAndWarn(zmpdGain, 0., s.MAX_ZMPD_GAIN, "ZMPd gain");
     clampInPlaceAndWarn(dfzAdmittance, 0., s.MAX_DFZ_ADMITTANCE, "DFz admittance");

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -6,17 +6,21 @@
 
 #include <mc_rtc/MessagePackBuilder.h>
 
+#include <mc/rtc/deprecated.hh>
+
+#include <mc_rbdyn/Gains.h>
+#include <mc_rbdyn/rpy_utils.h>
+
 #include <SpaceVecAlg/SpaceVecAlg>
 
-#include <mc_rbdyn/rpy_utils.h>
 #include <Eigen/Core>
+#include <spdlog/fmt/fmt.h>
+
 #include <array>
 #include <exception>
 #include <map>
-#include <mc/rtc/deprecated.hh>
 #include <memory>
 #include <set>
-#include <spdlog/fmt/fmt.h>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -284,6 +288,24 @@ public:
    * sequence of size 6
    */
   operator Eigen::Vector6d() const;
+
+  /*! \brief Retrieve as a mc_rbdyn::Gains2d instance
+   *
+   * \throws If the underlying value is not a single double or a numeric sequence of size 2
+   */
+  operator mc_rbdyn::Gains2d() const;
+
+  /*! \brief Retrieve as a mc_rbdyn::Gains3d instance
+   *
+   * \throws If the underlying value is not a single double or a numeric sequence of size 3
+   */
+  operator mc_rbdyn::Gains3d() const;
+
+  /*! \brief Retrieve as a mc_rbdyn::Gains6d instance
+   *
+   * \throws If the underlying value is not a single double or a numeric sequence of size 6
+   */
+  operator mc_rbdyn::Gains6d() const;
 
   /*! \brief Retrieve as a Eigen::VectorXd instance
    *

--- a/include/mc_rtc/MessagePackBuilder.h
+++ b/include/mc_rtc/MessagePackBuilder.h
@@ -2,6 +2,8 @@
 
 #include <mc_rtc/utils_api.h>
 
+#include <mc_rbdyn/Gains.h>
+
 #include <SpaceVecAlg/SpaceVecAlg>
 
 #include <Eigen/Core>

--- a/include/mc_rtc/log/utils.h
+++ b/include/mc_rtc/log/utils.h
@@ -85,6 +85,9 @@ IMPL_MAPPING(sva::PTransformd, PTransformd);
 IMPL_MAPPING(sva::ForceVecd, ForceVecd);
 IMPL_MAPPING(sva::MotionVecd, MotionVecd);
 IMPL_MAPPING(sva::ImpedanceVecd, MotionVecd);
+IMPL_MAPPING(mc_rbdyn::Gains2d, Vector2d);
+IMPL_MAPPING(mc_rbdyn::Gains3d, Vector3d);
+IMPL_MAPPING(mc_rbdyn::Gains6d, Vector6d);
 
 #undef IMPL_MAPPING
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -416,15 +416,16 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     pelvisTask->stiffness(stiffness);
   }
 
-  inline void dcmGains(Eigen::Vector2d p, Eigen::Vector2d i, Eigen::Vector2d d) noexcept
+  inline void dcmGains(double p, double i, double d) noexcept
   {
-    Eigen::Vector2d zero = Eigen::Vector2d::Zero();
-    Eigen::Vector2d max = c_.safetyThresholds.MAX_DCM_P_GAIN * Eigen::Vector2d::Ones();
-    c_.dcmPropGain = clamp(p, zero, max);
-    max = c_.safetyThresholds.MAX_DCM_I_GAIN * Eigen::Vector2d::Ones();
-    c_.dcmIntegralGain = clamp(i, zero, max);
-    max = c_.safetyThresholds.MAX_DCM_D_GAIN * Eigen::Vector2d::Ones();
-    c_.dcmDerivGain = clamp(d, zero, max);
+    dcmGains(Eigen::Vector2d::Constant(p), Eigen::Vector2d::Constant(i), Eigen::Vector2d::Constant(d));
+  }
+
+  inline void dcmGains(const Eigen::Vector2d & p, const Eigen::Vector2d & i, const Eigen::Vector2d & d) noexcept
+  {
+    c_.dcmPropGain = clamp(p, 0., c_.safetyThresholds.MAX_DCM_P_GAIN);
+    c_.dcmIntegralGain = clamp(i, 0., c_.safetyThresholds.MAX_DCM_I_GAIN);
+    c_.dcmDerivGain = clamp(d, 0., c_.safetyThresholds.MAX_DCM_D_GAIN);
   }
 
   inline void dcmIntegratorTimeConstant(double dcmIntegratorTimeConstant) noexcept

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -648,8 +648,10 @@ private:
    * \param com Position of the center of mass.
    *
    * \param comd Velocity of the center of mass.
+   *
+   * \param comdd Acceleration of the center of mass.
    */
-  void updateState(const Eigen::Vector3d & com, const Eigen::Vector3d & comd);
+  void updateState(const Eigen::Vector3d & com, const Eigen::Vector3d & comd, const Eigen::Vector3d & comdd);
 
   /**
    * @brief Update contact tasks in the solver
@@ -860,6 +862,7 @@ protected:
   Eigen::Vector3d dcmVelError_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d measuredCoM_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d measuredCoMd_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d measuredCoMdd_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d measuredZMP_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d measuredDCM_ = Eigen::Vector3d::Zero(); /// Measured DCM (only used for logging)
   Eigen::Vector3d measuredDCMUnbiased_ = Eigen::Vector3d::Zero(); /// DCM unbiased (only used for logging)

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -20,6 +20,8 @@
 #include <mc_tasks/lipm_stabilizer/Contact.h>
 #include <mc_tasks/lipm_stabilizer/ZMPCC.h>
 
+#include <mc/rtc/deprecated.hh>
+
 #include <state-observation/dynamics-estimators/lipm-dcm-estimator.hpp>
 
 #include <Eigen/QR>
@@ -431,9 +433,14 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     dcmIntegrator_.timeConstant(dcmIntegratorTimeConstant);
   }
 
+  MC_RTC_DEPRECATED inline void dcmDerivatorTimeConstant(double T) noexcept
+  {
+    dcmDerivatorCutoffPeriod(T);
+  }
+
   inline void dcmDerivatorCutoffPeriod(double T) noexcept
   {
-    c_.dcmDerivatorCutOffPeriod = T;
+    c_.dcmDerivatorTimeConstant = T;
     dcmDerivator_.cutoffPeriod(T);
   }
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -10,13 +10,13 @@
 #include <mc_filter/ExponentialMovingAverage.h>
 #include <mc_filter/LeakyIntegrator.h>
 #include <mc_filter/LowPass.h>
+#include <mc_filter/LowPassCompose.h>
 #include <mc_filter/StationaryOffset.h>
+#include <mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h>
 #include <mc_tasks/CoMTask.h>
 #include <mc_tasks/CoPTask.h>
 #include <mc_tasks/MetaTask.h>
 #include <mc_tasks/OrientationTask.h>
-
-#include <mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h>
 #include <mc_tasks/lipm_stabilizer/Contact.h>
 #include <mc_tasks/lipm_stabilizer/ZMPCC.h>
 
@@ -427,10 +427,10 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     dcmIntegrator_.timeConstant(dcmIntegratorTimeConstant);
   }
 
-  inline void dcmDerivatorTimeConstant(double dcmDerivatorTimeConstant) noexcept
+  inline void dcmDerivatorCutoffPeriod(double T) noexcept
   {
-    c_.dcmDerivatorTimeConstant = dcmDerivatorTimeConstant;
-    dcmDerivator_.timeConstant(dcmDerivatorTimeConstant);
+    c_.dcmDerivatorCutOffPeriod = T;
+    dcmDerivator_.cutoffPeriod(T);
   }
 
   inline void extWrenchSumLowPassCutoffPeriod(double cutoffPeriod) noexcept
@@ -900,7 +900,7 @@ protected:
   /** @} */
 
   mc_filter::ExponentialMovingAverage<Eigen::Vector3d> dcmIntegrator_;
-  mc_filter::StationaryOffset<Eigen::Vector3d> dcmDerivator_;
+  mc_filter::LowPassCompose<Eigen::Vector3d> dcmDerivator_;
   bool inTheAir_ = false; /**< Is the robot in the air? */
   double dfzForceError_ = 0.; /**< Force error in foot force difference control */
   double dfzHeightError_ = 0.; /**< Height error in foot force difference control */

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -414,11 +414,15 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     pelvisTask->stiffness(stiffness);
   }
 
-  inline void dcmGains(double p, double i, double d) noexcept
+  inline void dcmGains(Eigen::Vector2d p, Eigen::Vector2d i, Eigen::Vector2d d) noexcept
   {
-    c_.dcmPropGain = clamp(p, 0., c_.safetyThresholds.MAX_DCM_P_GAIN);
-    c_.dcmIntegralGain = clamp(i, 0., c_.safetyThresholds.MAX_DCM_I_GAIN);
-    c_.dcmDerivGain = clamp(d, 0., c_.safetyThresholds.MAX_DCM_D_GAIN);
+    Eigen::Vector2d zero = Eigen::Vector2d::Zero();
+    Eigen::Vector2d max = c_.safetyThresholds.MAX_DCM_P_GAIN * Eigen::Vector2d::Ones();
+    c_.dcmPropGain = clamp(p, zero, max);
+    max = c_.safetyThresholds.MAX_DCM_I_GAIN * Eigen::Vector2d::Ones();
+    c_.dcmIntegralGain = clamp(i, zero, max);
+    max = c_.safetyThresholds.MAX_DCM_D_GAIN * Eigen::Vector2d::Ones();
+    c_.dcmDerivGain = clamp(d, zero, max);
   }
 
   inline void dcmIntegratorTimeConstant(double dcmIntegratorTimeConstant) noexcept

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -298,6 +298,8 @@ Robot::Robot(NewRobotToken,
     }
     mbc().q = initQ;
     forwardKinematics();
+    forwardVelocity();
+    forwardAcceleration();
   }
 
   bodyTransforms_.resize(mb().bodies().size());

--- a/src/mc_robots/jvrc1.cpp
+++ b/src/mc_robots/jvrc1.cpp
@@ -88,9 +88,9 @@ JVRC1RobotModule::JVRC1RobotModule(bool fixed) : RobotModule(std::string(JVRC_VA
                                            "L_KNEE",    "L_ANKLE_P", "L_ANKLE_R"};
   _lipmStabilizerConfig.torsoPitch = 0;
   _lipmStabilizerConfig.copAdmittance = Eigen::Vector2d{0.01, 0.01};
-  _lipmStabilizerConfig.dcmPropGain = 5.0 * Eigen::Vector2d::Ones();
-  _lipmStabilizerConfig.dcmIntegralGain = 10 * Eigen::Vector2d::Ones();
-  _lipmStabilizerConfig.dcmDerivGain = 0.5 * Eigen::Vector2d::Ones();
+  _lipmStabilizerConfig.dcmPropGain = 5.0;
+  _lipmStabilizerConfig.dcmIntegralGain = 10;
+  _lipmStabilizerConfig.dcmDerivGain = 0.5;
   _lipmStabilizerConfig.dcmDerivatorTimeConstant = 1;
   _lipmStabilizerConfig.dcmIntegratorTimeConstant = 10;
 }

--- a/src/mc_robots/jvrc1.cpp
+++ b/src/mc_robots/jvrc1.cpp
@@ -88,9 +88,9 @@ JVRC1RobotModule::JVRC1RobotModule(bool fixed) : RobotModule(std::string(JVRC_VA
                                            "L_KNEE",    "L_ANKLE_P", "L_ANKLE_R"};
   _lipmStabilizerConfig.torsoPitch = 0;
   _lipmStabilizerConfig.copAdmittance = Eigen::Vector2d{0.01, 0.01};
-  _lipmStabilizerConfig.dcmPropGain = 5.0;
-  _lipmStabilizerConfig.dcmIntegralGain = 10;
-  _lipmStabilizerConfig.dcmDerivGain = 0.5;
+  _lipmStabilizerConfig.dcmPropGain = 5.0 * Eigen::Vector2d::Ones();
+  _lipmStabilizerConfig.dcmIntegralGain = 10 * Eigen::Vector2d::Ones();
+  _lipmStabilizerConfig.dcmDerivGain = 0.5 * Eigen::Vector2d::Ones();
   _lipmStabilizerConfig.dcmDerivatorTimeConstant = 1;
   _lipmStabilizerConfig.dcmIntegratorTimeConstant = 10;
 }

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -350,6 +350,39 @@ Configuration::operator Eigen::Vector6d() const
   throw Exception("Stored Json value is not a Vector6d", v);
 }
 
+Configuration::operator mc_rbdyn::Gains2d() const
+{
+  assert(v.value_);
+  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  if(value->IsNumber())
+  {
+    return value->GetDouble();
+  }
+  return this->operator Eigen::Vector2d();
+}
+
+Configuration::operator mc_rbdyn::Gains3d() const
+{
+  assert(v.value_);
+  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  if(value->IsNumber())
+  {
+    return value->GetDouble();
+  }
+  return this->operator Eigen::Vector3d();
+}
+
+Configuration::operator mc_rbdyn::Gains6d() const
+{
+  assert(v.value_);
+  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  if(value->IsNumber())
+  {
+    return value->GetDouble();
+  }
+  return this->operator Eigen::Vector6d();
+}
+
 Configuration::operator Eigen::VectorXd() const
 {
   if(v.isArray() && (v.size() == 0 || v[0].isNumeric()))

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -297,9 +297,9 @@ void StabilizerTask::disable()
   disableConfig_ = c_;
   // Set the stabilizer gains to zero
   disableConfig_.copAdmittance.setZero();
-  disableConfig_.dcmDerivGain = Eigen::Vector2d::Zero();
-  disableConfig_.dcmIntegralGain = Eigen::Vector2d::Zero();
-  disableConfig_.dcmPropGain = Eigen::Vector2d::Zero();
+  disableConfig_.dcmDerivGain = 0.;
+  disableConfig_.dcmIntegralGain = 0.;
+  disableConfig_.dcmPropGain = 0.;
   disableConfig_.comdErrorGain = 0.;
   disableConfig_.zmpdGain = 0.;
   disableConfig_.dfzAdmittance = 0.;

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -333,7 +333,7 @@ void StabilizerTask::commitConfig()
 
 void StabilizerTask::configure_(mc_solver::QPSolver & solver)
 {
-  dcmDerivator_.cutoffPeriod(c_.dcmDerivatorCutOffPeriod);
+  dcmDerivator_.cutoffPeriod(c_.dcmDerivatorTimeConstant);
   dcmIntegrator_.timeConstant(c_.dcmIntegratorTimeConstant);
   dcmIntegrator_.saturation(c_.safetyThresholds.MAX_AVERAGE_DCM_ERROR);
 

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -872,8 +872,7 @@ sva::ForceVecd StabilizerTask::computeDesiredWrench()
   }
   dcmAverageError_ = dcmIntegrator_.eval();
   dcmVelError_ = dcmDerivator_.eval();
-  sva::PTransformd X_0_floatingbase = robot().mbc().bodyPosW[robot().bodyIndexByName("BODY")];
-  Eigen::Matrix3d R_0_fb_yaw = sva::RotZ(mc_rbdyn::rpyFromMat(X_0_floatingbase.rotation()).z());
+  Eigen::Matrix3d R_0_fb_yaw = sva::RotZ(mc_rbdyn::rpyFromMat(robot().posW().rotation()).z());
   Eigen::Vector3d desiredCoMAccel = comddTarget_;
 
   Eigen::Vector3d gain = Eigen::Vector3d{c_.dcmPropGain.x(), c_.dcmPropGain.y(), 0};

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -70,11 +70,11 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
       ArrayInput(
           "DCM filters", {"Integrator T [s]", "Derivator T [s]"},
           [this]() -> Eigen::Vector2d {
-            return {dcmIntegrator_.timeConstant(), dcmDerivator_.timeConstant()};
+            return {dcmIntegrator_.timeConstant(), dcmDerivator_.cutoffPeriod()};
           },
           [this](const Eigen::Vector2d & T) {
             dcmIntegratorTimeConstant(T(0));
-            dcmDerivatorTimeConstant(T(1));
+            dcmDerivatorCutoffPeriod(T(1));
           }));
   gui.addElement({"Tasks", name_, "Advanced"}, Button("Disable", [this]() { disable(); }));
   addConfigButtons({"Tasks", name_, "Advanced"});
@@ -393,7 +393,9 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   logger.addLogEntry(name_ + "_admittance_cop", this, [this]() -> const Eigen::Vector2d & { return c_.copAdmittance; });
   logger.addLogEntry(name_ + "_admittance_dfz", this, [this]() { return c_.dfzAdmittance; });
   logger.addLogEntry(name_ + "_dcmDerivator_filtered", this, [this]() { return dcmDerivator_.eval(); });
-  logger.addLogEntry(name_ + "_dcmDerivator_timeConstant", this, [this]() { return dcmDerivator_.timeConstant(); });
+  logger.addLogEntry(name_ + "_dcmDerivator_input_lp", this, [this]() { return dcmDerivator_.input_lp(); });
+  logger.addLogEntry(name_ + "_dcmDerivator_input_hp", this, [this]() { return dcmDerivator_.input_hp(); });
+  logger.addLogEntry(name_ + "_dcmDerivator_cutoffPeriod", this, [this]() { return dcmDerivator_.cutoffPeriod(); });
   logger.addLogEntry(name_ + "_dcmIntegrator_timeConstant", this, [this]() { return dcmIntegrator_.timeConstant(); });
   logger.addLogEntry(name_ + "_dcmTracking_derivGain", this, [this]() { return c_.dcmDerivGain; });
   logger.addLogEntry(name_ + "_dcmTracking_integralGain", this, [this]() { return c_.dcmIntegralGain; });

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -58,11 +58,14 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
             dfzDamping(a(1));
           }),
       ArrayInput(
-          "DCM gains", {"Prop.", "Integral", "Deriv."},
-          [this]() -> Eigen::Vector3d {
-            return {c_.dcmPropGain, c_.dcmIntegralGain, c_.dcmDerivGain};
-          },
-          [this](const Eigen::Vector3d & gains) { dcmGains(gains(0), gains(1), gains(2)); }),
+          "DCM P gains", {"x", "y"}, [this]() -> Eigen::Vector2d { return c_.dcmPropGain; },
+          [this](const Eigen::Vector2d & gains) { dcmGains(gains, c_.dcmIntegralGain, c_.dcmDerivGain); }),
+      ArrayInput(
+          "DCM I gains", {"x", "y"}, [this]() -> Eigen::Vector2d { return c_.dcmIntegralGain; },
+          [this](const Eigen::Vector2d & gains) { dcmGains(c_.dcmPropGain, gains, c_.dcmDerivGain); }),
+      ArrayInput(
+          "DCM D gains", {"x", "y"}, [this]() -> Eigen::Vector2d { return c_.dcmDerivGain; },
+          [this](const Eigen::Vector2d & gains) { dcmGains(c_.dcmPropGain, c_.dcmIntegralGain, gains); }),
       NumberInput(
           "CoMd Error gain", [this]() { return c_.comdErrorGain; }, [this](double a) { c_.comdErrorGain = a; }),
       NumberInput(

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -58,13 +58,13 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
             dfzDamping(a(1));
           }),
       ArrayInput(
-          "DCM P gains", {"x", "y"}, [this]() -> Eigen::Vector2d { return c_.dcmPropGain; },
+          "DCM P gains", {"x", "y"}, [this]() -> const Eigen::Vector2d & { return c_.dcmPropGain; },
           [this](const Eigen::Vector2d & gains) { dcmGains(gains, c_.dcmIntegralGain, c_.dcmDerivGain); }),
       ArrayInput(
-          "DCM I gains", {"x", "y"}, [this]() -> Eigen::Vector2d { return c_.dcmIntegralGain; },
+          "DCM I gains", {"x", "y"}, [this]() -> const Eigen::Vector2d & { return c_.dcmIntegralGain; },
           [this](const Eigen::Vector2d & gains) { dcmGains(c_.dcmPropGain, gains, c_.dcmDerivGain); }),
       ArrayInput(
-          "DCM D gains", {"x", "y"}, [this]() -> Eigen::Vector2d { return c_.dcmDerivGain; },
+          "DCM D gains", {"x", "y"}, [this]() -> const Eigen::Vector2d & { return c_.dcmDerivGain; },
           [this](const Eigen::Vector2d & gains) { dcmGains(c_.dcmPropGain, c_.dcmIntegralGain, gains); }),
       NumberInput(
           "CoMd Error gain", [this]() { return c_.comdErrorGain; }, [this](double a) { c_.comdErrorGain = a; }),
@@ -400,9 +400,12 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   logger.addLogEntry(name_ + "_dcmDerivator_input_hp", this, [this]() { return dcmDerivator_.input_hp(); });
   logger.addLogEntry(name_ + "_dcmDerivator_cutoffPeriod", this, [this]() { return dcmDerivator_.cutoffPeriod(); });
   logger.addLogEntry(name_ + "_dcmIntegrator_timeConstant", this, [this]() { return dcmIntegrator_.timeConstant(); });
-  logger.addLogEntry(name_ + "_dcmTracking_derivGain", this, [this]() { return c_.dcmDerivGain; });
-  logger.addLogEntry(name_ + "_dcmTracking_integralGain", this, [this]() { return c_.dcmIntegralGain; });
-  logger.addLogEntry(name_ + "_dcmTracking_propGain", this, [this]() { return c_.dcmPropGain; });
+  logger.addLogEntry(name_ + "_dcmTracking_derivGain", this,
+                     [this]() -> const Eigen::Vector2d & { return c_.dcmDerivGain; });
+  logger.addLogEntry(name_ + "_dcmTracking_integralGain", this,
+                     [this]() -> const Eigen::Vector2d & { return c_.dcmIntegralGain; });
+  logger.addLogEntry(name_ + "_dcmTracking_propGain", this,
+                     [this]() -> const Eigen::Vector2d & { return c_.dcmPropGain; });
   logger.addLogEntry(name_ + "_dcmTracking_comdErrorGain", this, [this]() { return c_.comdErrorGain; });
   logger.addLogEntry(name_ + "_dcmTracking_zmpdGain", this, [this]() { return c_.zmpdGain; });
   logger.addLogEntry(name_ + "_dcmBias_dcmMeasureErrorStd", this, [this]() { return c_.dcmBias.dcmMeasureErrorStd; });

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -471,6 +471,7 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
                      [this]() { return realRobot().surfacePose(footSurface(ContactState::Right)); });
   MC_RTC_LOG_HELPER(name_ + "_realRobot_com", measuredCoM_);
   MC_RTC_LOG_HELPER(name_ + "_realRobot_comd", measuredCoMd_);
+  MC_RTC_LOG_HELPER(name_ + "_realRobot_comdd", measuredCoMdd_);
   MC_RTC_LOG_HELPER(name_ + "_realRobot_dcm", measuredDCM_);
   MC_RTC_LOG_HELPER(name_ + "_realRobot_dcm_unbiased", measuredDCMUnbiased_);
   MC_RTC_LOG_HELPER(name_ + "_realRobot_com_unbiased", measuredCoMUnbiased_);

--- a/tests/LoggerTraits.cpp
+++ b/tests/LoggerTraits.cpp
@@ -4,6 +4,8 @@
 
 #include <mc_rtc/log/Logger.h>
 
+#include <mc_rbdyn/Gains.h>
+
 /** This executable only test the various traits used to discriminate
  * valid logger callbacks, compilation failure would indicate an issue
  * with said traits. */
@@ -37,5 +39,6 @@ int main()
   test_traits<std::vector<unsigned int>, false>();
   test_traits<float, true>();
   test_traits<std::map<std::string, double>, false>();
+  test_traits<mc_rbdyn::Gains2d, true>();
   return 0;
 }

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -33,8 +33,10 @@ string: sometext
 intV: [0, 1, 2, 3, 4, 5]
 stringV: [a, b, c, foo, bar]
 doubleA3: [1.1, 2.2, 3.3]
+v2d: [1.0, 2.3]
 v3d: [1.0, 2.3, -100]
 v6d: [1.0, -1.5, 2.0, -2.5, 3.0, -3.5]
+g6d: [1.0, -1.5, 2.0, -2.5, 3.0, -3.5]
 vXd: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 quat: [0.71, 0, 0.71, 0]
 emptyArray: []
@@ -54,6 +56,7 @@ dict:
   string: sometext
   intV: [0, 1, 2, 3, 4, 5]
   stringV: [a, b, c, foo, bar]
+  v2d: [1.0, 2.3]
   v3d: [1.0, 2.3, -100]
   v6d: [1.0, -1.5, 2.0, -2.5, 3.0, -3.5]
   quat: [0.71, 0, 0.71, 0]
@@ -85,6 +88,7 @@ static std::string JSON_DATA = R"(
   "intV": [0, 1, 2, 3, 4, 5],
   "stringV": ["a", "b", "c", "foo", "bar"],
   "doubleA3": [1.1, 2.2, 3.3],
+  "v2d": [1.0, 2.3],
   "v3d": [1.0, 2.3, -100],
   "v6d": [1.0, -1.5, 2.0, -2.5, 3.0, -3.5],
   "vXd": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
@@ -107,6 +111,7 @@ static std::string JSON_DATA = R"(
     "string": "sometext",
     "intV": [0, 1, 2, 3, 4, 5],
     "stringV": ["a", "b", "c", "foo", "bar"],
+    "v2d": [1.0, 2.3],
     "v3d": [1.0, 2.3, -100],
     "v6d": [1.0, -1.5, 2.0, -2.5, 3.0, -3.5],
     "quat": [0.71, 0, 0.71, 0],
@@ -302,6 +307,81 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
     BOOST_CHECK_EQUAL(d, "sometext");
   }
 
+  /* Eigen::Vector2d test */
+  {
+    Eigen::Vector2d ref;
+    ref << 1.0, 2.3;
+    Eigen::Vector2d zero = Eigen::Vector2d::Zero();
+
+    Eigen::Vector2d a = config("v2d");
+    BOOST_CHECK_EQUAL(a, ref);
+
+    Eigen::Vector2d b = Eigen::Vector2d::Zero();
+    config("v2d", b);
+    BOOST_CHECK_EQUAL(b, ref);
+
+    Eigen::Vector2d c = Eigen::Vector2d::Zero();
+    config("v6d", c);
+    BOOST_CHECK_EQUAL(c, zero);
+
+    MC_RTC_diagnostic_push
+    MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
+    BOOST_CHECK_THROW(Eigen::Vector2d d = config("v6d"), mc_rtc::Configuration::Exception);
+    MC_RTC_diagnostic_pop
+
+    Eigen::Vector2d e = Eigen::Vector2d::Zero();
+    e = config("dict")("v2d");
+    BOOST_CHECK_EQUAL(e, ref);
+
+    Eigen::Vector2d f = Eigen::Vector2d::Zero();
+    config("dict")("v2d", f);
+    BOOST_CHECK_EQUAL(f, ref);
+  }
+
+  /* mc_rbdyn::Gains2d test */
+  {
+    mc_rbdyn::Gains2d ref;
+    ref << 1.0, 2.3;
+    mc_rbdyn::Gains2d zero = mc_rbdyn::Gains2d::Zero();
+
+    mc_rbdyn::Gains2d a = config("v2d");
+    BOOST_CHECK_EQUAL(a, ref);
+
+    mc_rbdyn::Gains2d b = mc_rbdyn::Gains2d::Zero();
+    config("v2d", b);
+    BOOST_CHECK_EQUAL(b, ref);
+
+    mc_rbdyn::Gains2d c = mc_rbdyn::Gains2d::Zero();
+    config("v6d", c);
+    BOOST_CHECK_EQUAL(c, zero);
+
+    MC_RTC_diagnostic_push
+    MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
+    BOOST_CHECK_THROW(mc_rbdyn::Gains2d d = config("v6d"), mc_rtc::Configuration::Exception);
+    MC_RTC_diagnostic_pop
+
+    mc_rbdyn::Gains2d e = mc_rbdyn::Gains2d::Zero();
+    e = config("dict")("v2d");
+    BOOST_CHECK_EQUAL(e, ref);
+
+    mc_rbdyn::Gains2d f = mc_rbdyn::Gains2d::Zero();
+    config("dict")("v2d", f);
+    BOOST_CHECK_EQUAL(f, ref);
+
+    ref.setConstant(42.5);
+
+    mc_rbdyn::Gains2d g = config("double");
+    BOOST_CHECK_EQUAL(g, ref);
+
+    mc_rbdyn::Gains2d h = mc_rbdyn::Gains2d::Zero();
+    config("double", h);
+    BOOST_CHECK_EQUAL(h, ref);
+
+    mc_rbdyn::Gains2d i = mc_rbdyn::Gains2d::Zero();
+    i = config("dict")("double");
+    BOOST_CHECK_EQUAL(i, ref);
+  }
+
   /* Eigen::Vector3d test */
   {
     Eigen::Vector3d ref;
@@ -333,6 +413,50 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
     BOOST_CHECK_EQUAL(f, ref);
   }
 
+  /* mc_rbdyn::Gains3d test */
+  {
+    mc_rbdyn::Gains3d ref;
+    ref << 1.0, 2.3, -100;
+    mc_rbdyn::Gains3d zero = mc_rbdyn::Gains3d::Zero();
+
+    mc_rbdyn::Gains3d a = config("v3d");
+    BOOST_CHECK_EQUAL(a, ref);
+
+    mc_rbdyn::Gains3d b = mc_rbdyn::Gains3d::Zero();
+    config("v3d", b);
+    BOOST_CHECK_EQUAL(b, ref);
+
+    mc_rbdyn::Gains3d c = mc_rbdyn::Gains3d::Zero();
+    config("v6d", c);
+    BOOST_CHECK_EQUAL(c, zero);
+
+    MC_RTC_diagnostic_push
+    MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
+    BOOST_CHECK_THROW(mc_rbdyn::Gains3d d = config("v6d"), mc_rtc::Configuration::Exception);
+    MC_RTC_diagnostic_pop
+
+    mc_rbdyn::Gains3d e = mc_rbdyn::Gains3d::Zero();
+    e = config("dict")("v3d");
+    BOOST_CHECK_EQUAL(e, ref);
+
+    mc_rbdyn::Gains3d f = mc_rbdyn::Gains3d::Zero();
+    config("dict")("v3d", f);
+    BOOST_CHECK_EQUAL(f, ref);
+
+    ref.setConstant(42.5);
+
+    mc_rbdyn::Gains3d g = config("double");
+    BOOST_CHECK_EQUAL(g, ref);
+
+    mc_rbdyn::Gains3d h = mc_rbdyn::Gains3d::Zero();
+    config("double", h);
+    BOOST_CHECK_EQUAL(h, ref);
+
+    mc_rbdyn::Gains3d i = mc_rbdyn::Gains3d::Zero();
+    i = config("dict")("double");
+    BOOST_CHECK_EQUAL(i, ref);
+  }
+
   /* Eigen::Vector6d test */
   {
     Eigen::Vector6d ref;
@@ -362,6 +486,50 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
     Eigen::Vector6d f = Eigen::Vector6d::Zero();
     config("dict")("v6d", f);
     BOOST_CHECK_EQUAL(f, ref);
+  }
+
+  /* mc_rbdyn::Gains6d test */
+  {
+    mc_rbdyn::Gains6d ref;
+    ref << 1.0, -1.5, 2.0, -2.5, 3.0, -3.5;
+    mc_rbdyn::Gains6d zero = mc_rbdyn::Gains6d::Zero();
+
+    mc_rbdyn::Gains6d a = config("v6d");
+    BOOST_CHECK_EQUAL(a, ref);
+
+    mc_rbdyn::Gains6d b = mc_rbdyn::Gains6d::Zero();
+    config("v6d", b);
+    BOOST_CHECK_EQUAL(b, ref);
+
+    mc_rbdyn::Gains6d c = mc_rbdyn::Gains6d::Zero();
+    config("v3d", c);
+    BOOST_CHECK_EQUAL(c, zero);
+
+    MC_RTC_diagnostic_push
+    MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
+    BOOST_CHECK_THROW(mc_rbdyn::Gains6d d = config("v3d"), mc_rtc::Configuration::Exception);
+    MC_RTC_diagnostic_pop
+
+    mc_rbdyn::Gains6d e = mc_rbdyn::Gains6d::Zero();
+    e = config("dict")("v6d");
+    BOOST_CHECK_EQUAL(e, ref);
+
+    mc_rbdyn::Gains6d f = mc_rbdyn::Gains6d::Zero();
+    config("dict")("v6d", f);
+    BOOST_CHECK_EQUAL(f, ref);
+
+    ref.setConstant(42.5);
+
+    mc_rbdyn::Gains6d g = config("double");
+    BOOST_CHECK_EQUAL(g, ref);
+
+    mc_rbdyn::Gains6d h = mc_rbdyn::Gains6d::Zero();
+    config("double", h);
+    BOOST_CHECK_EQUAL(h, ref);
+
+    mc_rbdyn::Gains6d i = mc_rbdyn::Gains6d::Zero();
+    i = config("dict")("double");
+    BOOST_CHECK_EQUAL(i, ref);
   }
 
   /* Eigen::VectorXd test */


### PR DESCRIPTION
This PR is composed of two elements with regards to the LIPMStabilizer Task : 

- The derivation of the DCM feedback is now done using a complementary filtering of a low pass filter between the model base derivate of the DCM and its derivate based on the varitaion of the measured DCM 

- The DCM feedback gain can now be 2d with respect of the orientation of the yaw of the "BODY" frame. 
- This update yet creates some conflict with former version configuration of the Stabilizer due to the conversion of the gain in 2d and must be fixed before merging