### PR TITLE
Ensure plots contain all the data

### DIFF
--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -729,8 +729,7 @@ protected:
    * \p id Plot id
    *
    * \p did Id for this data, this is strictly increasing from 0 to the
-   * number of plots - 1 and you can assume that only one data point is added
-   * in one iteration
+   * number of plots - 1
    *
    * \p legend Legend for this data
    *

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -21,6 +21,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <vector>
 

--- a/include/mc_rtc/gui/StateBuilder.h
+++ b/include/mc_rtc/gui/StateBuilder.h
@@ -36,7 +36,7 @@ struct MC_RTC_GUI_DLLAPI StateBuilder
    * - Adding fields to an existing Element
    * - Adding an Element type
    */
-  static constexpr int8_t PROTOCOL_VERSION = 3;
+  static constexpr int8_t PROTOCOL_VERSION = 4;
 
   /** Constructor */
   StateBuilder();

--- a/include/mc_rtc/gui/StateBuilder.h
+++ b/include/mc_rtc/gui/StateBuilder.h
@@ -333,6 +333,9 @@ struct MC_RTC_GUI_DLLAPI StateBuilder
    */
   size_t update(std::vector<char> & data);
 
+  /** Update the plots only */
+  void update();
+
   /** Handle a request */
   bool handleRequest(const std::vector<std::string> & category,
                      const std::string & name,
@@ -362,8 +365,8 @@ private:
 
   /** Holds static data for the GUI */
   mc_rtc::Configuration data_;
-  /** Callback used to write plot data into the GUI message */
-  using plot_callback_function_t = std::function<void(mc_rtc::MessagePackBuilder &, const std::string &)>;
+  /** Callback used to write/update plot data into the GUI message */
+  using plot_callback_function_t = std::function<void(mc_rtc::MessagePackBuilder &, const std::string &, bool)>;
   struct PlotCallback
   {
     plot::Plot type;

--- a/include/mc_rtc/gui/plot/Polygon.h
+++ b/include/mc_rtc/gui/plot/Polygon.h
@@ -41,6 +41,8 @@ struct Polygon
     builder.finish_array();
   }
 
+  void update() const {}
+
   Polygon & side(Side side)
   {
     side_ = side;

--- a/include/mc_rtc/gui/plot/Polygons.h
+++ b/include/mc_rtc/gui/plot/Polygons.h
@@ -47,6 +47,8 @@ struct Polygons
     builder.finish_array();
   }
 
+  void update() const {}
+
   Polygons & side(Side side)
   {
     side_ = side;

--- a/include/mc_rtc/gui/plot/types.h
+++ b/include/mc_rtc/gui/plot/types.h
@@ -108,9 +108,9 @@ struct MC_RTC_GUI_DLLAPI AxisConfiguration
   Range range;
 
   AxisConfiguration() = default;
-  AxisConfiguration(const std::string & name) : AxisConfiguration(name, {}) {}
+  AxisConfiguration(std::string_view name) : AxisConfiguration(name, {}) {}
   AxisConfiguration(Range range) : AxisConfiguration("", range) {}
-  AxisConfiguration(const std::string & name, Range range) : name(name), range(range) {}
+  AxisConfiguration(std::string_view name, Range range) : name(name), range(range) {}
 
   AxisConfiguration & min(double min)
   {

--- a/src/mc_control/ControllerServer.cpp
+++ b/src/mc_control/ControllerServer.cpp
@@ -99,6 +99,7 @@ void ControllerServer::publish(mc_rtc::gui::StateBuilder & gui_builder)
   }
   else
   {
+    gui_builder.update();
     buffer_size_ = 0;
   }
 }

--- a/src/mc_rtc/gui/StateBuilder.cpp
+++ b/src/mc_rtc/gui/StateBuilder.cpp
@@ -214,13 +214,23 @@ size_t StateBuilder::update(std::vector<char> & buffer)
   for(auto & p : plots_)
   {
     builder.start_array(p.second.msg_size);
-    p.second.callback(builder, p.first);
+    p.second.callback(builder, p.first, false);
     builder.finish_array();
   }
   builder.finish_array();
 
   builder.finish_array();
   return builder.finish();
+}
+
+void StateBuilder::update()
+{
+  static std::vector<char> buffer;
+  static mc_rtc::MessagePackBuilder builder(buffer);
+  for(auto & p : plots_)
+  {
+    p.second.callback(builder, p.first, true);
+  }
 }
 
 void StateBuilder::update(mc_rtc::MessagePackBuilder & builder, Category & category)


### PR DESCRIPTION
This PR makes sure all data in a plot is displayed

This avoids misinterpretation when looking at online plots where discontinuities might not appear as bad online as they actually are (and can usually be seen offline)