### PR TITLE
[ROS] Restore ROS Signal Handler

### DIFF
--- a/plugins/ROS/src/mc_rtc_ros/ros.cpp
+++ b/plugins/ROS/src/mc_rtc_ros/ros.cpp
@@ -454,7 +454,7 @@ inline bool ros_init(const std::string & name)
   }
   int argc = 0;
   char * argv[] = {0};
-  ros::init(argc, argv, name.c_str(), ros::init_options::NoSigintHandler);
+  ros::init(argc, argv, name.c_str());
   if(!ros::master::check())
   {
     mc_rtc::log::warning("ROS master is not available, continue without ROS functionalities");


### PR DESCRIPTION
Currently `ROS` is initialized with:

```
  ros::init(argc, argv, name.c_str(), ros::init_options::NoSigintHandler);
```

This means that interrupt signals (`Ctrl-C`) will not be caught by ROS itself, and thus that code execution will be interrupted immediately. In particular:

```cpp
while(ros::ok())
{
  MCGlobalController gc;
}
// destructors will not be called upon Ctrl-C (controllers, plugins, observers, etc)
```

Since in that case destructors are not called, this can cause issues down the line.
I can't think of any reason why we should be disabling the default signal handler, and doing so is confusing.