### PR TITLE
[stabilizer] Make the DCM estimator compatible with external forces

### DIFF
--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -744,13 +744,18 @@ private:
     std::string surfaceName;
   };
 
-  /** @brief Compute the CoM offset and the sum wrench from the external wrenches.
+  /** @brief Compute the CoM offset (\alpha) and the ZMP coefficient (\kappa) and the sum wrench from the external
+   * wrenches. see Murooka et al. RAL 2021 eq (8)
    *
    *  @tparam TargetOrMeasured Change depending on the used wrenches
-   *  @param robot Robot used to transform surface wrenches (control robot or real robot)
+   *  @param robot [in] - Robot used to transform surface wrenches (control robot or real robot)
+   *  @param offset_alpha [out] - Com offset
+   *  @param coef_alpha [out] - ZmP coefficient
    */
   template<sva::ForceVecd ExternalWrench::*TargetOrMeasured>
-  Eigen::Vector3d computeCoMOffset(const mc_rbdyn::Robot & robot) const;
+  void computeWrenchOffsetAndCoefficient(const mc_rbdyn::Robot & robot,
+                                         Eigen::Vector3d & offset_alpha,
+                                         double & coef_kappa) const;
 
   /** @brief Compute the sum of external wrenches.
    *
@@ -902,6 +907,8 @@ protected:
   sva::ForceVecd extWrenchSumMeasured_ = sva::ForceVecd::Zero(); /**< Sum of measured external wrenches */
   Eigen::Vector3d comOffsetTarget_ = Eigen::Vector3d::Zero(); /**< Target (expected) CoM offset */
   Eigen::Vector3d comOffsetMeasured_ = Eigen::Vector3d::Zero(); /**< Measured CoM offset */
+  double zmpCoeTarget_ = 1; /**< target (expected) Zmp Coefficient  */
+  double zmpCoefMeasured_ = 1; /**< Measured Zmp Coefficient  */
   Eigen::Vector3d comOffsetErr_ = Eigen::Vector3d::Zero(); /**< CoM offset error */
   Eigen::Vector3d comOffsetErrCoM_ = Eigen::Vector3d::Zero(); /**< CoM offset error handled by CoM modification */
   Eigen::Vector3d comOffsetErrZMP_ = Eigen::Vector3d::Zero(); /**< CoM offset error handled by ZMP modification */
@@ -930,10 +937,14 @@ protected:
   sva::PTransformd zmpFrame_ = sva::PTransformd::Identity(); /**< Frame in which the ZMP is computed */
 };
 
-extern template Eigen::Vector3d StabilizerTask::computeCoMOffset<&StabilizerTask::ExternalWrench::target>(
-    const mc_rbdyn::Robot &) const;
-extern template Eigen::Vector3d StabilizerTask::computeCoMOffset<&StabilizerTask::ExternalWrench::measured>(
-    const mc_rbdyn::Robot &) const;
+extern template void StabilizerTask::computeWrenchOffsetAndCoefficient<&StabilizerTask::ExternalWrench::target>(
+    const mc_rbdyn::Robot & robot,
+    Eigen::Vector3d & offset_alpha,
+    double & coef_kappa) const;
+extern template void StabilizerTask::computeWrenchOffsetAndCoefficient<&StabilizerTask::ExternalWrench::measured>(
+    const mc_rbdyn::Robot & robot,
+    Eigen::Vector3d & offset_alpha,
+    double & coef_kappa) const;
 
 extern template sva::ForceVecd StabilizerTask::computeExternalWrenchSum<&StabilizerTask::ExternalWrench::target>(
     const mc_rbdyn::Robot &,

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -649,7 +649,7 @@ void StabilizerTask::setExternalWrenches(const std::vector<std::string> & surfac
     }
   }
 
-  comOffsetTarget_ = computeCoMOffset<&ExternalWrench::target>(robot());
+  computeWrenchOffsetAndCoefficient<&ExternalWrench::target>(robot(), comOffsetTarget_, zmpCoefMeasured_);
   comTarget_ = comTargetRaw_ - comOffsetErrCoM_;
   if(c_.extWrench.addExpectedCoMOffset)
   {
@@ -658,29 +658,39 @@ void StabilizerTask::setExternalWrenches(const std::vector<std::string> & surfac
 }
 
 template<sva::ForceVecd StabilizerTask::ExternalWrench::*TargetOrMeasured>
-Eigen::Vector3d StabilizerTask::computeCoMOffset(const mc_rbdyn::Robot & robot) const
+void StabilizerTask::computeWrenchOffsetAndCoefficient(const mc_rbdyn::Robot & robot,
+                                                       Eigen::Vector3d & offset_alpha,
+                                                       double & coef_kappa) const
 {
-  Eigen::Vector3d comOffset = Eigen::Vector3d::Zero();
+  offset_alpha.setZero();
+  coef_kappa = 0;
   Eigen::Vector3d pos, force, moment;
   for(const auto & extWrench : extWrenches_)
   {
     computeExternalContact(robot, extWrench.surfaceName, extWrench.*TargetOrMeasured, pos, force, moment);
 
-    comOffset.x() += (pos.z() - zmpTarget_.z()) * force.x() - pos.x() * force.z() + moment.y();
-    comOffset.y() += (pos.z() - zmpTarget_.z()) * force.y() - pos.y() * force.z() - moment.x();
+    offset_alpha.x() += (pos.z() - zmpTarget_.z()) * force.x() - pos.x() * force.z() + moment.y();
+    offset_alpha.y() += (pos.z() - zmpTarget_.z()) * force.y() - pos.y() * force.z() - moment.x();
+
+    coef_kappa -= force.z();
   }
   double verticalComAcc = comddTarget_.z() + constants::gravity.z();
   double verticalComAccThre = 1e-3;
   if(std::abs(verticalComAcc) < verticalComAccThre)
   {
-    mc_rtc::log::warning(
-        "[StabilizerTask::computeCoMOffset] overwrite verticalComAcc because it's too close to zero: {}",
-        verticalComAcc);
+    mc_rtc::log::warning("[StabilizerTask::computeWrenchOffsetAndCoefficient] overwrite verticalComAcc because it's "
+                         "too close to zero: {}",
+                         verticalComAcc);
     verticalComAcc = verticalComAcc >= 0 ? verticalComAccThre : -verticalComAccThre;
   }
-  comOffset /= robot.mass() * verticalComAcc;
 
-  return comOffset;
+  // \zeta in Murooka et al. RAL 2019
+  double zeta = robot.mass() * verticalComAcc;
+
+  offset_alpha /= zeta;
+
+  coef_kappa /= zeta;
+  coef_kappa += 1.;
 }
 
 template<sva::ForceVecd StabilizerTask::ExternalWrench::*TargetOrMeasured>
@@ -800,6 +810,22 @@ sva::ForceVecd StabilizerTask::computeDesiredWrench()
   dcmError_ = comError + comdError / omega_;
   dcmError_.z() = 0.;
 
+  // Calculate CoM offset from measured wrench
+  // this corresponds to \gamma in Murooka et al RAL 2021
+  for(auto & extWrench : extWrenches_)
+  {
+    if(robot().surfaceHasIndirectForceSensor(extWrench.surfaceName))
+    {
+      extWrench.measured =
+          sva::ForceVecd(extWrench.gain.vector().cwiseProduct(robot().surfaceWrench(extWrench.surfaceName).vector()));
+    }
+    else
+    {
+      extWrench.measured = extWrench.target;
+    }
+  }
+  computeWrenchOffsetAndCoefficient<&ExternalWrench::measured>(realRobot(), comOffsetMeasured_, zmpCoefMeasured_);
+
   if(inTheAir_)
   {
     dcmDerivator_.reset(Eigen::Vector3d::Zero());
@@ -823,11 +849,15 @@ sva::ForceVecd StabilizerTask::computeDesiredWrench()
       if(dcmEstimatorNeedsReset_)
       {
         dcmEstimator_.resetWithMeasurements(dcmError_.head<2>(), zmpError.head<2>(), waistOrientation, true);
+        dcmEstimator_.setUnbiasedCoMOffset(comOffsetMeasured_.head<2>());
+        dcmEstimator_.setZMPCoef(zmpCoefMeasured_);
+
         dcmEstimatorNeedsReset_ = false;
       }
       else
       {
-        dcmEstimator_.setInputs(dcmError_.head<2>(), zmpError.head<2>(), waistOrientation);
+        dcmEstimator_.setInputs(dcmError_.head<2>(), zmpError.head<2>(), waistOrientation, comOffsetMeasured_.head<2>(),
+                                zmpCoefMeasured_);
       }
 
       /// run the estimation
@@ -872,35 +902,29 @@ sva::ForceVecd StabilizerTask::computeDesiredWrench()
   }
   dcmAverageError_ = dcmIntegrator_.eval();
   dcmVelError_ = dcmDerivator_.eval();
+
+  /// The gains along the axis are defined in the local cordinates so we extract the yaw
+  /// rotation matrix
   Eigen::Matrix3d R_0_fb_yaw = sva::RotZ(mc_rbdyn::rpyFromMat(robot().posW().rotation()).z());
+
+  /// feed forward
   Eigen::Vector3d desiredCoMAccel = comddTarget_;
 
+  /// Proportional term
   Eigen::Vector3d gain = Eigen::Vector3d{c_.dcmPropGain.x(), c_.dcmPropGain.y(), 0};
   desiredCoMAccel += omega_ * R_0_fb_yaw.transpose() * gain.cwiseProduct(R_0_fb_yaw * dcmError_);
 
+  /// integral term
   gain = Eigen::Vector3d{c_.dcmIntegralGain.x(), c_.dcmIntegralGain.y(), 0};
   desiredCoMAccel += omega_ * R_0_fb_yaw.transpose() * gain.cwiseProduct(R_0_fb_yaw * dcmAverageError_);
 
+  /// derivative term
   gain = Eigen::Vector3d{c_.dcmDerivGain.x(), c_.dcmDerivGain.y(), 0};
   desiredCoMAccel += omega_ * R_0_fb_yaw.transpose() * gain.cwiseProduct(R_0_fb_yaw * dcmVelError_);
 
+  /// additional terms
   desiredCoMAccel += omega_ * (c_.comdErrorGain * comdError);
   desiredCoMAccel -= omega_ * omega_ * c_.zmpdGain * zmpdTarget_;
-
-  // Calculate CoM offset from measured wrench
-  for(auto & extWrench : extWrenches_)
-  {
-    if(robot().surfaceHasIndirectForceSensor(extWrench.surfaceName))
-    {
-      extWrench.measured =
-          sva::ForceVecd(extWrench.gain.vector().cwiseProduct(robot().surfaceWrench(extWrench.surfaceName).vector()));
-    }
-    else
-    {
-      extWrench.measured = extWrench.target;
-    }
-  }
-  comOffsetMeasured_ = computeCoMOffset<&ExternalWrench::measured>(realRobot());
 
   // Modify the desired CoM and ZMP depending on the external wrench error
   comOffsetLowPass_.update(comOffsetMeasured_ - comOffsetTarget_);
@@ -1185,10 +1209,14 @@ void StabilizerTask::updateFootForceDifferenceControl()
   rightFootTask->refVelB(0.5 * (T_0_R * (velT + velF)));
 }
 
-template Eigen::Vector3d StabilizerTask::computeCoMOffset<&StabilizerTask::ExternalWrench::target>(
-    const mc_rbdyn::Robot &) const;
-template Eigen::Vector3d StabilizerTask::computeCoMOffset<&StabilizerTask::ExternalWrench::measured>(
-    const mc_rbdyn::Robot &) const;
+template void StabilizerTask::computeWrenchOffsetAndCoefficient<&StabilizerTask::ExternalWrench::target>(
+    const mc_rbdyn::Robot & robot,
+    Eigen::Vector3d & offset_alpha,
+    double & coef_kappa) const;
+template void StabilizerTask::computeWrenchOffsetAndCoefficient<&StabilizerTask::ExternalWrench::measured>(
+    const mc_rbdyn::Robot & robot,
+    Eigen::Vector3d & offset_alpha,
+    double & coef_kappa) const;
 
 template sva::ForceVecd StabilizerTask::computeExternalWrenchSum<&StabilizerTask::ExternalWrench::target>(
     const mc_rbdyn::Robot &,


### PR DESCRIPTION
This PR allows to make the DCM bias estimator compatible with the compensation of external forces in lIPM Stabilizer.

- [ ] Setup the interface
- [ ] Compute the CoM offset and ZMP Coefficient
- [ ] Test the stabilizer
- [ ] Update logging and GUI feedback