### PR TITLE
[GUI] Implement Polyhedron element

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright 2015-2020 CNRS-UM LIRMM, CNRS-AIST JRL
 #
 
-cmake_minimum_required(VERSION 3.7)
+cmake_minimum_required(VERSION 3.8)
 if(POLICY CMP0063)
   cmake_policy(SET CMP0063 NEW)
 endif()

--- a/doc/_i18n/en/tutorials/usage/gui.md
+++ b/doc/_i18n/en/tutorials/usage/gui.md
@@ -186,6 +186,16 @@ Polygon("Step plan",
         [this]]() { return step_plan_display_; });
 ```
 
+##### `Polyhedron`
+
+This element displays a polyhedron two representations are accepted:
+1. Providing a single list of triangles as `std::vector<std::array<Eigen::Vector3d, 3>>`
+2. Providing a list of vertices as `std::vector<Eigen::Vector3d>` and a list of triangles as indices into the vertices array as `std::vector<std::array<size_t, 3>>`
+
+Furthermore, you can provide per vertex color for this polyhedron, for each case the representation is:
+1. An `std::vector<std::array<mc_rtc::gui::Color, 3>>`
+2. An `std::vector<mc_rtc::gui::Color>`
+
 ##### `Force`
 
 This element displays a force vector in the 3D environment. You need to provide the force value as an `sva::ForceVecd` as well as the frame where the force is applied as an `sva::PTransformd`.

--- a/doc/_i18n/jp/tutorials/usage/gui.md
+++ b/doc/_i18n/jp/tutorials/usage/gui.md
@@ -187,6 +187,8 @@ Polygon("Step plan",
         [this]]() { return step_plan_display_; });
 ```
 
+{% comment %}FIXME Missing Polyhedron section{% endcomment %}
+
 ##### `Force`
 
 この要素は、3次元環境に力ベクトルを表示します。力の値を`sva::ForceVecd`として指定し、力を適用する対象となるフレームを`sva::PTransformd`として指定する必要があります。

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -360,8 +360,8 @@ protected:
   }
 
   virtual void polyhedron(const ElementId & id,
-                          const std::vector<Eigen::Vector3d> & /* triangles */,
-                          const std::vector<mc_rtc::gui::Color> & /* colors */,
+                          const std::vector<std::array<Eigen::Vector3d, 3>> & /* triangles */,
+                          const std::vector<std::array<mc_rtc::gui::Color, 3>> & /* colors */,
                           const mc_rtc::gui::PolyhedronConfig & /* config */)
   {
     default_impl("Polyhedron", id);

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -359,6 +359,14 @@ protected:
     polygon(id, points, config.color);
   }
 
+  virtual void polyhedron(const ElementId & id,
+                          const std::vector<Eigen::Vector3d> & /* triangles */,
+                          const std::vector<Eigen::Vector4d> & /* colors */,
+                          const mc_rtc::gui::PolyhedronConfig & /* config */)
+  {
+    default_impl("Polyhedron", id);
+  }
+
   /** Should display a force in 3D environment
    */
   virtual void force(const ElementId & id,
@@ -797,13 +805,16 @@ private:
   /** Handle Trajectory and dispatch to 3D or Pose case */
   void handle_trajectory(const ElementId & id, const mc_rtc::Configuration & data);
 
-  /** Hand details of DisplayPolygon elemets */
+  /** Handle details of DisplayPolygon elements */
   void handle_polygon(const ElementId & id, const mc_rtc::Configuration & data);
 
-  /** Hand details of DisplayForce elemets */
+  /** Handle details of Polyhedron elements */
+  void handle_polyhedron(const ElementId & id, const mc_rtc::Configuration & data_);
+
+  /** Handle details of DisplayForce elements */
   void handle_force(const ElementId & id, const mc_rtc::Configuration & data);
 
-  /** Hand details of DisplayArrow elemets */
+  /** Handle details of DisplayArrow elemets */
   void handle_arrow(const ElementId & id, const mc_rtc::Configuration & data);
 
   /** Handle details of Rotation elements */

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -361,7 +361,7 @@ protected:
 
   virtual void polyhedron(const ElementId & id,
                           const std::vector<Eigen::Vector3d> & /* triangles */,
-                          const std::vector<Eigen::Vector4d> & /* colors */,
+                          const std::vector<mc_rtc::gui::Color> & /* colors */,
                           const mc_rtc::gui::PolyhedronConfig & /* config */)
   {
     default_impl("Polyhedron", id);

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -359,13 +359,36 @@ protected:
     polygon(id, points, config.color);
   }
 
+  /** Should display a polyhedron
+   *
+   * The polyhedron is described by a list of clockwise-ordered triangles.
+   *
+   * A vertices/triangles version is also available, this default implementation calls that by default.
+   *
+   * \param colors might be empty
+   *
+   * \param config contains additional information about handling the drawing
+   */
   virtual void polyhedron(const ElementId & id,
-                          const std::vector<std::array<Eigen::Vector3d, 3>> & /* triangles */,
-                          const std::vector<std::array<mc_rtc::gui::Color, 3>> & /* colors */,
-                          const mc_rtc::gui::PolyhedronConfig & /* config */)
-  {
-    default_impl("Polyhedron", id);
-  }
+                          const std::vector<std::array<Eigen::Vector3d, 3>> & triangles,
+                          const std::vector<std::array<mc_rtc::gui::Color, 3>> & colors,
+                          const mc_rtc::gui::PolyhedronConfig & config);
+
+  /** Should display a polyhedron
+   *
+   * The polygon is described by a list of vertices and a list of triangles
+   *
+   * A triangle list version is also available, this default implementation calls that by default.
+   *
+   * \param colors might be empty
+   *
+   * \param config contains additional information about handling the drawing
+   */
+  virtual void polyhedron(const ElementId & id,
+                          const std::vector<Eigen::Vector3d> & vertices,
+                          const std::vector<std::array<size_t, 3>> & triangles,
+                          const std::vector<mc_rtc::gui::Color> & colors,
+                          const mc_rtc::gui::PolyhedronConfig & config);
 
   /** Should display a force in 3D environment
    */
@@ -809,7 +832,10 @@ private:
   void handle_polygon(const ElementId & id, const mc_rtc::Configuration & data);
 
   /** Handle details of Polyhedron elements */
-  void handle_polyhedron(const ElementId & id, const mc_rtc::Configuration & data_);
+  void handle_polyhedron_triangles_list(const ElementId & id, const mc_rtc::Configuration & data_);
+
+  /** Handle details of Polyhedron elements */
+  void handle_polyhedron_vertices_triangles(const ElementId & id, const mc_rtc::Configuration & data_);
 
   /** Handle details of DisplayForce elements */
   void handle_force(const ElementId & id, const mc_rtc::Configuration & data);
@@ -843,6 +869,11 @@ private:
                     const std::vector<std::string> & header,
                     const std::vector<std::string> & format,
                     const std::vector<mc_rtc::Configuration> & data);
+
+  /** These two booleans allow to only implement one of the two versions of the polyhedron callback, the other is
+   * automatically handled by the default implementation */
+  bool default_polyhedron_triangles_list_ = false;
+  bool default_polyhedron_vertices_triangles_ = false;
 };
 
 } // namespace mc_control

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -868,6 +868,12 @@ public:
    */
   void add(const std::string & key, const Eigen::Vector3d & value);
 
+  /*! \brief Add a Eigen::Vector4d element to the Configuration
+   *
+   * \see add(const std::string&, bool)
+   */
+  void add(const std::string & key, const Eigen::Vector4d & value);
+
   /*! \brief Add a Eigen::Vector6d element to the Configuration
    *
    * \see add(const std::string&, bool)
@@ -1019,6 +1025,12 @@ public:
    * \see push(bool);
    */
   void push(const Eigen::Vector3d & value);
+
+  /*! \brief Insert a Eigen::Vector4d element into an array
+   *
+   * \see push(bool);
+   */
+  void push(const Eigen::Vector4d & value);
 
   /*! \brief Insert a Eigen::Vector6d element into an array
    *

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -97,41 +97,6 @@ struct has_configuration_save_object : decltype(_has_configuration_save_object::
 {
 };
 
-template<typename T>
-constexpr bool is_integral_v = std::is_integral_v<T> || std::numeric_limits<std::decay_t<T>>::is_integer;
-
-/** Compare two integral types */
-template<typename RefT, typename T>
-constexpr bool is_like()
-{
-  static_assert(std::is_integral_v<RefT>);
-  if constexpr(is_integral_v<T>)
-  {
-    // clang-format off
-    return std::numeric_limits<T>::is_signed == std::is_signed_v<RefT>
-           && std::numeric_limits<T>::max() == std::numeric_limits<RefT>::max();
-    // clang-format on
-  }
-  return false;
-}
-
-template<typename T>
-constexpr bool is_like_int8_t = is_like<int8_t, T>();
-template<typename T>
-constexpr bool is_like_int16_t = is_like<int16_t, T>();
-template<typename T>
-constexpr bool is_like_int32_t = is_like<int32_t, T>();
-template<typename T>
-constexpr bool is_like_int64_t = is_like<int64_t, T>();
-template<typename T>
-constexpr bool is_like_uint8_t = is_like<uint8_t, T>();
-template<typename T>
-constexpr bool is_like_uint16_t = is_like<uint16_t, T>();
-template<typename T>
-constexpr bool is_like_uint32_t = is_like<uint32_t, T>();
-template<typename T>
-constexpr bool is_like_uint64_t = is_like<uint64_t, T>();
-
 } // namespace internal
 
 /*! \brief Simplify access to values hold within a JSON file

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -213,22 +213,56 @@ public:
    */
   operator bool() const;
 
-  /*! \brief Cast to int
+  /*! \brief Cast to int8_t
    *
-   * Strictly for int-typed entries
+   * Strictly for int8_t-typed entries
    *
-   * \throws If the underlying value does not hold an int
+   * \throws If the underlying value does not hold an int8_t
    */
-  operator int() const;
+  operator int8_t() const;
 
-  /*! \brief Cast to unsigned int
+  /*! \brief Cast to uint8_t
    *
    * Int entries that are strictly positive will be treated as
-   * unsigned int entries
+   * uint8_t entries
    *
-   * \throws If the underlying value does not hold an unsigned int
+   * \throws If the underlying value does not hold an uint8_t
    */
-  operator unsigned int() const;
+  operator uint8_t() const;
+
+  /*! \brief Cast to int16_t
+   *
+   * Strictly for int16_t-typed entries
+   *
+   * \throws If the underlying value does not hold an int16_t
+   */
+  operator int16_t() const;
+
+  /*! \brief Cast to uint16_t
+   *
+   * Int entries that are strictly positive will be treated as
+   * uint16_t entries
+   *
+   * \throws If the underlying value does not hold an uint16_t
+   */
+  operator uint16_t() const;
+
+  /*! \brief Cast to int32_t
+   *
+   * Strictly for int32_t-typed entries
+   *
+   * \throws If the underlying value does not hold an int32_t
+   */
+  operator int32_t() const;
+
+  /*! \brief Cast to uint32_t
+   *
+   * Int entries that are strictly positive will be treated as
+   * uint32_t entries
+   *
+   * \throws If the underlying value does not hold an uint32_t
+   */
+  operator uint32_t() const;
 
   /*! \brief Cast to int64_t
    *
@@ -813,17 +847,41 @@ public:
    */
   void add(const std::string & key, bool value);
 
-  /*! \brief Add a int element to the Configuration
+  /*! \brief Add a int64_t element to the Configuration
    *
    * \see add(const std::string&, bool)
    */
-  void add(const std::string & key, int value);
+  void add(const std::string & key, int8_t value);
 
-  /*! \brief Add a unsigned int element to the Configuration
+  /*! \brief Add a uint8_t element to the Configuration
    *
    * \see add(const std::string&, bool)
    */
-  void add(const std::string & key, unsigned int value);
+  void add(const std::string & key, uint8_t value);
+
+  /*! \brief Add a int16_t element to the Configuration
+   *
+   * \see add(const std::string&, bool)
+   */
+  void add(const std::string & key, int16_t value);
+
+  /*! \brief Add a uint16_t element to the Configuration
+   *
+   * \see add(const std::string&, bool)
+   */
+  void add(const std::string & key, uint16_t value);
+
+  /*! \brief Add a int32_t element to the Configuration
+   *
+   * \see add(const std::string&, bool)
+   */
+  void add(const std::string & key, int32_t value);
+
+  /*! \brief Add a uint32_t element to the Configuration
+   *
+   * \see add(const std::string&, bool)
+   */
+  void add(const std::string & key, uint32_t value);
 
   /*! \brief Add a int64_t element to the Configuration
    *
@@ -972,17 +1030,41 @@ public:
    */
   void push(bool value);
 
-  /*! \brief Insert a int element into an array
+  /*! \brief Insert a int8_t element int8_to an array
    *
    * \see push(bool);
    */
-  void push(int value);
+  void push(int8_t value);
 
-  /*! \brief Insert a unsigned int element into an array
+  /*! \brief Insert a uint8_t element into an array
    *
    * \see push(bool);
    */
-  void push(unsigned int value);
+  void push(uint8_t value);
+
+  /*! \brief Insert a int16_t element int16_to an array
+   *
+   * \see push(bool);
+   */
+  void push(int16_t value);
+
+  /*! \brief Insert a uint16_t element into an array
+   *
+   * \see push(bool);
+   */
+  void push(uint16_t value);
+
+  /*! \brief Insert a int32_t element int32_to an array
+   *
+   * \see push(bool);
+   */
+  void push(int32_t value);
+
+  /*! \brief Insert a uint32_t element into an array
+   *
+   * \see push(bool);
+   */
+  void push(uint32_t value);
 
   /*! \brief Insert a int64_t element int64_to an array
    *

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -281,6 +281,13 @@ public:
    */
   operator Eigen::Vector3d() const;
 
+  /*! \brief Retrieve as a Eigen::Vector4d instance
+   *
+   * \throws If the underlying value does not hold a numeric
+   * sequence of size 4
+   */
+  operator Eigen::Vector4d() const;
+
   /*! \brief Retrieve as a Eigen::Vector6d instance
    *
    * \throws If the underlying value does not hold a numeric

--- a/include/mc_rtc/MessagePackBuilder.h
+++ b/include/mc_rtc/MessagePackBuilder.h
@@ -102,6 +102,12 @@ struct MC_RTC_UTILS_DLLAPI MessagePackBuilder
    */
   void write(const Eigen::Vector3d & v);
 
+  /** Write an Eigen::Vector4d
+   *
+   * Serializes as an array of size 4
+   */
+  void write(const Eigen::Vector4d & v);
+
   /** Write an Eigen::Vector6d
    *
    * Serializes as an array of size 6

--- a/include/mc_rtc/MessagePackBuilder.h
+++ b/include/mc_rtc/MessagePackBuilder.h
@@ -22,6 +22,46 @@ struct Configuration;
 
 struct MessagePackBuilderImpl;
 
+namespace internal
+{
+
+template<typename T>
+constexpr bool is_integral_v = std::is_integral_v<T> || std::numeric_limits<std::decay_t<T>>::is_integer;
+
+/** Compare two integral types */
+template<typename RefT, typename T>
+constexpr bool is_like()
+{
+  static_assert(std::is_integral_v<RefT>);
+  if constexpr(is_integral_v<T>)
+  {
+    // clang-format off
+    return std::numeric_limits<T>::is_signed == std::is_signed_v<RefT>
+           && std::numeric_limits<T>::max() == std::numeric_limits<RefT>::max();
+    // clang-format on
+  }
+  return false;
+}
+
+template<typename T>
+constexpr bool is_like_int8_t = is_like<int8_t, T>();
+template<typename T>
+constexpr bool is_like_int16_t = is_like<int16_t, T>();
+template<typename T>
+constexpr bool is_like_int32_t = is_like<int32_t, T>();
+template<typename T>
+constexpr bool is_like_int64_t = is_like<int64_t, T>();
+template<typename T>
+constexpr bool is_like_uint8_t = is_like<uint8_t, T>();
+template<typename T>
+constexpr bool is_like_uint16_t = is_like<uint16_t, T>();
+template<typename T>
+constexpr bool is_like_uint32_t = is_like<uint32_t, T>();
+template<typename T>
+constexpr bool is_like_uint64_t = is_like<uint64_t, T>();
+
+} // namespace internal
+
 /** Helper class to build a MessagePack message
  *
  * After a message has been built, the builder object must be discarded to
@@ -161,6 +201,48 @@ struct MC_RTC_UTILS_DLLAPI MessagePackBuilder
    * Serialied as the JSON data it holds
    */
   void write(const mc_rtc::Configuration & config);
+
+  /** Write numbers by finding their closest standard size match */
+  template<typename T, typename std::enable_if_t<internal::is_integral_v<T>, int> = 0>
+  void write(const T & number)
+  {
+    if constexpr(internal::is_like_int8_t<T>)
+    {
+      write(static_cast<int8_t>(number));
+    }
+    else if constexpr(internal::is_like_int16_t<T>)
+    {
+      write(static_cast<int16_t>(number));
+    }
+    else if constexpr(internal::is_like_int32_t<T>)
+    {
+      write(static_cast<int32_t>(number));
+    }
+    else if constexpr(internal::is_like_int64_t<T>)
+    {
+      write(static_cast<int64_t>(number));
+    }
+    else if constexpr(internal::is_like_uint8_t<T>)
+    {
+      write(static_cast<uint8_t>(number));
+    }
+    else if constexpr(internal::is_like_uint16_t<T>)
+    {
+      write(static_cast<uint16_t>(number));
+    }
+    else if constexpr(internal::is_like_uint32_t<T>)
+    {
+      write(static_cast<uint32_t>(number));
+    }
+    else if constexpr(internal::is_like_uint64_t<T>)
+    {
+      write(static_cast<uint64_t>(number));
+    }
+    else
+    {
+      static_assert(!std::is_same_v<T, T>, "T is integral but has an unsupported size");
+    }
+  }
 
   /** @} */
   /* End Add data to the MessagePack section (advanced) */

--- a/include/mc_rtc/gui.h
+++ b/include/mc_rtc/gui.h
@@ -23,6 +23,7 @@
 #include <mc_rtc/gui/NumberSlider.h>
 #include <mc_rtc/gui/Point3D.h>
 #include <mc_rtc/gui/Polygon.h>
+#include <mc_rtc/gui/Polyhedron.h>
 #include <mc_rtc/gui/Robot.h>
 #include <mc_rtc/gui/Rotation.h>
 #include <mc_rtc/gui/Schema.h>

--- a/include/mc_rtc/gui/Polyhedron.h
+++ b/include/mc_rtc/gui/Polyhedron.h
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_rtc/gui/details/traits.h>
+#include <mc_rtc/gui/elements.h>
+#include <mc_rtc/gui/types.h>
+
+namespace mc_rtc
+{
+
+namespace gui
+{
+
+/** Polyhedron should display a polyhedron or a set of polyhedrons
+ *
+ * A color is provided to display the polyhedron(s)
+ *
+ * \tparam GetT Should return an std::vector<Eigen::Vector3d> (one polyhedron) or an
+ * std::vector<std::vector<Eigen:Vector3d>> (list of polyhedrons)
+ *
+ */
+template<typename GetVerticesT, typename GetColorT>
+struct PolyhedronImpl : public Element
+{
+  static constexpr auto type = Elements::Polyhedron;
+
+  PolyhedronImpl(const std::string & name,
+                 const PolyhedronConfig & config,
+                 GetVerticesT get_vertices_fn,
+                 GetColorT get_color_fn)
+  : Element(name), config_(config), get_vertices_fn_(get_vertices_fn), get_color_fn_(get_color_fn)
+  {
+    static_assert(details::CheckReturnType<GetVerticesT, PolyhedronTriangles>::value,
+                  "Polyhedron vertices callback must return an std::vector<Eigen::Vector3d> (triangle set with points "
+                  "ordered clockwise)");
+    static_assert(details::CheckReturnType<GetColorT, PolyhedronColors>::value,
+                  "Polyhedron vertices' color callback must return an std::vector<Eigen::Vector4d> (triangle set with "
+                  "points ordered clockwise)");
+  }
+
+  /** Invalid element */
+  PolyhedronImpl() {}
+
+  static constexpr size_t write_size()
+  {
+    return Element::write_size() + 2 + PolyhedronConfig::write_size();
+  }
+
+  void write(mc_rtc::MessagePackBuilder & builder)
+  {
+    builder.write(get_vertices_fn_());
+    builder.write(get_color_fn_());
+    config_.write(builder);
+  }
+
+private:
+  PolyhedronConfig config_;
+  GetVerticesT get_vertices_fn_;
+  GetColorT get_color_fn_;
+};
+
+/** Helper function to build a PolyhedronImpl */
+template<typename GetVerticesT, typename GetColorT>
+PolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
+                                                   GetVerticesT get_vertices_fn,
+                                                   GetColorT get_color_fn)
+{
+  return PolyhedronImpl<GetVerticesT, GetColorT>(name, {}, get_vertices_fn, get_color_fn);
+}
+
+/** Helper function to build a PolyhedronImpl */
+template<typename GetVerticesT, typename GetColorT>
+PolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
+                                                   const PolyhedronConfig & config,
+                                                   GetVerticesT get_vertices_fn,
+                                                   GetColorT get_color_fn)
+{
+  return PolyhedronImpl<GetVerticesT, GetColorT>(name, config, get_vertices_fn, get_color_fn);
+}
+
+} // namespace gui
+
+} // namespace mc_rtc

--- a/include/mc_rtc/gui/Polyhedron.h
+++ b/include/mc_rtc/gui/Polyhedron.h
@@ -16,25 +16,22 @@ namespace gui
 
 namespace details
 {
-/** Polyhedron should display a polyhedron or a set of polyhedrons
+/** Polyhedron should display a polyhedron
  *
- * A color is provided to display the polyhedron(s)
- *
- * \tparam GetT Should return an std::vector<Eigen::Vector3d> (one polyhedron) or an
- * std::vector<std::vector<Eigen:Vector3d>> (list of polyhedrons)
- *
+ * \tparam GetTrianglesT Should return a vector of triangles with points ordered clockwise, expressed as either an
+ * std::vector<std::array<double, 3>>
  */
-template<typename GetVerticesT>
+template<typename GetTrianglesT>
 struct PolyhedronImpl : public Element
 {
   static constexpr auto type = Elements::Polyhedron;
 
-  PolyhedronImpl(const std::string & name, const PolyhedronConfig & config, GetVerticesT get_vertices_fn)
-  : Element(name), config_(config), get_vertices_fn_(get_vertices_fn)
+  PolyhedronImpl(const std::string & name, const PolyhedronConfig & config, GetTrianglesT get_triangles_fn)
+  : Element(name), config_(config), get_triangles_fn_(get_triangles_fn)
   {
-    static_assert(details::CheckReturnType<GetVerticesT, std::vector<Eigen::Vector3d>>::value,
-                  "Polyhedron vertices callback must return an std::vector<Eigen::Vector3d> (triangle set with points "
-                  "ordered clockwise)");
+    static_assert(details::CheckReturnType<GetTrianglesT, std::vector<std::array<Eigen::Vector3d, 3>>>::value,
+                  "Polyhedron callback must return a vector of triangles with points ordered clockwise, expressed as "
+                  "an std::vector<std::array<double, 3>>");
   }
 
   /** Invalid element */
@@ -47,29 +44,34 @@ struct PolyhedronImpl : public Element
 
   void write(mc_rtc::MessagePackBuilder & builder)
   {
-    builder.write(get_vertices_fn_());
+    builder.write(get_triangles_fn_());
     builder.write();
     config_.write(builder);
   }
 
 protected:
   PolyhedronConfig config_;
-  GetVerticesT get_vertices_fn_;
+  GetTrianglesT get_triangles_fn_;
 };
 
-template<typename GetVerticesT, typename GetColorT>
-struct ColoredPolyhedronImpl : public PolyhedronImpl<GetVerticesT>
+/** ColoredPolyhedron should display a polyhedron
+ *
+ * \tparam GetTrianglesT \see PolyhedronImpl
+ * \tparam GetColorT Should return a vector of triangle colors expressed as an
+ * std::vector<std::array<mc_rtc::gui::Color, 3>>
+ */
+template<typename GetTrianglesT, typename GetColorT>
+struct ColoredPolyhedronImpl : public PolyhedronImpl<GetTrianglesT>
 {
-
   ColoredPolyhedronImpl(const std::string & name,
                         const PolyhedronConfig & config,
-                        GetVerticesT get_vertices_fn,
+                        GetTrianglesT get_triangles_fn,
                         GetColorT get_color_fn)
-  : PolyhedronImpl<GetVerticesT>(name, config, get_vertices_fn), get_color_fn_(get_color_fn)
+  : PolyhedronImpl<GetTrianglesT>(name, config, get_triangles_fn), get_color_fn_(get_color_fn)
   {
-    static_assert(details::CheckReturnType<GetColorT, std::vector<mc_rtc::gui::Color>>::value,
-                  "Polyhedron color callback must return an std::vector<mc_rtc::gui::Color> (color for each of the "
-                  "triangle vertices)");
+    static_assert(details::CheckReturnType<GetColorT, std::vector<std::array<mc_rtc::gui::Color, 3>>>::value,
+                  "Polyhedron color callback must return an std::vector<std::array<mc_rtc::gui::Color, 3>> (color for "
+                  "each of the triangle vertices)");
   }
 
   /** Invalid element */
@@ -77,20 +79,24 @@ struct ColoredPolyhedronImpl : public PolyhedronImpl<GetVerticesT>
 
   void write(mc_rtc::MessagePackBuilder & builder)
   {
-    builder.write(get_vertices_fn_());
+    builder.write(get_triangles_fn_());
     const auto & colors = get_color_fn_();
     builder.start_array(colors.size());
     for(const auto & c : colors)
     {
-      c.write(builder);
+      builder.start_array(3);
+      c[0].write(builder);
+      c[1].write(builder);
+      c[2].write(builder);
+      builder.finish_array();
     }
     builder.finish_array();
     config_.write(builder);
   }
 
 protected:
-  using PolyhedronImpl<GetVerticesT>::config_;
-  using PolyhedronImpl<GetVerticesT>::get_vertices_fn_;
+  using PolyhedronImpl<GetTrianglesT>::config_;
+  using PolyhedronImpl<GetTrianglesT>::get_triangles_fn_;
   GetColorT get_color_fn_;
 };
 
@@ -99,36 +105,36 @@ protected:
 /** Helper function to build a PolyhedronImpl */
 template<typename GetVerticesT, typename GetColorT>
 details::ColoredPolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
-                                                                   GetVerticesT get_vertices_fn,
+                                                                   GetVerticesT get_triangles_fn,
                                                                    GetColorT get_color_fn)
 {
-  return details::ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, {}, get_vertices_fn, get_color_fn);
+  return details::ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, {}, get_triangles_fn, get_color_fn);
 }
 
 /** Helper function to build a PolyhedronImpl */
 template<typename GetVerticesT, typename GetColorT>
 details::ColoredPolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
                                                                    const PolyhedronConfig & config,
-                                                                   GetVerticesT get_vertices_fn,
+                                                                   GetVerticesT get_triangles_fn,
                                                                    GetColorT get_color_fn)
 {
-  return details::ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, config, get_vertices_fn, get_color_fn);
+  return details::ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, config, get_triangles_fn, get_color_fn);
 }
 
 /** Helper function to build a PolyhedronImpl */
 template<typename GetVerticesT>
-details::PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name, GetVerticesT get_vertices_fn)
+details::PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name, GetVerticesT get_triangles_fn)
 {
-  return details::PolyhedronImpl<GetVerticesT>(name, {}, get_vertices_fn);
+  return details::PolyhedronImpl<GetVerticesT>(name, {}, get_triangles_fn);
 }
 
 /** Helper function to build a PolyhedronImpl */
 template<typename GetVerticesT>
 details::PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name,
                                                  const PolyhedronConfig & config,
-                                                 GetVerticesT get_vertices_fn)
+                                                 GetVerticesT get_triangles_fn)
 {
-  return details::PolyhedronImpl<GetVerticesT>(name, config, get_vertices_fn);
+  return details::PolyhedronImpl<GetVerticesT>(name, config, get_triangles_fn);
 }
 
 } // namespace gui

--- a/include/mc_rtc/gui/Polyhedron.h
+++ b/include/mc_rtc/gui/Polyhedron.h
@@ -16,17 +16,18 @@ namespace gui
 
 namespace details
 {
+
 /** Polyhedron should display a polyhedron
  *
- * \tparam GetTrianglesT Should return a vector of triangles with points ordered clockwise, expressed as either an
+ * \tparam GetTrianglesT Should return a vector of triangles with points ordered clockwise, expressed as a
  * std::vector<std::array<double, 3>>
  */
 template<typename GetTrianglesT>
-struct PolyhedronImpl : public Element
+struct PolyhedronTrianglesListImpl : public Element
 {
-  static constexpr auto type = Elements::Polyhedron;
+  static constexpr auto type = Elements::PolyhedronTrianglesList;
 
-  PolyhedronImpl(const std::string & name, const PolyhedronConfig & config, GetTrianglesT get_triangles_fn)
+  PolyhedronTrianglesListImpl(const std::string & name, const PolyhedronConfig & config, GetTrianglesT get_triangles_fn)
   : Element(name), config_(config), get_triangles_fn_(get_triangles_fn)
   {
     static_assert(details::CheckReturnType<GetTrianglesT, std::vector<std::array<Eigen::Vector3d, 3>>>::value,
@@ -35,17 +36,16 @@ struct PolyhedronImpl : public Element
   }
 
   /** Invalid element */
-  PolyhedronImpl() {}
+  PolyhedronTrianglesListImpl() {}
 
   static constexpr size_t write_size()
   {
-    return Element::write_size() + 2 + PolyhedronConfig::write_size();
+    return Element::write_size() + 1 + PolyhedronConfig::write_size();
   }
 
   void write(mc_rtc::MessagePackBuilder & builder)
   {
     builder.write(get_triangles_fn_());
-    builder.write();
     config_.write(builder);
   }
 
@@ -54,87 +54,186 @@ protected:
   GetTrianglesT get_triangles_fn_;
 };
 
-/** ColoredPolyhedron should display a polyhedron
+/** Polyhedron should display a polyhedron
  *
- * \tparam GetTrianglesT \see PolyhedronImpl
+ * \tparam GetVerticesT Should return a list of vertices as an std::vector<Eigen::Vector3d>
+ *
+ * \tparam GetTrianglesT Should return a list of triangle as std::vector<std::array<size_t, 3>>
+ */
+template<typename GetVerticesT, typename GetTrianglesT>
+struct PolyhedronVerticesTrianglesImpl : public Element
+{
+  static constexpr auto type = Elements::PolyhedronVerticesTriangles;
+
+  PolyhedronVerticesTrianglesImpl(const std::string & name,
+                                  const PolyhedronConfig & config,
+                                  GetVerticesT get_vertices_fn,
+                                  GetTrianglesT get_triangles_fn)
+  : Element(name), config_(config), get_vertices_fn_(get_vertices_fn), get_triangles_fn_(get_triangles_fn)
+  {
+    static_assert(details::CheckReturnType<GetVerticesT, std::vector<Eigen::Vector3d>>::value,
+                  "Polyhedron vertices callback must return a vector of 3D points");
+    static_assert(details::CheckReturnType<GetTrianglesT, std::vector<std::array<size_t, 3>>>::value,
+                  "Polyhedron triangles callback must return a list of 3-uple index into vertices array");
+  }
+
+  /** Invalid element */
+  PolyhedronVerticesTrianglesImpl() {}
+
+  static constexpr size_t write_size()
+  {
+    return Element::write_size() + 2 + PolyhedronConfig::write_size();
+  }
+
+  void write(mc_rtc::MessagePackBuilder & builder)
+  {
+    builder.write(get_vertices_fn_());
+    builder.write(get_triangles_fn_());
+    config_.write(builder);
+  }
+
+protected:
+  PolyhedronConfig config_;
+  GetVerticesT get_vertices_fn_;
+  GetTrianglesT get_triangles_fn_;
+};
+
+/** ColoredPolyhedron should display a polyhedron using the color information provided
+ *
+ * \tparam PolyhedronT this represents
  * \tparam GetColorT Should return a vector of triangle colors expressed as an
  * std::vector<std::array<mc_rtc::gui::Color, 3>>
  */
-template<typename GetTrianglesT, typename GetColorT>
-struct ColoredPolyhedronImpl : public PolyhedronImpl<GetTrianglesT>
+template<typename PolyhedronT, typename GetColorT>
+struct ColoredPolyhedronImpl : public PolyhedronT
 {
-  ColoredPolyhedronImpl(const std::string & name,
-                        const PolyhedronConfig & config,
-                        GetTrianglesT get_triangles_fn,
-                        GetColorT get_color_fn)
-  : PolyhedronImpl<GetTrianglesT>(name, config, get_triangles_fn), get_color_fn_(get_color_fn)
+  ColoredPolyhedronImpl(PolyhedronT && poly, GetColorT get_color_fn) : PolyhedronT(poly), get_color_fn_(get_color_fn)
   {
-    static_assert(details::CheckReturnType<GetColorT, std::vector<std::array<mc_rtc::gui::Color, 3>>>::value,
-                  "Polyhedron color callback must return an std::vector<std::array<mc_rtc::gui::Color, 3>> (color for "
-                  "each of the triangle vertices)");
+    if constexpr(PolyhedronT::type == Elements::PolyhedronTrianglesList)
+    {
+      static_assert(
+          details::CheckReturnType<GetColorT, std::vector<std::array<mc_rtc::gui::Color, 3>>>::value,
+          "Polyhedron color callback must return an std::vector<std::array<mc_rtc::gui::Color, 3>> (color for "
+          "each of the triangle vertices)");
+    }
+    else
+    {
+      static_assert(details::CheckReturnType<GetColorT, std::vector<mc_rtc::gui::Color>>::value,
+                    "Polyhedron color callback must return an std::vector<mc_rtc::gui::Color> (color for "
+                    "each of the vertices)");
+    }
   }
 
   /** Invalid element */
   ColoredPolyhedronImpl() {}
 
+  static constexpr size_t write_size()
+  {
+    return PolyhedronT::write_size() + 1;
+  }
+
   void write(mc_rtc::MessagePackBuilder & builder)
   {
-    builder.write(get_triangles_fn_());
+    PolyhedronT::write(builder);
     const auto & colors = get_color_fn_();
     builder.start_array(colors.size());
     for(const auto & c : colors)
     {
-      builder.start_array(3);
-      c[0].write(builder);
-      c[1].write(builder);
-      c[2].write(builder);
-      builder.finish_array();
+      if constexpr(PolyhedronT::type == Elements::PolyhedronTrianglesList)
+      {
+        builder.start_array(3);
+        c[0].write(builder);
+        c[1].write(builder);
+        c[2].write(builder);
+        builder.finish_array();
+      }
+      else
+      {
+        c.write(builder);
+      }
     }
     builder.finish_array();
-    config_.write(builder);
   }
 
 protected:
-  using PolyhedronImpl<GetTrianglesT>::config_;
-  using PolyhedronImpl<GetTrianglesT>::get_triangles_fn_;
   GetColorT get_color_fn_;
 };
 
 } // namespace details
 
-/** Helper function to build a PolyhedronImpl */
-template<typename GetVerticesT, typename GetColorT>
-details::ColoredPolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
-                                                                   GetVerticesT get_triangles_fn,
-                                                                   GetColorT get_color_fn)
+/** Helper function to build a PolyhedronTriangleListImpl */
+template<typename GetTrianglesT>
+auto Polyhedron(const std::string & name, GetTrianglesT get_triangles_fn)
 {
-  return details::ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, {}, get_triangles_fn, get_color_fn);
+  return details::PolyhedronTrianglesListImpl<GetTrianglesT>(name, {}, get_triangles_fn);
 }
 
-/** Helper function to build a PolyhedronImpl */
-template<typename GetVerticesT, typename GetColorT>
-details::ColoredPolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
-                                                                   const PolyhedronConfig & config,
-                                                                   GetVerticesT get_triangles_fn,
-                                                                   GetColorT get_color_fn)
+/** Helper function to build a PolyhedronTriangleListImpl */
+template<typename GetTrianglesT>
+auto Polyhedron(const std::string & name, const PolyhedronConfig & config, GetTrianglesT get_triangles_fn)
 {
-  return details::ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, config, get_triangles_fn, get_color_fn);
+  return details::PolyhedronTrianglesListImpl<GetTrianglesT>(name, config, get_triangles_fn);
 }
 
-/** Helper function to build a PolyhedronImpl */
-template<typename GetVerticesT>
-details::PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name, GetVerticesT get_triangles_fn)
+/** Helper function to build a PolyhedronVerticesTrianglesImpl */
+template<typename GetVerticesT, typename GetTrianglesT>
+auto Polyhedron(const std::string & name, GetVerticesT get_vertices_fn, GetTrianglesT get_triangles_fn)
 {
-  return details::PolyhedronImpl<GetVerticesT>(name, {}, get_triangles_fn);
+  return details::PolyhedronVerticesTrianglesImpl<GetVerticesT, GetTrianglesT>(name, {}, get_vertices_fn,
+                                                                               get_triangles_fn);
 }
 
-/** Helper function to build a PolyhedronImpl */
-template<typename GetVerticesT>
-details::PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name,
-                                                 const PolyhedronConfig & config,
-                                                 GetVerticesT get_triangles_fn)
+/** Helper function to build a PolyhedronVerticesTrianglesImpl */
+template<typename GetVerticesT, typename GetTrianglesT>
+auto Polyhedron(const std::string & name,
+                const PolyhedronConfig & config,
+                GetVerticesT get_vertices_fn,
+                GetTrianglesT get_triangles_fn)
 {
-  return details::PolyhedronImpl<GetVerticesT>(name, config, get_triangles_fn);
+  return details::PolyhedronVerticesTrianglesImpl<GetVerticesT, GetTrianglesT>(name, config, get_vertices_fn,
+                                                                               get_triangles_fn);
+}
+
+/** Helper function to build a ColoredPolyhedronImpl */
+template<typename GetTrianglesT, typename GetColorT>
+auto ColoredPolyhedron(const std::string & name, GetTrianglesT get_triangles_fn, GetColorT get_color_fn)
+{
+  auto poly = Polyhedron(name, get_triangles_fn);
+  return details::ColoredPolyhedronImpl<decltype(poly), GetColorT>(std::move(poly), get_color_fn);
+}
+
+/** Helper function to build a ColoredPolyhedronImpl */
+template<typename GetTrianglesT, typename GetColorT>
+auto ColoredPolyhedron(const std::string & name,
+                       const PolyhedronConfig & config,
+                       GetTrianglesT get_triangles_fn,
+                       GetColorT get_color_fn)
+{
+  auto poly = Polyhedron(name, config, get_triangles_fn);
+  return details::ColoredPolyhedronImpl<decltype(poly), GetColorT>(std::move(poly), get_color_fn);
+}
+
+/** Helper function to build a ColoredPolyhedronImpl */
+template<typename GetVerticesT, typename GetTrianglesT, typename GetColorT>
+auto ColoredPolyhedron(const std::string & name,
+                       GetVerticesT get_vertices_fn,
+                       GetTrianglesT get_triangles_fn,
+                       GetColorT get_color_fn)
+{
+  auto poly = Polyhedron(name, get_vertices_fn, get_triangles_fn);
+  return details::ColoredPolyhedronImpl<decltype(poly), GetColorT>(std::move(poly), get_color_fn);
+}
+
+/** Helper function to build a ColoredPolyhedronImpl */
+template<typename GetVerticesT, typename GetTrianglesT, typename GetColorT>
+auto ColoredPolyhedron(const std::string & name,
+                       const PolyhedronConfig & config,
+                       GetVerticesT get_vertices_fn,
+                       GetVerticesT get_triangles_fn,
+                       GetColorT get_color_fn)
+{
+  auto poly = Polyhedron(name, config, get_vertices_fn, get_triangles_fn);
+  return details::ColoredPolyhedronImpl<decltype(poly), GetColorT>(std::move(poly), get_color_fn);
 }
 
 } // namespace gui

--- a/include/mc_rtc/gui/Polyhedron.h
+++ b/include/mc_rtc/gui/Polyhedron.h
@@ -22,23 +22,17 @@ namespace gui
  * std::vector<std::vector<Eigen:Vector3d>> (list of polyhedrons)
  *
  */
-template<typename GetVerticesT, typename GetColorT>
+template<typename GetVerticesT>
 struct PolyhedronImpl : public Element
 {
   static constexpr auto type = Elements::Polyhedron;
 
-  PolyhedronImpl(const std::string & name,
-                 const PolyhedronConfig & config,
-                 GetVerticesT get_vertices_fn,
-                 GetColorT get_color_fn)
-  : Element(name), config_(config), get_vertices_fn_(get_vertices_fn), get_color_fn_(get_color_fn)
+  PolyhedronImpl(const std::string & name, const PolyhedronConfig & config, GetVerticesT get_vertices_fn)
+  : Element(name), config_(config), get_vertices_fn_(get_vertices_fn)
   {
     static_assert(details::CheckReturnType<GetVerticesT, PolyhedronTriangles>::value,
                   "Polyhedron vertices callback must return an std::vector<Eigen::Vector3d> (triangle set with points "
                   "ordered clockwise)");
-    static_assert(details::CheckReturnType<GetColorT, PolyhedronColors>::value,
-                  "Polyhedron vertices' color callback must return an std::vector<Eigen::Vector4d> (triangle set with "
-                  "points ordered clockwise)");
   }
 
   /** Invalid element */
@@ -52,33 +46,84 @@ struct PolyhedronImpl : public Element
   void write(mc_rtc::MessagePackBuilder & builder)
   {
     builder.write(get_vertices_fn_());
+    builder.write(PolyhedronColors{});
+    config_.write(builder);
+  }
+
+protected:
+  PolyhedronConfig config_;
+  GetVerticesT get_vertices_fn_;
+};
+
+template<typename GetVerticesT, typename GetColorT>
+struct ColoredPolyhedronImpl : public PolyhedronImpl<GetVerticesT>
+{
+
+  ColoredPolyhedronImpl(const std::string & name,
+                        const PolyhedronConfig & config,
+                        GetVerticesT get_vertices_fn,
+                        GetColorT get_color_fn)
+  : PolyhedronImpl<GetVerticesT>(name, config, get_vertices_fn), get_color_fn_(get_color_fn)
+  {
+    static_assert(details::CheckReturnType<GetColorT, PolyhedronColors>::value,
+                  "Polyhedron vertices' color callback must return an std::vector<Eigen::Vector4d> (triangle set with "
+                  "points ordered clockwise)");
+  }
+
+  /** Invalid element */
+  ColoredPolyhedronImpl() {}
+
+  static constexpr size_t write_size()
+  {
+    return PolyhedronImpl<GetVerticesT>::write_size();
+  }
+
+  void write(mc_rtc::MessagePackBuilder & builder)
+  {
+    builder.write(get_vertices_fn_());
     builder.write(get_color_fn_());
     config_.write(builder);
   }
 
-private:
-  PolyhedronConfig config_;
-  GetVerticesT get_vertices_fn_;
+protected:
+  using PolyhedronImpl<GetVerticesT>::config_;
+  using PolyhedronImpl<GetVerticesT>::get_vertices_fn_;
   GetColorT get_color_fn_;
 };
 
 /** Helper function to build a PolyhedronImpl */
 template<typename GetVerticesT, typename GetColorT>
-PolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
-                                                   GetVerticesT get_vertices_fn,
-                                                   GetColorT get_color_fn)
+ColoredPolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
+                                                          GetVerticesT get_vertices_fn,
+                                                          GetColorT get_color_fn)
 {
-  return PolyhedronImpl<GetVerticesT, GetColorT>(name, {}, get_vertices_fn, get_color_fn);
+  return ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, {}, get_vertices_fn, get_color_fn);
 }
 
 /** Helper function to build a PolyhedronImpl */
 template<typename GetVerticesT, typename GetColorT>
-PolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
-                                                   const PolyhedronConfig & config,
-                                                   GetVerticesT get_vertices_fn,
-                                                   GetColorT get_color_fn)
+ColoredPolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
+                                                          const PolyhedronConfig & config,
+                                                          GetVerticesT get_vertices_fn,
+                                                          GetColorT get_color_fn)
 {
-  return PolyhedronImpl<GetVerticesT, GetColorT>(name, config, get_vertices_fn, get_color_fn);
+  return ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, config, get_vertices_fn, get_color_fn);
+}
+
+/** Helper function to build a PolyhedronImpl */
+template<typename GetVerticesT>
+PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name, GetVerticesT get_vertices_fn)
+{
+  return PolyhedronImpl<GetVerticesT>(name, {}, get_vertices_fn);
+}
+
+/** Helper function to build a PolyhedronImpl */
+template<typename GetVerticesT>
+PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name,
+                                        const PolyhedronConfig & config,
+                                        GetVerticesT get_vertices_fn)
+{
+  return PolyhedronImpl<GetVerticesT>(name, config, get_vertices_fn);
 }
 
 } // namespace gui

--- a/include/mc_rtc/gui/Polyhedron.h
+++ b/include/mc_rtc/gui/Polyhedron.h
@@ -176,30 +176,42 @@ auto Polyhedron(const std::string & name, const PolyhedronConfig & config, GetTr
 }
 
 /** Helper function to build a PolyhedronVerticesTrianglesImpl */
-template<typename GetVerticesT, typename GetTrianglesT>
-auto Polyhedron(const std::string & name, GetVerticesT get_vertices_fn, GetTrianglesT get_triangles_fn)
+template<typename GetVerticesOrTrianglesT, typename GetTrianglesOrColorsT>
+auto Polyhedron(const std::string & name,
+                GetVerticesOrTrianglesT get_vertices_or_triangles_fn,
+                GetTrianglesOrColorsT get_triangles_or_colors_fn)
 {
-  return details::PolyhedronVerticesTrianglesImpl<GetVerticesT, GetTrianglesT>(name, {}, get_vertices_fn,
-                                                                               get_triangles_fn);
+  if constexpr(details::CheckReturnType<GetVerticesOrTrianglesT, std::vector<std::array<Eigen::Vector3d, 3>>>::value)
+  {
+    auto poly = Polyhedron(name, PolyhedronConfig{}, get_vertices_or_triangles_fn);
+    return details::ColoredPolyhedronImpl<decltype(poly), GetTrianglesOrColorsT>(std::move(poly),
+                                                                                 get_triangles_or_colors_fn);
+  }
+  else
+  {
+    return details::PolyhedronVerticesTrianglesImpl<GetVerticesOrTrianglesT, GetTrianglesOrColorsT>(
+        name, {}, get_vertices_or_triangles_fn, get_triangles_or_colors_fn);
+  }
 }
 
 /** Helper function to build a PolyhedronVerticesTrianglesImpl */
-template<typename GetVerticesT, typename GetTrianglesT>
+template<typename GetVerticesOrTrianglesT, typename GetTrianglesOrColorsT>
 auto Polyhedron(const std::string & name,
                 const PolyhedronConfig & config,
-                GetVerticesT get_vertices_fn,
-                GetTrianglesT get_triangles_fn)
+                GetVerticesOrTrianglesT get_vertices_or_triangles_fn,
+                GetTrianglesOrColorsT get_triangles_or_colors_fn)
 {
-  return details::PolyhedronVerticesTrianglesImpl<GetVerticesT, GetTrianglesT>(name, config, get_vertices_fn,
-                                                                               get_triangles_fn);
-}
-
-/** Helper function to build a ColoredPolyhedronImpl */
-template<typename GetTrianglesT, typename GetColorT>
-auto ColoredPolyhedron(const std::string & name, GetTrianglesT get_triangles_fn, GetColorT get_color_fn)
-{
-  auto poly = Polyhedron(name, get_triangles_fn);
-  return details::ColoredPolyhedronImpl<decltype(poly), GetColorT>(std::move(poly), get_color_fn);
+  if constexpr(details::CheckReturnType<GetVerticesOrTrianglesT, std::vector<std::array<Eigen::Vector3d, 3>>>::value)
+  {
+    auto poly = Polyhedron(name, config, get_vertices_or_triangles_fn);
+    return details::ColoredPolyhedronImpl<decltype(poly), GetTrianglesOrColorsT>(std::move(poly),
+                                                                                 get_triangles_or_colors_fn);
+  }
+  else
+  {
+    return details::PolyhedronVerticesTrianglesImpl<GetVerticesOrTrianglesT, GetTrianglesOrColorsT>(
+        name, config, get_vertices_or_triangles_fn, get_triangles_or_colors_fn);
+  }
 }
 
 /** Helper function to build a ColoredPolyhedronImpl */
@@ -215,10 +227,10 @@ auto ColoredPolyhedron(const std::string & name,
 
 /** Helper function to build a ColoredPolyhedronImpl */
 template<typename GetVerticesT, typename GetTrianglesT, typename GetColorT>
-auto ColoredPolyhedron(const std::string & name,
-                       GetVerticesT get_vertices_fn,
-                       GetTrianglesT get_triangles_fn,
-                       GetColorT get_color_fn)
+auto Polyhedron(const std::string & name,
+                GetVerticesT get_vertices_fn,
+                GetTrianglesT get_triangles_fn,
+                GetColorT get_color_fn)
 {
   auto poly = Polyhedron(name, get_vertices_fn, get_triangles_fn);
   return details::ColoredPolyhedronImpl<decltype(poly), GetColorT>(std::move(poly), get_color_fn);
@@ -226,11 +238,11 @@ auto ColoredPolyhedron(const std::string & name,
 
 /** Helper function to build a ColoredPolyhedronImpl */
 template<typename GetVerticesT, typename GetTrianglesT, typename GetColorT>
-auto ColoredPolyhedron(const std::string & name,
-                       const PolyhedronConfig & config,
-                       GetVerticesT get_vertices_fn,
-                       GetVerticesT get_triangles_fn,
-                       GetColorT get_color_fn)
+auto Polyhedron(const std::string & name,
+                const PolyhedronConfig & config,
+                GetVerticesT get_vertices_fn,
+                GetVerticesT get_triangles_fn,
+                GetColorT get_color_fn)
 {
   auto poly = Polyhedron(name, config, get_vertices_fn, get_triangles_fn);
   return details::ColoredPolyhedronImpl<decltype(poly), GetColorT>(std::move(poly), get_color_fn);

--- a/include/mc_rtc/gui/Polyhedron.h
+++ b/include/mc_rtc/gui/Polyhedron.h
@@ -14,6 +14,8 @@ namespace mc_rtc
 namespace gui
 {
 
+namespace details
+{
 /** Polyhedron should display a polyhedron or a set of polyhedrons
  *
  * A color is provided to display the polyhedron(s)
@@ -92,39 +94,41 @@ protected:
   GetColorT get_color_fn_;
 };
 
+} // namespace details
+
 /** Helper function to build a PolyhedronImpl */
 template<typename GetVerticesT, typename GetColorT>
-ColoredPolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
-                                                          GetVerticesT get_vertices_fn,
-                                                          GetColorT get_color_fn)
+details::ColoredPolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
+                                                                   GetVerticesT get_vertices_fn,
+                                                                   GetColorT get_color_fn)
 {
-  return ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, {}, get_vertices_fn, get_color_fn);
+  return details::ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, {}, get_vertices_fn, get_color_fn);
 }
 
 /** Helper function to build a PolyhedronImpl */
 template<typename GetVerticesT, typename GetColorT>
-ColoredPolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
-                                                          const PolyhedronConfig & config,
-                                                          GetVerticesT get_vertices_fn,
-                                                          GetColorT get_color_fn)
+details::ColoredPolyhedronImpl<GetVerticesT, GetColorT> Polyhedron(const std::string & name,
+                                                                   const PolyhedronConfig & config,
+                                                                   GetVerticesT get_vertices_fn,
+                                                                   GetColorT get_color_fn)
 {
-  return ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, config, get_vertices_fn, get_color_fn);
+  return details::ColoredPolyhedronImpl<GetVerticesT, GetColorT>(name, config, get_vertices_fn, get_color_fn);
 }
 
 /** Helper function to build a PolyhedronImpl */
 template<typename GetVerticesT>
-PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name, GetVerticesT get_vertices_fn)
+details::PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name, GetVerticesT get_vertices_fn)
 {
-  return PolyhedronImpl<GetVerticesT>(name, {}, get_vertices_fn);
+  return details::PolyhedronImpl<GetVerticesT>(name, {}, get_vertices_fn);
 }
 
 /** Helper function to build a PolyhedronImpl */
 template<typename GetVerticesT>
-PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name,
-                                        const PolyhedronConfig & config,
-                                        GetVerticesT get_vertices_fn)
+details::PolyhedronImpl<GetVerticesT> Polyhedron(const std::string & name,
+                                                 const PolyhedronConfig & config,
+                                                 GetVerticesT get_vertices_fn)
 {
-  return PolyhedronImpl<GetVerticesT>(name, config, get_vertices_fn);
+  return details::PolyhedronImpl<GetVerticesT>(name, config, get_vertices_fn);
 }
 
 } // namespace gui

--- a/include/mc_rtc/gui/Polyhedron.h
+++ b/include/mc_rtc/gui/Polyhedron.h
@@ -241,7 +241,7 @@ template<typename GetVerticesT, typename GetTrianglesT, typename GetColorT>
 auto Polyhedron(const std::string & name,
                 const PolyhedronConfig & config,
                 GetVerticesT get_vertices_fn,
-                GetVerticesT get_triangles_fn,
+                GetTrianglesT get_triangles_fn,
                 GetColorT get_color_fn)
 {
   auto poly = Polyhedron(name, config, get_vertices_fn, get_triangles_fn);

--- a/include/mc_rtc/gui/elements.h
+++ b/include/mc_rtc/gui/elements.h
@@ -42,7 +42,8 @@ enum class Elements
   XYTheta,
   Table,
   Robot,
-  Visual
+  Visual,
+  Polyhedron
 };
 
 /** Element is the common class for every element's type available in the

--- a/include/mc_rtc/gui/elements.h
+++ b/include/mc_rtc/gui/elements.h
@@ -43,7 +43,8 @@ enum class Elements
   Table,
   Robot,
   Visual,
-  Polyhedron
+  PolyhedronTrianglesList,
+  PolyhedronVerticesTriangles
 };
 
 /** Element is the common class for every element's type available in the

--- a/include/mc_rtc/gui/types.h
+++ b/include/mc_rtc/gui/types.h
@@ -20,6 +20,8 @@ struct MC_RTC_GUI_DLLAPI Color
 {
   Color() {}
   Color(double r, double g, double b, double a = 1.0) : r(r), g(g), b(b), a(a) {}
+  Color(const Eigen::Vector3d & color) : r(color.x()), g(color.y()), b(color.z()) {}
+  Color(const Eigen::Vector4d & color) : r(color.x()), g(color.y()), b(color.z()), a(color[3]) {}
   Color(const mc_rtc::Configuration & config)
   {
     fromConfig(config);
@@ -458,9 +460,6 @@ struct ConfigurationLoader<mc_rtc::gui::PointConfig>
 
 namespace gui
 {
-
-using PolyhedronTriangles = std::vector<Eigen::Vector3d>;
-using PolyhedronColors = std::vector<Eigen::Vector4d>;
 
 struct MC_RTC_GUI_DLLAPI PolyhedronConfig
 {

--- a/include/mc_rtc/gui/types.h
+++ b/include/mc_rtc/gui/types.h
@@ -455,4 +455,114 @@ struct ConfigurationLoader<mc_rtc::gui::PointConfig>
     return point.saveConfig();
   }
 };
+
+namespace gui
+{
+
+using PolyhedronTriangles = std::vector<Eigen::Vector3d>;
+using PolyhedronColors = std::vector<Eigen::Vector4d>;
+
+struct MC_RTC_GUI_DLLAPI PolyhedronConfig
+{
+  PolyhedronConfig() {}
+
+  PolyhedronConfig(const mc_rtc::Configuration & config)
+  {
+    fromConfig(config);
+  }
+
+  void fromConfig(const mc_rtc::Configuration & config)
+  {
+    config("triangle_color", triangle_color);
+    config("show_triangle", show_triangle);
+    config("use_triangle_color", use_triangle_color);
+    config("edges", edge_config);
+    config("show_edges", show_edges);
+    config("fixed_edge_color", fixed_edge_color);
+    config("vertices", vertices_config);
+    config("show_vertices", show_vertices);
+    config("fixed_vertices_color", fixed_vertices_color);
+  }
+
+  mc_rtc::Configuration saveConfig() const
+  {
+    mc_rtc::Configuration conf;
+    conf.add("triangle_color", triangle_color);
+    conf.add("show_triangle", show_triangle);
+    conf.add("use_triangle_color", use_triangle_color);
+    conf.add("edges", edge_config);
+    conf.add("show_edges", show_edges);
+    conf.add("fixed_edge_color", fixed_edge_color);
+    conf.add("vertices", vertices_config);
+    conf.add("show_vertices", show_vertices);
+    conf.add("fixed_vertices_color", fixed_vertices_color);
+    return conf;
+  }
+
+  void fromMessagePack(const mc_rtc::Configuration & config)
+  {
+    triangle_color.fromMessagePack(config[0]);
+    show_triangle = config[1];
+    use_triangle_color = config[2];
+    edge_config.fromMessagePack(config[3]);
+    show_edges = config[4];
+    fixed_edge_color = config[5];
+    vertices_config.fromMessagePack(config[6]);
+    show_vertices = config[7];
+    fixed_vertices_color = config[8];
+  }
+
+  static constexpr size_t write_size()
+  {
+    return 1;
+  }
+
+  void write(mc_rtc::MessagePackBuilder & out) const
+  {
+    out.start_array(9);
+    triangle_color.write(out);
+    out.write(show_triangle);
+    out.write(use_triangle_color);
+
+    edge_config.write(out);
+    out.write(show_edges);
+    out.write(fixed_edge_color);
+
+    vertices_config.write(out);
+    out.write(show_vertices);
+    out.write(fixed_vertices_color);
+    out.finish_array();
+  }
+
+  Color triangle_color; ///< Default triangle face color
+  bool show_triangle = true;
+  bool use_triangle_color =
+      false; ///< When true, use triangle face color from triangle_color. Else interpolate between each vertex color
+  LineConfig edge_config;
+  bool show_edges = true;
+  bool fixed_edge_color =
+      true; ///< When true, use edge colors from edges_config. Else interpolate between each vertex color
+  PointConfig vertices_config;
+  bool show_vertices = true;
+  bool fixed_vertices_color = true; ///< When true, use vertices colors from vertices_config. Else use the vertex color
+                                    ///< passed along with the triangles
+};
+} // namespace gui
+
+template<>
+struct ConfigurationLoader<mc_rtc::gui::PolyhedronConfig>
+{
+  static mc_rtc::gui::PolyhedronConfig load(const mc_rtc::Configuration & config)
+  {
+    mc_rtc::gui::PolyhedronConfig polyhedron;
+    polyhedron.fromConfig(config);
+    return polyhedron;
+  }
+
+  static mc_rtc::Configuration save(const mc_rtc::gui::PolyhedronConfig & polyhedron)
+  {
+    return polyhedron.saveConfig();
+  }
+};
+
 } // namespace mc_rtc

--- a/include/mc_rtc/gui/types.h
+++ b/include/mc_rtc/gui/types.h
@@ -533,18 +533,20 @@ struct MC_RTC_GUI_DLLAPI PolyhedronConfig
     out.finish_array();
   }
 
-  Color triangle_color; ///< Default triangle face color
+  ///< Default triangle face color
+  Color triangle_color;
   bool show_triangle = true;
-  bool use_triangle_color =
-      false; ///< When true, use triangle face color from triangle_color. Else interpolate between each vertex color
+  ///< When true, use triangle face color from triangle_color. Else interpolate between each vertex color
+  bool use_triangle_color = false;
   LineConfig edge_config;
   bool show_edges = true;
-  bool fixed_edge_color =
-      true; ///< When true, use edge colors from edges_config. Else interpolate between each vertex color
+  ///< When true, use edge colors from edges_config. Else interpolate between each vertex color
+  bool fixed_edge_color = true;
   PointConfig vertices_config;
   bool show_vertices = true;
-  bool fixed_vertices_color = true; ///< When true, use vertices colors from vertices_config. Else use the vertex color
-                                    ///< passed along with the triangles
+  ///< When true, use vertices colors from vertices_config. Else use the vertex color
+  ///< passed along with the triangles
+  bool fixed_vertices_color = true;
 };
 } // namespace gui
 

--- a/include/mc_rtc/utils/heatmap.h
+++ b/include/mc_rtc/utils/heatmap.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <Eigen/Core>
+
+namespace mc_rtc
+{
+namespace utils
+{
+
+/**
+ * @brief Compute rgb heatmap colors expressed between 0 and 1
+ *
+ * Minimum value is represented as pure blue
+ * Maximum value is represented as pure red
+ * In-between values vary between blue and red
+ *
+ * @param minimum Minimum value that the heatmap should represent
+ * @param maximum Maximum value that the heatmap should represent
+ * @param value Current value in [minimum, maximum] range. Values outside of
+ * this range will be displayed as either blue or red.
+ *
+ * @return [r,g,b] values
+ */
+template<typename T>
+T heatmap(double minimum, double maximum, double value)
+{
+  if(value > maximum)
+  {
+    return {1, 0, 0};
+  }
+  if(value < minimum)
+  {
+    return {0, 0, 1};
+  }
+
+  const auto ratio = 2 * (value - minimum) / (maximum - minimum);
+  const auto b = std::max(0., (1 - ratio));
+  const auto r = std::max(0., (ratio - 1));
+  const auto g = 1 - b - r;
+  return {r, g, b};
+}
+
+} // namespace utils
+} // namespace mc_rtc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -124,6 +124,7 @@ set(mc_rtc_utils_HDR
   ../include/mc_rtc/deprecated.h
   ../include/mc_rtc/pragma.h
   ../include/mc_rtc/shared.h
+  ../include/mc_rtc/utils/heatmap.h
 )
 
 add_library(mc_rtc_utils SHARED ${mc_rtc_utils_SRC} ${mc_rtc_utils_HDR})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ if(UNIX AND NOT EMSCRIPTEN)
 endif()
 
 macro(install_mc_rtc_lib_common MC_LIB KWD)
+  target_compile_features(${MC_LIB} ${KWD} cxx_std_17)
   target_include_directories(${MC_LIB} INTERFACE $<INSTALL_INTERFACE:include> $<BUILD_INTERFACE:${MC_RTC_INCLUDE_DIR}>)
   if(MSVC)
     target_compile_options(${MC_LIB} ${KWD} /source-charset:utf-8)

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -392,6 +392,9 @@ void ControllerClient::handle_widget(const ElementId & id, const mc_rtc::Configu
       case Elements::Polygon:
         handle_polygon(id, data);
         break;
+      case Elements::Polyhedron:
+        handle_polyhedron(id, data);
+        break;
       case Elements::Force:
         handle_force(id, data);
         break;
@@ -555,6 +558,39 @@ void ControllerClient::handle_polygon(const ElementId & id, const mc_rtc::Config
       exc.silence();
     }
   }
+}
+
+void ControllerClient::handle_polyhedron(const ElementId & id, const mc_rtc::Configuration & data_)
+{
+  mc_rtc::gui::PolyhedronConfig config;
+  if(data_.size() > 5)
+  {
+    config.fromMessagePack(data_[5]);
+  }
+
+  std::vector<Eigen::Vector3d> triangles;
+  std::vector<Eigen::Vector4d> colors;
+  try
+  {
+    triangles = data_[3];
+  }
+  catch(mc_rtc::Configuration::Exception & exc)
+  {
+    mc_rtc::log::error("Could not deserialize polyhedron vertices, supported data is vector<Eigen::Vector3d>");
+    mc_rtc::log::error(exc.what());
+    exc.silence();
+  }
+  try
+  {
+    colors = data_[4];
+  }
+  catch(mc_rtc::Configuration::Exception & exc)
+  {
+    mc_rtc::log::error("Could not deserialize polyhedron colors, supported data is vector<Eigen::Vector4d>");
+    mc_rtc::log::error(exc.what());
+    exc.silence();
+  }
+  polyhedron(id, triangles, colors, config);
 }
 
 void ControllerClient::handle_force(const ElementId & id, const mc_rtc::Configuration & data)

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -569,7 +569,7 @@ void ControllerClient::handle_polyhedron(const ElementId & id, const mc_rtc::Con
   }
 
   std::vector<Eigen::Vector3d> triangles;
-  std::vector<Eigen::Vector4d> colors;
+  std::vector<mc_rtc::gui::Color> colors;
   try
   {
     triangles = data_[3];

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -392,8 +392,11 @@ void ControllerClient::handle_widget(const ElementId & id, const mc_rtc::Configu
       case Elements::Polygon:
         handle_polygon(id, data);
         break;
-      case Elements::Polyhedron:
-        handle_polyhedron(id, data);
+      case Elements::PolyhedronTrianglesList:
+        handle_polyhedron_triangles_list(id, data);
+        break;
+      case Elements::PolyhedronVerticesTriangles:
+        handle_polyhedron_vertices_triangles(id, data);
         break;
       case Elements::Force:
         handle_force(id, data);
@@ -451,6 +454,72 @@ void ControllerClient::default_impl(const std::string & type, const ElementId & 
 {
   mc_rtc::log::warning("This implementation of ControllerClient does not handle {} GUI needed by {}/{}", type,
                        cat2str(id.category), id.name);
+}
+
+void ControllerClient::polyhedron(const ElementId & id,
+                                  const std::vector<std::array<Eigen::Vector3d, 3>> & triangles,
+                                  const std::vector<std::array<mc_rtc::gui::Color, 3>> & colors,
+                                  const mc_rtc::gui::PolyhedronConfig & config)
+{
+  // The default other polyhedron implementation was called and this is also the default implementation, we are running
+  // in circle
+  if(default_polyhedron_vertices_triangles_)
+  {
+    default_impl("Polyhedron", id);
+    return;
+  }
+  // Otherwise we transform this call for the other implementation
+  default_polyhedron_triangles_list_ = true;
+  std::vector<Eigen::Vector3d> vertices;
+  vertices.reserve(3 * triangles.size());
+  std::vector<std::array<size_t, 3>> indices;
+  indices.reserve(triangles.size());
+  for(size_t i = 0; i < triangles.size(); ++i)
+  {
+    vertices.push_back(triangles[i][0]);
+    vertices.push_back(triangles[i][1]);
+    vertices.push_back(triangles[i][2]);
+    indices.push_back({3 * i, 3 * i + 1, 3 * i + 2});
+  }
+  std::vector<mc_rtc::gui::Color> vertices_colors;
+  vertices_colors.reserve(3 * colors.size());
+  for(const auto & c : colors)
+  {
+    vertices_colors.push_back(c[0]);
+    vertices_colors.push_back(c[1]);
+    vertices_colors.push_back(c[2]);
+  }
+  polyhedron(id, vertices, indices, vertices_colors, config);
+}
+
+void ControllerClient::polyhedron(const ElementId & id,
+                                  const std::vector<Eigen::Vector3d> & vertices,
+                                  const std::vector<std::array<size_t, 3>> & indices,
+                                  const std::vector<mc_rtc::gui::Color> & colors,
+                                  const mc_rtc::gui::PolyhedronConfig & config)
+{
+  // The default other polyhedron implementation was called and this is also the default implementation, we are running
+  // in circle
+  if(default_polyhedron_triangles_list_)
+  {
+    default_impl("Polyhedron", id);
+    return;
+  }
+  // Otherwise we transform this call for the other implementation
+  default_polyhedron_vertices_triangles_ = true;
+  std::vector<std::array<Eigen::Vector3d, 3>> triangles;
+  triangles.reserve(indices.size());
+  for(const auto & idx : indices)
+  {
+    triangles.push_back({vertices[idx[0]], vertices[idx[1]], vertices[idx[2]]});
+  }
+  std::vector<std::array<mc_rtc::gui::Color, 3>> triangle_colors;
+  triangle_colors.reserve(indices.size());
+  for(const auto & idx : indices)
+  {
+    triangle_colors.push_back({colors[idx[0]], colors[idx[1]], colors[idx[2]]});
+  }
+  polyhedron(id, triangles, triangle_colors, config);
 }
 
 void ControllerClient::handle_point3d(const ElementId & id, const mc_rtc::Configuration & data)
@@ -560,13 +629,9 @@ void ControllerClient::handle_polygon(const ElementId & id, const mc_rtc::Config
   }
 }
 
-void ControllerClient::handle_polyhedron(const ElementId & id, const mc_rtc::Configuration & data_)
+void ControllerClient::handle_polyhedron_triangles_list(const ElementId & id, const mc_rtc::Configuration & data_)
 {
-  mc_rtc::gui::PolyhedronConfig config;
-  if(data_.size() > 5)
-  {
-    config.fromMessagePack(data_[5]);
-  }
+  mc_rtc::gui::PolyhedronConfig config(data_[4]);
 
   std::vector<std::array<Eigen::Vector3d, 3>> triangles;
   std::vector<std::array<mc_rtc::gui::Color, 3>> colors;
@@ -580,19 +645,81 @@ void ControllerClient::handle_polyhedron(const ElementId & id, const mc_rtc::Con
         "Could not deserialize polyhedron vertices, supported data is vector<std::array<Eigen::Vector3d, 3>>");
     mc_rtc::log::error(exc.what());
     exc.silence();
+    return;
   }
+  if(data_.size() > 5)
+  {
+    try
+    {
+      colors = data_[5];
+    }
+    catch(mc_rtc::Configuration::Exception & exc)
+    {
+      mc_rtc::log::error(
+          "Could not deserialize polyhedron colors, supported data is vector<std::array<mc_rtc::gui::Color,3>>");
+      mc_rtc::log::error(exc.what());
+      exc.silence();
+    }
+    if(colors.size() != 0 && colors.size() != triangles.size())
+    {
+      mc_rtc::log::error("{}/{} is not providing enough color data (expected: {}, got: {})", cat2str(id.category),
+                         id.name, triangles.size(), colors.size());
+      return;
+    }
+  }
+  polyhedron(id, triangles, colors, config);
+}
+
+void ControllerClient::handle_polyhedron_vertices_triangles(const ElementId & id, const mc_rtc::Configuration & data_)
+{
+  mc_rtc::gui::PolyhedronConfig config(data_[5]);
+
+  std::vector<Eigen::Vector3d> vertices;
   try
   {
-    colors = data_[4];
+    vertices = data_[3];
   }
   catch(mc_rtc::Configuration::Exception & exc)
   {
-    mc_rtc::log::error(
-        "Could not deserialize polyhedron colors, supported data is vector<std::array<mc_rtc::gui::Color,3>>");
+    mc_rtc::log::error("Could not deserialize polyhedron vertices, expecting a list of vertices");
     mc_rtc::log::error(exc.what());
     exc.silence();
+    return;
   }
-  polyhedron(id, triangles, colors, config);
+  std::vector<std::array<size_t, 3>> indices;
+  try
+  {
+    indices = data_[4];
+  }
+  catch(mc_rtc::Configuration::Exception & exc)
+  {
+    mc_rtc::log::error("Could not deserialize polyhedron triangles, expecting a list of indices");
+    mc_rtc::log::error(exc.what());
+    exc.silence();
+    return;
+  }
+  std::vector<mc_rtc::gui::Color> colors;
+  if(data_.size() > 5)
+  {
+    try
+    {
+      colors = data_[5];
+    }
+    catch(mc_rtc::Configuration::Exception & exc)
+    {
+      mc_rtc::log::error(
+          "Could not deserialize polyhedron colors, supported data is vector<std::array<mc_rtc::gui::Color,3>>");
+      mc_rtc::log::error(exc.what());
+      exc.silence();
+    }
+    if(colors.size() != 0 && colors.size() != vertices.size())
+    {
+      mc_rtc::log::error("{}/{} is not providing enough color data (expected: {}, got: {})", cat2str(id.category),
+                         id.name, vertices.size(), colors.size());
+      return;
+    }
+  }
+  polyhedron(id, vertices, indices, colors, config);
 }
 
 void ControllerClient::handle_force(const ElementId & id, const mc_rtc::Configuration & data)

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -699,16 +699,15 @@ void ControllerClient::handle_polyhedron_vertices_triangles(const ElementId & id
     return;
   }
   std::vector<mc_rtc::gui::Color> colors;
-  if(data_.size() > 5)
+  if(data_.size() > 6)
   {
     try
     {
-      colors = data_[5];
+      colors = data_[6];
     }
     catch(mc_rtc::Configuration::Exception & exc)
     {
-      mc_rtc::log::error(
-          "Could not deserialize polyhedron colors, supported data is vector<std::array<mc_rtc::gui::Color,3>>");
+      mc_rtc::log::error("Could not deserialize polyhedron colors, supported data is std::vector<mc_rtc::gui::Color>");
       mc_rtc::log::error(exc.what());
       exc.silence();
     }

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -568,15 +568,16 @@ void ControllerClient::handle_polyhedron(const ElementId & id, const mc_rtc::Con
     config.fromMessagePack(data_[5]);
   }
 
-  std::vector<Eigen::Vector3d> triangles;
-  std::vector<mc_rtc::gui::Color> colors;
+  std::vector<std::array<Eigen::Vector3d, 3>> triangles;
+  std::vector<std::array<mc_rtc::gui::Color, 3>> colors;
   try
   {
     triangles = data_[3];
   }
   catch(mc_rtc::Configuration::Exception & exc)
   {
-    mc_rtc::log::error("Could not deserialize polyhedron vertices, supported data is vector<Eigen::Vector3d>");
+    mc_rtc::log::error(
+        "Could not deserialize polyhedron vertices, supported data is vector<std::array<Eigen::Vector3d, 3>>");
     mc_rtc::log::error(exc.what());
     exc.silence();
   }
@@ -586,7 +587,8 @@ void ControllerClient::handle_polyhedron(const ElementId & id, const mc_rtc::Con
   }
   catch(mc_rtc::Configuration::Exception & exc)
   {
-    mc_rtc::log::error("Could not deserialize polyhedron colors, supported data is vector<Eigen::Vector4d>");
+    mc_rtc::log::error(
+        "Could not deserialize polyhedron colors, supported data is vector<std::array<mc_rtc::gui::Color,3>>");
     mc_rtc::log::error(exc.what());
     exc.silence();
   }

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -339,6 +339,17 @@ Configuration::operator Eigen::Vector3d() const
   throw Exception("Stored Json value is not a Vector3d", v);
 }
 
+Configuration::operator Eigen::Vector4d() const
+{
+  if(v.isArray() && v.size() == 4 && v[0].isNumeric())
+  {
+    Eigen::Vector4d ret;
+    ret << v[0].asDouble(), v[1].asDouble(), v[2].asDouble(), v[3].asDouble();
+    return ret;
+  }
+  throw Exception("Stored Json value is not a Vector4d", v);
+}
+
 Configuration::operator Eigen::Vector6d() const
 {
   if(v.isArray() && v.size() == 6 && v[0].isNumeric())

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -883,6 +883,7 @@ void Configuration::add(const std::string & key, const char * value) { add(key, 
 void Configuration::add(const std::string & key, const std::string & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
 void Configuration::add(const std::string & key, const Eigen::Vector2d & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
 void Configuration::add(const std::string & key, const Eigen::Vector3d & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, const Eigen::Vector4d & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
 void Configuration::add(const std::string & key, const Eigen::Vector6d & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
 void Configuration::add(const std::string & key, const Eigen::VectorXd & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
 void Configuration::add(const std::string & key, const Eigen::Quaterniond & value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
@@ -991,6 +992,7 @@ void Configuration::push(const char * value) { push(std::string(value)); }
 void Configuration::push(const std::string & value) { push_impl(*this, value, v.value_, v.doc_.get()); }
 void Configuration::push(const Eigen::Vector2d & value) { push_impl(*this, value, v.value_, v.doc_.get()); }
 void Configuration::push(const Eigen::Vector3d & value) { push_impl(*this, value, v.value_, v.doc_.get()); }
+void Configuration::push(const Eigen::Vector4d & value) { push_impl(*this, value, v.value_, v.doc_.get()); }
 void Configuration::push(const Eigen::Vector6d & value) { push_impl(*this, value, v.value_, v.doc_.get()); }
 void Configuration::push(const Eigen::VectorXd & value) { push_impl(*this, value, v.value_, v.doc_.get()); }
 void Configuration::push(const Eigen::Quaterniond & value) { push_impl(*this, value, v.value_, v.doc_.get()); }

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -251,7 +251,39 @@ Configuration::operator bool() const
   throw Exception("Stored Json value is not a bool", v);
 }
 
-Configuration::operator int() const
+Configuration::operator int8_t() const
+{
+  assert(v.value_);
+  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  if(value->IsInt())
+  {
+    int32_t i = value->GetInt();
+    if(i >= std::numeric_limits<int8_t>::min() && i <= std::numeric_limits<int8_t>::max())
+    {
+      return static_cast<int8_t>(i);
+    }
+    throw Exception("Stored Json value is too large or too small for an int8_t", v);
+  }
+  throw Exception("Stored Json value is not an int", v);
+}
+
+Configuration::operator int16_t() const
+{
+  assert(v.value_);
+  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  if(value->IsInt())
+  {
+    int32_t i = value->GetInt();
+    if(i >= std::numeric_limits<int16_t>::min() && i <= std::numeric_limits<int16_t>::max())
+    {
+      return static_cast<int16_t>(i);
+    }
+    throw Exception("Stored Json value is too large or too small for an int16_t", v);
+  }
+  throw Exception("Stored Json value is not an int", v);
+}
+
+Configuration::operator int32_t() const
 {
   assert(v.value_);
   auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
@@ -259,18 +291,7 @@ Configuration::operator int() const
   {
     return value->GetInt();
   }
-  throw Exception("Stored Json value is not an int", v);
-}
-
-Configuration::operator unsigned int() const
-{
-  assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
-  if(value->IsUint() || (value->IsInt() && value->GetInt() >= 0))
-  {
-    return value->GetUint();
-  }
-  throw Exception("Stored Json value is not an unsigned int", v);
+  throw Exception("Stored Json value is not an int32_t", v);
 }
 
 Configuration::operator int64_t() const
@@ -282,6 +303,49 @@ Configuration::operator int64_t() const
     return value->GetInt64();
   }
   throw Exception("Stored Json value is not an int64_t", v);
+}
+
+Configuration::operator uint8_t() const
+{
+  assert(v.value_);
+  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  if(value->IsUint())
+  {
+    uint32_t i = value->GetUint();
+    if(i <= std::numeric_limits<uint8_t>::max())
+    {
+      return static_cast<uint8_t>(i);
+    }
+    throw Exception("Stored Json value is too large or too small for an uint8_t", v);
+  }
+  throw Exception("Stored Json value is not an uint", v);
+}
+
+Configuration::operator uint16_t() const
+{
+  assert(v.value_);
+  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  if(value->IsUint())
+  {
+    uint32_t i = value->GetUint();
+    if(i <= std::numeric_limits<uint16_t>::max())
+    {
+      return static_cast<uint16_t>(i);
+    }
+    throw Exception("Stored Json value is too large or too small for an uint16_t", v);
+  }
+  throw Exception("Stored Json value is not an uint", v);
+}
+
+Configuration::operator uint32_t() const
+{
+  assert(v.value_);
+  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  if(value->IsUint())
+  {
+    return value->GetUint();
+  }
+  throw Exception("Stored Json value is not an uint32_t", v);
 }
 
 Configuration::operator uint64_t() const
@@ -874,8 +938,12 @@ void Configuration::push_null()
 
 // clang-format off
 void Configuration::add(const std::string & key, bool value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, int value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
-void Configuration::add(const std::string & key, unsigned int value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, int8_t value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, uint8_t value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, int16_t value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, uint16_t value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, int32_t value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
+void Configuration::add(const std::string & key, uint32_t value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
 void Configuration::add(const std::string & key, int64_t value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
 void Configuration::add(const std::string & key, uint64_t value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
 void Configuration::add(const std::string & key, double value) { add_impl(*this, key, value, v.value_, v.doc_.get()); }
@@ -983,8 +1051,12 @@ Configuration Configuration::object()
 
 // clang-format off
 void Configuration::push(bool value) { push_impl(*this, value, v.value_, v.doc_.get()); }
-void Configuration::push(int value) { push_impl(*this, value, v.value_, v.doc_.get()); }
-void Configuration::push(unsigned int value) { push_impl(*this, value, v.value_, v.doc_.get()); }
+void Configuration::push(int8_t value) { push_impl(*this, value, v.value_, v.doc_.get()); }
+void Configuration::push(uint8_t value) { push_impl(*this, value, v.value_, v.doc_.get()); }
+void Configuration::push(int16_t value) { push_impl(*this, value, v.value_, v.doc_.get()); }
+void Configuration::push(uint16_t value) { push_impl(*this, value, v.value_, v.doc_.get()); }
+void Configuration::push(int32_t value) { push_impl(*this, value, v.value_, v.doc_.get()); }
+void Configuration::push(uint32_t value) { push_impl(*this, value, v.value_, v.doc_.get()); }
 void Configuration::push(int64_t value) { push_impl(*this, value, v.value_, v.doc_.get()); }
 void Configuration::push(uint64_t value) { push_impl(*this, value, v.value_, v.doc_.get()); }
 void Configuration::push(double value) { push_impl(*this, value, v.value_, v.doc_.get()); }

--- a/src/mc_rtc/MessagePackBuilder.cpp
+++ b/src/mc_rtc/MessagePackBuilder.cpp
@@ -200,6 +200,13 @@ void MessagePackBuilder::write(const Eigen::Vector3d & v)
   finish_array();
 }
 
+void MessagePackBuilder::write(const Eigen::Vector4d & v)
+{
+  start_array(4);
+  write_vector(impl_.get(), v);
+  finish_array();
+}
+
 void MessagePackBuilder::write(const Eigen::Vector6d & v)
 {
   start_array(6);

--- a/src/mc_rtc/internals/json.h
+++ b/src/mc_rtc/internals/json.h
@@ -389,6 +389,18 @@ inline RapidJSONValue toJSON(const Eigen::Vector3d & value, RapidJSONDocument::A
 }
 
 template<>
+inline RapidJSONValue toJSON(const Eigen::Vector4d & value, RapidJSONDocument::AllocatorType & allocator)
+{
+  RapidJSONValue ret(rapidjson::kArrayType);
+  ret.Reserve(4, allocator);
+  ret.PushBack(value(0), allocator);
+  ret.PushBack(value(1), allocator);
+  ret.PushBack(value(2), allocator);
+  ret.PushBack(value(3), allocator);
+  return ret;
+}
+
+template<>
 inline RapidJSONValue toJSON(const Eigen::Vector6d & value, RapidJSONDocument::AllocatorType & allocator)
 {
   RapidJSONValue ret(rapidjson::kArrayType);

--- a/tests/dummyServer.cpp
+++ b/tests/dummyServer.cpp
@@ -560,8 +560,9 @@ TestServer::TestServer() : xythetaz_(4)
   pconfig.fixed_edge_color = true;
   pconfig.edge_config.color = mc_rtc::gui::Color::LightGray;
   pconfig.edge_config.width = 0.03;
-  builder.addElement({"GUI Markers", "Polyhedrons"},
-                     mc_rtc::gui::Polyhedron("Polyhedron", pconfig, polyhedron_vertices_fn, polyhedron_colors_fn));
+  builder.addElement(
+      {"GUI Markers", "Polyhedrons"},
+      mc_rtc::gui::ColoredPolyhedron("Polyhedron", pconfig, polyhedron_vertices_fn, polyhedron_colors_fn));
 
   builder.addElement(
       {"GUI Markers", "Trajectories"}, mc_rtc::gui::Trajectory("Vector3d", [this]() { return trajectory_; }),

--- a/tests/dummyServer.cpp
+++ b/tests/dummyServer.cpp
@@ -5,6 +5,7 @@
 #include <mc_control/ControllerServer.h>
 
 #include <mc_rtc/gui.h>
+#include <mc_rtc/utils/heatmap.h>
 
 #include <SpaceVecAlg/Conversions.h>
 
@@ -540,31 +541,10 @@ TestServer::TestServer() : xythetaz_(4)
                                             {-1, -1, 0}};
   };
 
-  auto rgbColorMap = [](double minimum, double maximum, double value) {
-    Eigen::Vector3d rgb;
-    if(value > maximum)
-    {
-      rgb << 1, 0, 0;
-      return rgb;
-    }
-    if(value < minimum)
-    {
-      rgb << 0, 0, 0;
-      return rgb;
-    }
-
-    const auto ratio = 2 * (value - minimum) / (maximum - minimum);
-    const auto b = std::max(0., (1 - ratio));
-    const auto r = std::max(0., (ratio - 1));
-    const auto g = 1 - b - r;
-    rgb << r, g, b;
-    return rgb;
-  };
-
-  auto polyhedron_colors_fn = [this, rgbColorMap] {
+  auto polyhedron_colors_fn = [this] {
     double z = std::max(0.1, (1 + cos(t_ / 2)) / 2);
     Eigen::Vector4d color;
-    color << rgbColorMap(0, 1, z), 1;
+    color << mc_rtc::utils::heatmap<Eigen::Vector3d>(0, 1, z), 1;
     return mc_rtc::gui::PolyhedronColors{{0, 0, 1, 1},
                                          {0, 0, 1, 1},
                                          color,

--- a/tests/dummyServer.cpp
+++ b/tests/dummyServer.cpp
@@ -256,6 +256,58 @@ struct TestServer
   std::vector<Eigen::Vector3d> polygon_;
   std::vector<Eigen::Vector3d> polygonColor_;
   std::vector<Eigen::Vector3d> polygonLineConfig_;
+  mc_rtc::gui::PolyhedronTriangles polyhedron_vertices_{// Upper pyramid
+                                                        {-1, -1, 0},
+                                                        {1, -1, 0},
+                                                        {0, 0, 1},
+                                                        {1, -1, 0},
+                                                        {1, 1, 0},
+                                                        {0, 0, 1},
+                                                        {1, 1, 0},
+                                                        {-1, 1, 0},
+                                                        {0, 0, 1},
+                                                        {-1, 1, 0},
+                                                        {-1, -1, 0},
+                                                        {0, 0, 1},
+                                                        // Lower pyramid
+                                                        {-1, -1, 0},
+                                                        {0, 0, -1},
+                                                        {1, -1, 0},
+                                                        {1, -1, 0},
+                                                        {0, 0, -1},
+                                                        {1, 1, 0},
+                                                        {1, 1, 0},
+                                                        {0, 0, -1},
+                                                        {-1, 1, 0},
+                                                        {-1, 1, 0},
+                                                        {0, 0, -1},
+                                                        {-1, -1, 0}};
+  mc_rtc::gui::PolyhedronColors polyhedron_colors_{// Colors for upper pyramid
+                                                   {1, 0, 0, 0.5},
+                                                   {1, 0, 0, 0.5},
+                                                   {1, 0, 0, 0.8},
+                                                   {0, 1, 0, 0.5},
+                                                   {0, 1, 0, 0.5},
+                                                   {0, 1, 0, 0.8},
+                                                   {0, 0, 1, 0.5},
+                                                   {0, 0, 1, 0.5},
+                                                   {0, 0, 1, 0.8},
+                                                   {1, 0, 1, 0.5},
+                                                   {1, 0, 1, 0.5},
+                                                   {1, 0, 1, 0.8},
+                                                   // Colors for lower pyramid
+                                                   {1, 0, 0, 0.5},
+                                                   {0, 1, 0, 0.5},
+                                                   {0, 0, 1, 0.5},
+                                                   {1, 0, 0, 0.5},
+                                                   {0, 1, 0, 0.5},
+                                                   {0, 0, 1, 0.5},
+                                                   {1, 0, 0, 0.5},
+                                                   {0, 1, 0, 0.5},
+                                                   {0, 0, 1, 0.5},
+                                                   {1, 0, 0, 0.5},
+                                                   {0, 1, 0, 0.5},
+                                                   {0, 0, 1, 0.5}};
   std::vector<std::vector<Eigen::Vector3d>> polygons_;
   std::vector<std::vector<Eigen::Vector3d>> polygonsColor_;
   std::vector<std::vector<Eigen::Vector3d>> polygonsLineConfig_;
@@ -509,6 +561,18 @@ TestServer::TestServer() : xythetaz_(4)
                      mc_rtc::gui::Polygon("Polygons", [this]() { return polygons_; }),
                      mc_rtc::gui::Polygon("Polygons (color)", orange, [this]() { return polygonsColor_; }),
                      mc_rtc::gui::Polygon("Polygons (config)", pstyle, [this]() { return polygonsLineConfig_; }));
+
+  mc_rtc::gui::PolyhedronConfig pconfig;
+  pconfig.triangle_color = mc_rtc::gui::Color::Red;
+  pconfig.use_triangle_color = false;
+  pconfig.show_triangle = false;
+  pconfig.show_vertices = false;
+  pconfig.show_edges = true;
+  pconfig.fixed_edge_color = false;
+  builder.addElement(
+      {"GUI Markers", "Polyhedrons"},
+      mc_rtc::gui::Polyhedron(
+          "Polyhedron", pconfig, [this]() { return polyhedron_vertices_; }, [this] { return polyhedron_colors_; }));
 
   builder.addElement(
       {"GUI Markers", "Trajectories"}, mc_rtc::gui::Trajectory("Vector3d", [this]() { return trajectory_; }),

--- a/tests/dummyServer.cpp
+++ b/tests/dummyServer.cpp
@@ -513,63 +513,43 @@ TestServer::TestServer() : xythetaz_(4)
 
   auto polyhedron_vertices_fn = [this] {
     double z = std::max(0.1, (1 + cos(t_ / 2)) / 2);
-    return std::vector<Eigen::Vector3d>{// Upper pyramid
-                                        {-1, -1, 0},
-                                        {1, -1, 0},
-                                        {0, 0, z},
-                                        {1, -1, 0},
-                                        {1, 1, 0},
-                                        {0, 0, z},
-                                        {1, 1, 0},
-                                        {-1, 1, 0},
-                                        {0, 0, z},
-                                        {-1, 1, 0},
-                                        {-1, -1, 0},
-                                        {0, 0, z},
-                                        // Lower pyramid
-                                        {-1, -1, 0},
-                                        {0, 0, -z},
-                                        {1, -1, 0},
-                                        {1, -1, 0},
-                                        {0, 0, -z},
-                                        {1, 1, 0},
-                                        {1, 1, 0},
-                                        {0, 0, -z},
-                                        {-1, 1, 0},
-                                        {-1, 1, 0},
-                                        {0, 0, -z},
-                                        {-1, -1, 0}};
+    // clang-format off
+    return std::vector<std::array<Eigen::Vector3d, 3>>
+    {
+      // Upper pyramid
+      {{ {-1, -1, 0}, {1, -1, 0}, {0, 0, z} }},
+      {{ {1, -1, 0}, {1, 1, 0}, {0, 0, z} }},
+      {{ {1, 1, 0}, {-1, 1, 0}, {0, 0, z} }},
+      {{ {-1, 1, 0}, {-1, -1, 0}, {0, 0, z} }},
+      // Lower pyramid
+      {{ {-1, -1, 0}, {0, 0, -z}, {1, -1, 0} }},
+      {{ {1, -1, 0}, {0, 0, -z}, {1, 1, 0} }},
+      {{ {1, 1, 0}, {0, 0, -z}, {-1, 1, 0} }},
+      {{ {-1, 1, 0}, {0, 0, -z}, {-1, -1, 0} }}
+    };
+    // clang-format on
   };
 
   auto polyhedron_colors_fn = [this] {
     double z = std::max(0.1, (1 + cos(t_ / 2)) / 2);
     Eigen::Vector4d color;
     color << mc_rtc::utils::heatmap<Eigen::Vector3d>(0, 1, z), 1;
-    return std::vector<mc_rtc::gui::Color>{{0, 0, 1, 1},
-                                           {0, 0, 1, 1},
-                                           color,
-                                           {0, 0, 1, 1},
-                                           {0, 0, 1, 1},
-                                           color,
-                                           {0, 0, 1, 1},
-                                           {0, 0, 1, 1},
-                                           color,
-                                           {0, 0, 1, 1},
-                                           {0, 0, 1, 1},
-                                           color,
-                                           // Colors for lower pyramid
-                                           {0, 0, 1, 1},
-                                           color,
-                                           {0, 0, 1, 1},
-                                           {0, 0, 1, 1},
-                                           color,
-                                           {0, 0, 1, 1},
-                                           {0, 0, 1, 1},
-                                           color,
-                                           {0, 0, 1, 1},
-                                           {0, 0, 1, 1},
-                                           color,
-                                           {0, 0, 1, 1}};
+    auto blue = mc_rtc::gui::Color{0, 0, 1, 1};
+    // clang-format off
+    return std::vector<std::array<mc_rtc::gui::Color, 3>>
+    {
+      // Colors for upper pyramid
+      {blue, blue, color},
+      {blue, blue, color},
+      {blue, blue, color},
+      {blue, blue, color},
+      // Colors for lower pyramid
+      {blue, color, blue},
+      {blue, color, blue},
+      {blue, color, blue},
+      {blue, color, blue}
+     };
+    // clang-format on
   };
   mc_rtc::gui::PolyhedronConfig pconfig;
   pconfig.triangle_color = mc_rtc::gui::Color(1, 0, 0, 1.0);

--- a/tests/dummyServer.cpp
+++ b/tests/dummyServer.cpp
@@ -560,9 +560,8 @@ TestServer::TestServer() : xythetaz_(4)
   pconfig.fixed_edge_color = true;
   pconfig.edge_config.color = mc_rtc::gui::Color::LightGray;
   pconfig.edge_config.width = 0.03;
-  builder.addElement(
-      {"GUI Markers", "Polyhedrons"},
-      mc_rtc::gui::ColoredPolyhedron("Polyhedron", pconfig, polyhedron_vertices_fn, polyhedron_colors_fn));
+  builder.addElement({"GUI Markers", "Polyhedrons"},
+                     mc_rtc::gui::Polyhedron("Polyhedron", pconfig, polyhedron_vertices_fn, polyhedron_colors_fn));
 
   builder.addElement(
       {"GUI Markers", "Trajectories"}, mc_rtc::gui::Trajectory("Vector3d", [this]() { return trajectory_; }),

--- a/tests/dummyServer.cpp
+++ b/tests/dummyServer.cpp
@@ -256,58 +256,6 @@ struct TestServer
   std::vector<Eigen::Vector3d> polygon_;
   std::vector<Eigen::Vector3d> polygonColor_;
   std::vector<Eigen::Vector3d> polygonLineConfig_;
-  mc_rtc::gui::PolyhedronTriangles polyhedron_vertices_{// Upper pyramid
-                                                        {-1, -1, 0},
-                                                        {1, -1, 0},
-                                                        {0, 0, 1},
-                                                        {1, -1, 0},
-                                                        {1, 1, 0},
-                                                        {0, 0, 1},
-                                                        {1, 1, 0},
-                                                        {-1, 1, 0},
-                                                        {0, 0, 1},
-                                                        {-1, 1, 0},
-                                                        {-1, -1, 0},
-                                                        {0, 0, 1},
-                                                        // Lower pyramid
-                                                        {-1, -1, 0},
-                                                        {0, 0, -1},
-                                                        {1, -1, 0},
-                                                        {1, -1, 0},
-                                                        {0, 0, -1},
-                                                        {1, 1, 0},
-                                                        {1, 1, 0},
-                                                        {0, 0, -1},
-                                                        {-1, 1, 0},
-                                                        {-1, 1, 0},
-                                                        {0, 0, -1},
-                                                        {-1, -1, 0}};
-  mc_rtc::gui::PolyhedronColors polyhedron_colors_{// Colors for upper pyramid
-                                                   {1, 0, 0, 0.5},
-                                                   {1, 0, 0, 0.5},
-                                                   {1, 0, 0, 0.8},
-                                                   {0, 1, 0, 0.5},
-                                                   {0, 1, 0, 0.5},
-                                                   {0, 1, 0, 0.8},
-                                                   {0, 0, 1, 0.5},
-                                                   {0, 0, 1, 0.5},
-                                                   {0, 0, 1, 0.8},
-                                                   {1, 0, 1, 0.5},
-                                                   {1, 0, 1, 0.5},
-                                                   {1, 0, 1, 0.8},
-                                                   // Colors for lower pyramid
-                                                   {1, 0, 0, 0.5},
-                                                   {0, 1, 0, 0.5},
-                                                   {0, 0, 1, 0.5},
-                                                   {1, 0, 0, 0.5},
-                                                   {0, 1, 0, 0.5},
-                                                   {0, 0, 1, 0.5},
-                                                   {1, 0, 0, 0.5},
-                                                   {0, 1, 0, 0.5},
-                                                   {0, 0, 1, 0.5},
-                                                   {1, 0, 0, 0.5},
-                                                   {0, 1, 0, 0.5},
-                                                   {0, 0, 1, 0.5}};
   std::vector<std::vector<Eigen::Vector3d>> polygons_;
   std::vector<std::vector<Eigen::Vector3d>> polygonsColor_;
   std::vector<std::vector<Eigen::Vector3d>> polygonsLineConfig_;
@@ -562,19 +510,98 @@ TestServer::TestServer() : xythetaz_(4)
                      mc_rtc::gui::Polygon("Polygons (color)", orange, [this]() { return polygonsColor_; }),
                      mc_rtc::gui::Polygon("Polygons (config)", pstyle, [this]() { return polygonsLineConfig_; }));
 
+  auto polyhedron_vertices_fn = [this] {
+    double z = std::max(0.1, (1 + cos(t_ / 2)) / 2);
+    return mc_rtc::gui::PolyhedronTriangles{// Upper pyramid
+                                            {-1, -1, 0},
+                                            {1, -1, 0},
+                                            {0, 0, z},
+                                            {1, -1, 0},
+                                            {1, 1, 0},
+                                            {0, 0, z},
+                                            {1, 1, 0},
+                                            {-1, 1, 0},
+                                            {0, 0, z},
+                                            {-1, 1, 0},
+                                            {-1, -1, 0},
+                                            {0, 0, z},
+                                            // Lower pyramid
+                                            {-1, -1, 0},
+                                            {0, 0, -z},
+                                            {1, -1, 0},
+                                            {1, -1, 0},
+                                            {0, 0, -z},
+                                            {1, 1, 0},
+                                            {1, 1, 0},
+                                            {0, 0, -z},
+                                            {-1, 1, 0},
+                                            {-1, 1, 0},
+                                            {0, 0, -z},
+                                            {-1, -1, 0}};
+  };
+
+  auto rgbColorMap = [](double minimum, double maximum, double value) {
+    Eigen::Vector3d rgb;
+    if(value > maximum)
+    {
+      rgb << 1, 0, 0;
+      return rgb;
+    }
+    if(value < minimum)
+    {
+      rgb << 0, 0, 0;
+      return rgb;
+    }
+
+    const auto ratio = 2 * (value - minimum) / (maximum - minimum);
+    const auto b = std::max(0., (1 - ratio));
+    const auto r = std::max(0., (ratio - 1));
+    const auto g = 1 - b - r;
+    rgb << r, g, b;
+    return rgb;
+  };
+
+  auto polyhedron_colors_fn = [this, rgbColorMap] {
+    double z = std::max(0.1, (1 + cos(t_ / 2)) / 2);
+    Eigen::Vector4d color;
+    color << rgbColorMap(0, 1, z), 1;
+    return mc_rtc::gui::PolyhedronColors{{0, 0, 1, 1},
+                                         {0, 0, 1, 1},
+                                         color,
+                                         {0, 0, 1, 1},
+                                         {0, 0, 1, 1},
+                                         color,
+                                         {0, 0, 1, 1},
+                                         {0, 0, 1, 1},
+                                         color,
+                                         {0, 0, 1, 1},
+                                         {0, 0, 1, 1},
+                                         color,
+                                         // Colors for lower pyramid
+                                         {0, 0, 1, 1},
+                                         color,
+                                         {0, 0, 1, 1},
+                                         {0, 0, 1, 1},
+                                         color,
+                                         {0, 0, 1, 1},
+                                         {0, 0, 1, 1},
+                                         color,
+                                         {0, 0, 1, 1},
+                                         {0, 0, 1, 1},
+                                         color,
+                                         {0, 0, 1, 1}};
+  };
   mc_rtc::gui::PolyhedronConfig pconfig;
-  pconfig.triangle_color = mc_rtc::gui::Color::Red;
+  pconfig.triangle_color = mc_rtc::gui::Color(1, 0, 0, 1.0);
   pconfig.use_triangle_color = false;
-  pconfig.show_triangle = false;
-  pconfig.show_vertices = false;
+  pconfig.show_triangle = true;
+  pconfig.show_vertices = true;
   pconfig.show_edges = true;
-  pconfig.fixed_edge_color = false;
-  builder.addElement(
-      {"GUI Markers", "Polyhedrons"},
-      mc_rtc::gui::Polyhedron(
-          "Polyhedron (colors)", pconfig, [this]() { return polyhedron_vertices_; },
-          [this] { return polyhedron_colors_; }),
-      mc_rtc::gui::Polyhedron("Polyhedron (no color)", pconfig, [this]() { return polyhedron_vertices_; }));
+  pconfig.fixed_edge_color = true;
+  pconfig.edge_config.color = mc_rtc::gui::Color::LightGray;
+  pconfig.edge_config.width = 0.03;
+  builder.addElement({"GUI Markers", "Polyhedrons"},
+                     mc_rtc::gui::Polyhedron("Polyhedron", pconfig, polyhedron_vertices_fn, polyhedron_colors_fn));
 
   builder.addElement(
       {"GUI Markers", "Trajectories"}, mc_rtc::gui::Trajectory("Vector3d", [this]() { return trajectory_; }),

--- a/tests/dummyServer.cpp
+++ b/tests/dummyServer.cpp
@@ -572,7 +572,9 @@ TestServer::TestServer() : xythetaz_(4)
   builder.addElement(
       {"GUI Markers", "Polyhedrons"},
       mc_rtc::gui::Polyhedron(
-          "Polyhedron", pconfig, [this]() { return polyhedron_vertices_; }, [this] { return polyhedron_colors_; }));
+          "Polyhedron (colors)", pconfig, [this]() { return polyhedron_vertices_; },
+          [this] { return polyhedron_colors_; }),
+      mc_rtc::gui::Polyhedron("Polyhedron (no color)", pconfig, [this]() { return polyhedron_vertices_; }));
 
   builder.addElement(
       {"GUI Markers", "Trajectories"}, mc_rtc::gui::Trajectory("Vector3d", [this]() { return trajectory_; }),

--- a/tests/dummyServer.cpp
+++ b/tests/dummyServer.cpp
@@ -513,63 +513,63 @@ TestServer::TestServer() : xythetaz_(4)
 
   auto polyhedron_vertices_fn = [this] {
     double z = std::max(0.1, (1 + cos(t_ / 2)) / 2);
-    return mc_rtc::gui::PolyhedronTriangles{// Upper pyramid
-                                            {-1, -1, 0},
-                                            {1, -1, 0},
-                                            {0, 0, z},
-                                            {1, -1, 0},
-                                            {1, 1, 0},
-                                            {0, 0, z},
-                                            {1, 1, 0},
-                                            {-1, 1, 0},
-                                            {0, 0, z},
-                                            {-1, 1, 0},
-                                            {-1, -1, 0},
-                                            {0, 0, z},
-                                            // Lower pyramid
-                                            {-1, -1, 0},
-                                            {0, 0, -z},
-                                            {1, -1, 0},
-                                            {1, -1, 0},
-                                            {0, 0, -z},
-                                            {1, 1, 0},
-                                            {1, 1, 0},
-                                            {0, 0, -z},
-                                            {-1, 1, 0},
-                                            {-1, 1, 0},
-                                            {0, 0, -z},
-                                            {-1, -1, 0}};
+    return std::vector<Eigen::Vector3d>{// Upper pyramid
+                                        {-1, -1, 0},
+                                        {1, -1, 0},
+                                        {0, 0, z},
+                                        {1, -1, 0},
+                                        {1, 1, 0},
+                                        {0, 0, z},
+                                        {1, 1, 0},
+                                        {-1, 1, 0},
+                                        {0, 0, z},
+                                        {-1, 1, 0},
+                                        {-1, -1, 0},
+                                        {0, 0, z},
+                                        // Lower pyramid
+                                        {-1, -1, 0},
+                                        {0, 0, -z},
+                                        {1, -1, 0},
+                                        {1, -1, 0},
+                                        {0, 0, -z},
+                                        {1, 1, 0},
+                                        {1, 1, 0},
+                                        {0, 0, -z},
+                                        {-1, 1, 0},
+                                        {-1, 1, 0},
+                                        {0, 0, -z},
+                                        {-1, -1, 0}};
   };
 
   auto polyhedron_colors_fn = [this] {
     double z = std::max(0.1, (1 + cos(t_ / 2)) / 2);
     Eigen::Vector4d color;
     color << mc_rtc::utils::heatmap<Eigen::Vector3d>(0, 1, z), 1;
-    return mc_rtc::gui::PolyhedronColors{{0, 0, 1, 1},
-                                         {0, 0, 1, 1},
-                                         color,
-                                         {0, 0, 1, 1},
-                                         {0, 0, 1, 1},
-                                         color,
-                                         {0, 0, 1, 1},
-                                         {0, 0, 1, 1},
-                                         color,
-                                         {0, 0, 1, 1},
-                                         {0, 0, 1, 1},
-                                         color,
-                                         // Colors for lower pyramid
-                                         {0, 0, 1, 1},
-                                         color,
-                                         {0, 0, 1, 1},
-                                         {0, 0, 1, 1},
-                                         color,
-                                         {0, 0, 1, 1},
-                                         {0, 0, 1, 1},
-                                         color,
-                                         {0, 0, 1, 1},
-                                         {0, 0, 1, 1},
-                                         color,
-                                         {0, 0, 1, 1}};
+    return std::vector<mc_rtc::gui::Color>{{0, 0, 1, 1},
+                                           {0, 0, 1, 1},
+                                           color,
+                                           {0, 0, 1, 1},
+                                           {0, 0, 1, 1},
+                                           color,
+                                           {0, 0, 1, 1},
+                                           {0, 0, 1, 1},
+                                           color,
+                                           {0, 0, 1, 1},
+                                           {0, 0, 1, 1},
+                                           color,
+                                           // Colors for lower pyramid
+                                           {0, 0, 1, 1},
+                                           color,
+                                           {0, 0, 1, 1},
+                                           {0, 0, 1, 1},
+                                           color,
+                                           {0, 0, 1, 1},
+                                           {0, 0, 1, 1},
+                                           color,
+                                           {0, 0, 1, 1},
+                                           {0, 0, 1, 1},
+                                           color,
+                                           {0, 0, 1, 1}};
   };
   mc_rtc::gui::PolyhedronConfig pconfig;
   pconfig.triangle_color = mc_rtc::gui::Color(1, 0, 0, 1.0);

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -1418,4 +1418,10 @@ BOOST_AUTO_TEST_CASE(TestIntegralTypes)
     MyNumber number2 = config("array")[0];
     BOOST_CHECK_EQUAL(number.n, number2.n);
   }
+  {
+    std::vector<char> buffer(512);
+    mc_rtc::MessagePackBuilder builder(buffer);
+    builder.write(number);
+    builder.finish();
+  }
 }

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -35,6 +35,7 @@ stringV: [a, b, c, foo, bar]
 doubleA3: [1.1, 2.2, 3.3]
 v2d: [1.0, 2.3]
 v3d: [1.0, 2.3, -100]
+v4d: [1.0, 2.3, 3.3, -100]
 v6d: [1.0, -1.5, 2.0, -2.5, 3.0, -3.5]
 g6d: [1.0, -1.5, 2.0, -2.5, 3.0, -3.5]
 vXd: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
@@ -58,6 +59,7 @@ dict:
   stringV: [a, b, c, foo, bar]
   v2d: [1.0, 2.3]
   v3d: [1.0, 2.3, -100]
+  v4d: [1.0, 2.3, 3.3, -100]
   v6d: [1.0, -1.5, 2.0, -2.5, 3.0, -3.5]
   quat: [0.71, 0, 0.71, 0]
   doubleDoublePair: [42.5, -42.5]
@@ -90,6 +92,7 @@ static std::string JSON_DATA = R"(
   "doubleA3": [1.1, 2.2, 3.3],
   "v2d": [1.0, 2.3],
   "v3d": [1.0, 2.3, -100],
+  "v4d": [1.0, 2.3, 3.3, -100],
   "v6d": [1.0, -1.5, 2.0, -2.5, 3.0, -3.5],
   "vXd": [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
   "quat": [0.71, 0, 0.71, 0],
@@ -113,6 +116,7 @@ static std::string JSON_DATA = R"(
     "stringV": ["a", "b", "c", "foo", "bar"],
     "v2d": [1.0, 2.3],
     "v3d": [1.0, 2.3, -100],
+    "v4d": [1.0, 2.3, 3.3, -100],
     "v6d": [1.0, -1.5, 2.0, -2.5, 3.0, -3.5],
     "quat": [0.71, 0, 0.71, 0],
     "doubleDoublePair": [42.5, -42.5],
@@ -455,6 +459,37 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
     mc_rbdyn::Gains3d i = mc_rbdyn::Gains3d::Zero();
     i = config("dict")("double");
     BOOST_CHECK_EQUAL(i, ref);
+  }
+
+  /* Eigen::Vector4d test */
+  {
+    Eigen::Vector4d ref;
+    ref << 1.0, 2.3, 3.3, -100;
+    Eigen::Vector4d zero = Eigen::Vector4d::Zero();
+
+    Eigen::Vector4d a = config("v4d");
+    BOOST_CHECK_EQUAL(a, ref);
+
+    Eigen::Vector4d b = Eigen::Vector4d::Zero();
+    config("v4d", b);
+    BOOST_CHECK_EQUAL(b, ref);
+
+    Eigen::Vector4d c = Eigen::Vector4d::Zero();
+    config("v6d", c);
+    BOOST_CHECK_EQUAL(c, zero);
+
+    MC_RTC_diagnostic_push
+    MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
+    BOOST_CHECK_THROW(Eigen::Vector4d d = config("v6d"), mc_rtc::Configuration::Exception);
+    MC_RTC_diagnostic_pop
+
+    Eigen::Vector4d e = Eigen::Vector4d::Zero();
+    e = config("dict")("v4d");
+    BOOST_CHECK_EQUAL(e, ref);
+
+    Eigen::Vector4d f = Eigen::Vector4d::Zero();
+    config("dict")("v4d", f);
+    BOOST_CHECK_EQUAL(f, ref);
   }
 
   /* Eigen::Vector6d test */


### PR DESCRIPTION
This PR adds an `mc_rtc::gui::Polyhedron` element, represented as a list of triangles (with points in clockwise order).
Additionally a list of per-vertex color can be provided (in which case rviz will display it by interpolating the colors in-between each triangle vertices. We can also choose to display edges as lines and vertices as 3D points (either using each vertex color, or providing a custom color for all edges). And of course transparent colors are supported so that we can see the robot behind ;)

![polyhedron](https://user-images.githubusercontent.com/67139/191514025-a90d5984-87ce-47a3-acd8-4d21c179685e.png)

Example:

```cpp
 mc_rtc::gui::PolyhedronTriangles polyhedron_vertices_{
// Upper pyramid
{-1, -1, 0}, {1, -1, 0}, {0, 0, 1}, {1, -1, 0}, {1, 1, 0}, {0, 0, 1}, {1, 1, 0}, {-1, 1, 0}, {0, 0, 1}, {-1, 1, 0}, {-1, -1, 0}, {0, 0, 1},
// Lower pyramid
{-1, -1, 0}, {0, 0, -1}, {1, -1, 0}, {1, -1, 0}, {0, 0, -1}, {1, 1, 0}, {1, 1, 0}, {0, 0, -1}, {-1, 1, 0}, {-1, 1, 0}, {0, 0, -1}, {-1, -1, 0}};
mc_rtc::gui::PolyhedronColors polyhedron_colors_{
// Colors for upper pyramid
{1, 0, 0, 0.5}, {1, 0, 0, 0.5}, {1, 0, 0, 0.8}, {0, 1, 0, 0.5}, {0, 1, 0, 0.5}, {0, 1, 0, 0.8}, {0, 0, 1, 0.5}, {0, 0, 1, 0.5}, {0, 0, 1, 0.8}, {1, 0, 1, 0.5}, {1, 0, 1, 0.5}, {1, 0, 1, 0.8},
// Colors for lower pyramid
{1, 0, 0, 0.5}, {0, 1, 0, 0.5}, {0, 0, 1, 0.5}, {1, 0, 0, 0.5}, {0, 1, 0, 0.5}, {0, 0, 1, 0.5}, {1, 0, 0, 0.5}, {0, 1, 0, 0.5}, {0, 0, 1, 0.5}, {1, 0, 0, 0.5}, {0, 1, 0, 0.5}, {0, 0, 1, 0.5}};

  mc_rtc::gui::PolyhedronConfig pconfig;
  pconfig.triangle_color = mc_rtc::gui::Color::Red;
  pconfig.use_triangle_color = false;
  pconfig.show_triangle = false;
  pconfig.show_vertices = false;
  pconfig.show_edges = true;
  pconfig.fixed_edge_color = false;
  builder.addElement(
      {"GUI Markers", "Polyhedrons"},
      mc_rtc::gui::Polyhedron(
          "Polyhedron", pconfig, [this]() { return polyhedron_vertices_; }, [this] { return polyhedron_colors_; }));


```

To be tested in practice with Hugo's controller.

Todo:
- [ ] Add documentation