### PR TITLE
[mc_log_ui] Fix 3D plots for recent matplotlib

### DIFF
--- a/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_plotcanvas.py
@@ -241,7 +241,7 @@ class PlotYAxis(object):
       if not _3D:
         self._axis = parent.fig.add_subplot(111)
       else:
-        self._axis = parent.fig.gca(projection='3d')
+        self._axis = parent.fig.add_subplot(projection='3d')
         self._axis.set_xlabel('X')
         self._axis.set_ylabel('Y')
         self._axis.set_zlabel('Z')


### PR DESCRIPTION
This PR fixes running `mc_log_ui` with recent versions of matplotlib. I've confirmed it to work on Ubuntu 20.04, however I am not I am not 100% sure whether this works on Ubuntu 18.04 (the projection argument does exist, but the documentation does not mention the `3d` mode).