### PR TITLE
[bugfix] Treat the transformation between sensor and parent link in KinematicInertialPoseObserver

### DIFF
--- a/include/mc_control/mc_global_controller.h
+++ b/include/mc_control/mc_global_controller.h
@@ -218,9 +218,7 @@ public:
    * \param ori Orientation given by a sensor
    *
    * \note By convention, this rotation should be given from the inertial frame
-   * (i.e. a fixed frame in the real world) to a body frame of the robot. For
-   * instance, on HRP-4 the body sensor orientation goes from the inertial
-   * frame to the "base_link" frame.
+   * (i.e. a fixed frame in the real world) to a sensor frame of the robot.
    *
    * \throws If the robot does not have any body sensor
    */

--- a/include/mc_rbdyn/BodySensor.h
+++ b/include/mc_rbdyn/BodySensor.h
@@ -99,9 +99,7 @@ struct MC_RBDYN_DLLAPI BodySensor : public Device
   /** Set the sensor's orientation reading
    *
    * \note By convention, this rotation should be given from the inertial frame
-   * (i.e. a fixed frame in the real world) to a body frame of the robot. For
-   * instance, on HRP-4 the body sensor orientation goes from the inertial
-   * frame to the "base_link" frame.
+   * (i.e. a fixed frame in the real world) to a sensor frame of the robot.
    *
    */
   inline void orientation(const Eigen::Quaterniond & orientation)

--- a/plugins/ROS/src/mc_rtc_ros/ros.cpp
+++ b/plugins/ROS/src/mc_rtc_ros/ros.cpp
@@ -287,6 +287,7 @@ void RobotPublisherImpl::update(double, const mc_rbdyn::Robot & robot)
   data.imu.angular_velocity.y = imu_angular_velocity.y();
   data.imu.angular_velocity.z = imu_angular_velocity.z();
   const auto & imu_orientation = robot.bodySensor().orientation();
+  data.imu.orientation.w = imu_orientation.w();
   data.imu.orientation.x = imu_orientation.x();
   data.imu.orientation.y = imu_orientation.y();
   data.imu.orientation.z = imu_orientation.z();

--- a/src/mc_observers/KinematicInertialPoseObserver.cpp
+++ b/src/mc_observers/KinematicInertialPoseObserver.cpp
@@ -106,7 +106,7 @@ void KinematicInertialPoseObserver::estimateOrientation(const mc_rbdyn::Robot & 
   const sva::PTransformd & X_0_cIMU = robot.bodyPosW(imuParent);
   sva::PTransformd X_rIMU_rBase = X_0_rBase * X_0_rIMU.inv();
 
-  Eigen::Matrix3d E_0_mIMU = imuSensor.orientation().toRotationMatrix();
+  Eigen::Matrix3d E_0_mIMU = imuSensor.X_b_s().rotation().transpose() * imuSensor.orientation().toRotationMatrix();
   const Eigen::Matrix3d & E_0_cIMU = X_0_cIMU.rotation();
   // Estimate IMU orientation: merges roll+pitch from measurement with yaw from control
   Eigen::Matrix3d E_0_eIMU = mergeRoll1Pitch1WithYaw2(E_0_mIMU, E_0_cIMU);

--- a/src/mc_observers/KinematicInertialPoseObserver.cpp
+++ b/src/mc_observers/KinematicInertialPoseObserver.cpp
@@ -62,13 +62,13 @@ bool KinematicInertialPoseObserver::run(const mc_control::MCController & ctl)
   anchorFrameJumped_ = false;
   auto anchorFrame = ctl.datastore().call<sva::PTransformd>(anchorFrameFunction_, ctl.robot(robot_));
   auto anchorFrameReal = ctl.datastore().call<sva::PTransformd>(anchorFrameFunction_, ctl.realRobot(realRobot_));
-  auto error = (anchorFrame.translation() - X_0_anchorFrame_.translation()).norm();
   if(firstIter_)
   { // Ignore anchor frame check on first iteration
     firstIter_ = false;
   }
   else
   { // Check whether anchor frame jumped
+    auto error = (anchorFrame.translation() - X_0_anchorFrame_.translation()).norm();
     if(error > maxAnchorFrameDiscontinuity_)
     {
       mc_rtc::log::warning("[{}] Control anchor frame jumped from [{}] to [{}] (error norm {} > threshold {})", name(),
@@ -76,11 +76,12 @@ bool KinematicInertialPoseObserver::run(const mc_control::MCController & ctl)
                            MC_FMT_STREAMED(anchorFrame.translation().transpose()), error, maxAnchorFrameDiscontinuity_);
       anchorFrameJumped_ = true;
     }
-    if((anchorFrameReal.translation() - X_0_anchorFrameReal_.translation()).norm() > maxAnchorFrameDiscontinuity_)
+    auto errorReal = (anchorFrameReal.translation() - X_0_anchorFrameReal_.translation()).norm();
+    if(errorReal > maxAnchorFrameDiscontinuity_)
     {
       mc_rtc::log::warning("[{}] Real anchor frame jumped from [{}] to [{}] (error norm {:.3f} > threshold {:.3f})",
                            name(), MC_FMT_STREAMED(X_0_anchorFrameReal_.translation().transpose()),
-                           MC_FMT_STREAMED(anchorFrameReal.translation().transpose()), error,
+                           MC_FMT_STREAMED(anchorFrameReal.translation().transpose()), errorReal,
                            maxAnchorFrameDiscontinuity_);
       anchorFrameJumped_ = true;
     }


### PR DESCRIPTION
This patch is required for robots whose BodySensor orientation is not identity relative to the parent link.
Fixes https://github.com/isri-aist/mc_rhps1/issues/10