### PR TITLE
[mc_tasks] Add PostureTask::jointWeights

### DIFF
--- a/doc/_data/schemas/common/PostureTask_targets_properties.json
+++ b/doc/_data/schemas/common/PostureTask_targets_properties.json
@@ -26,7 +26,7 @@
       "description": "Weights for specific joints",
       "properties":
       {
-        "*": { "type": "number", "description": "Joint weight [rad]" }
+        "*": { "type": "number", "description": "Joint weight" }
       }
     },
     "target":

--- a/doc/_data/schemas/common/PostureTask_targets_properties.json
+++ b/doc/_data/schemas/common/PostureTask_targets_properties.json
@@ -20,6 +20,15 @@
         "$ref": "/../../Tasks/JointGains.json" 
       } 
     },
+    "jointWeights":
+    {
+      "type": "object",
+      "description": "Weights for specific joints",
+      "properties":
+      {
+        "*": { "type": "number", "description": "Joint weight [rad]" }
+      }
+    },
     "target":
     {
       "type": "array",

--- a/include/mc_tasks/PostureTask.h
+++ b/include/mc_tasks/PostureTask.h
@@ -148,6 +148,9 @@ public:
   /** Set joint stiffness for the posture task */
   void jointStiffness(const mc_solver::QPSolver & solver, const std::vector<tasks::qp::JointStiffness> & jss);
 
+  /** Set joint weights for the posture task */
+  void jointWeights(const std::map<std::string, double> & jws);
+
   /** Set specific joint targets
    *
    * \param joints Map of joint's name to joint's configuration

--- a/src/mc_tasks/PostureTask.cpp
+++ b/src/mc_tasks/PostureTask.cpp
@@ -88,6 +88,10 @@ void PostureTask::load(mc_solver::QPSolver & solver, const mc_rtc::Configuration
   {
     this->weight(config("weight"));
   }
+  if(config.has("jointWeights"))
+  {
+    this->jointWeights(config("jointWeights"));
+  }
 }
 
 void PostureTask::selectActiveJoints(mc_solver::QPSolver & solver,
@@ -324,6 +328,17 @@ void PostureTask::jointStiffness(const mc_solver::QPSolver & solver, const std::
     default:
       break;
   }
+}
+
+void PostureTask::jointWeights(const std::map<std::string, double> & jws)
+{
+  Eigen::VectorXd dimW = dimWeight();
+  const auto & mb = robots_.robot(rIndex_).mb();
+  for(const auto & jw : jws)
+  {
+    dimW[mb.jointPosInDof(mb.jointIndexByName(jw.first))] = jw.second;
+  }
+  dimWeight(dimW);
 }
 
 void PostureTask::target(const std::map<std::string, std::vector<double>> & joints)

--- a/src/mc_tasks/PostureTask.cpp
+++ b/src/mc_tasks/PostureTask.cpp
@@ -333,10 +333,24 @@ void PostureTask::jointStiffness(const mc_solver::QPSolver & solver, const std::
 void PostureTask::jointWeights(const std::map<std::string, double> & jws)
 {
   Eigen::VectorXd dimW = dimWeight();
-  const auto & mb = robots_.robot(rIndex_).mb();
+  const auto & robot = robots_.robot(rIndex_);
+  const auto & mb = robot.mb();
   for(const auto & jw : jws)
   {
-    dimW[mb.jointPosInDof(mb.jointIndexByName(jw.first))] = jw.second;
+    if(robot.hasJoint(jw.first))
+    {
+      auto jIndex = mb.jointIndexByName(jw.first);
+      if(mb.joint(jIndex).dof() > 0)
+      {
+        dimW[mb.jointPosInDof(jIndex)] = jw.second;
+      }
+      // No warning, it's probably over specified
+    }
+    else
+    {
+      mc_rtc::log::warning("[PostureTask] No joint named {} in {}, joint weight will have no effect", jw.first,
+                           robot.name());
+    }
   }
   dimWeight(dimW);
 }

--- a/tests/controllers/plugins/TestCanonicalRobotController.cpp
+++ b/tests/controllers/plugins/TestCanonicalRobotController.cpp
@@ -54,7 +54,7 @@ struct MC_CONTROL_DLLAPI TestCanonicalRobotController : public mc_control::Globa
       // to the output robot
       for(const auto & j : gripper.get().activeJoints())
       {
-        BOOST_REQUIRE_CLOSE(commanded, outputRobot.mbc().q[outputRobot.jointIndexByName(j)][0], 1e-10);
+        BOOST_REQUIRE(std::fabs(commanded - outputRobot.mbc().q[outputRobot.jointIndexByName(j)][0]) < 1e-10);
       }
 
       // Check mimics


### PR DESCRIPTION
>> As a proposal, in PostureTask, it would be useful to specify dimWeight by passing a pair of joint name and weight via mc_rtc::Configuration.
>
> Sounds good. Maybe a jointWeight entry? (note that jointGains/jointStiffness can do this at the stiffness/damping level of the task)

(from https://github.com/jrl-umi3218/mc_rtc/issues/314#issuecomment-1350492087)

I verified that the following configurations can be loaded correctly.
```yaml
jointWeights:
  WAIST_R: 100
  WAIST_P: 200
  WAIST_Y: 300
```

Documentation and testing may need to be updated, but I'm not familiar with them, so I'd appreciate it if the maintainer could do that.
