### PR TITLE
[mc_control] Allow loading a robot specific configuration

### DIFF
--- a/doc/_i18n/en.yml
+++ b/doc/_i18n/en.yml
@@ -80,7 +80,7 @@ tutorials:
             # Assuming you have a ROS distribution mirror setup
             sudo apt install ros-${ROS_DISTRO}-mc-rtc-plugin ros-${ROS_DISTRO}-mc-rtc-tools
     configuration:
-      title: Configuring mc_rtc
+      title: Configuring mc_rtc and its components
     running-a-controller:
       title: Running a controller
     first-controller:

--- a/doc/_i18n/en/tutorials/introduction/configuration.html
+++ b/doc/_i18n/en/tutorials/introduction/configuration.html
@@ -120,3 +120,37 @@ publish:
 {% endhighlight %}
   </div>
 </div>
+
+{% include h2.html title="Controller configuration" %}
+
+<p>For a given controller {% ihighlight bash %}NAME{% endihighlight %}, the following configuration files are loaded:</p>
+
+<ol>
+  <li>{% ihighlight bash %}${NAME_RUNTIME_LOCATION}/etc/${NAME}.yaml{% endihighlight %}</li>
+  <li>
+    <ul>
+      <li>Linux/MacOS: {% ihighlight bash %}${HOME}/.config/mc_rtc/controllers/${NAME}.yaml{% endihighlight %}</li>
+      <li>Windows: {% ihighlight msshell %}%APPDATA%/mc_rtc/controllers/%NAME%.yaml{% endihighlight %}</li>
+    </ul>
+  </li>
+</ol>
+
+<p>The configuration loaded from those files is available in the {% ihighlight bash %}configuration{% endihighlight %} parameter of the controller constructor. You can check the {% include link_tutorial.html category="usage" tutorial="mc_rtc_configuration" %} tutorial for more information on the configuration object.</p>
+
+{% include h4.html title="Controller's robot specific configuration" %}
+
+<p>Controller can also access a robot's specific configuration &mdash; for example to set specific gains.</p>
+
+<p>For a given controller {% ihighlight bash %}NAME{% endihighlight %} and a given robot's module named {% ihighlight bash %}ROBOT{% endihighlight %}, the following configuration files are loaded:</p>
+
+<ol>
+  <li>{% ihighlight bash %}${NAME_RUNTIME_LOCATION}/${NAME}/${ROBOT}.yaml{% endihighlight %}</li>
+  <li>
+    <ul>
+      <li>Linux/MacOS: {% ihighlight bash %}${HOME}/.config/mc_rtc/controllers/${NAME}/${ROBOT}.yaml{% endihighlight %}</li>
+      <li>Windows: {% ihighlight msshell %}%APPDATA%/mc_rtc/controllers/%NAME%/%ROBOT%.yaml{% endihighlight %}</li>
+    </ul>
+  </li>
+</ol>
+
+<p>These configurations can be accessed via the {% doxygen mc_control::MCController::robot_config(const mc_rbdyn::Robot & robot) %} method.</p>

--- a/doc/_i18n/en/tutorials/introduction/configuration.html
+++ b/doc/_i18n/en/tutorials/introduction/configuration.html
@@ -153,4 +153,6 @@ publish:
   </li>
 </ol>
 
-<p>These configurations can be accessed via the {% doxygen mc_control::MCController::robot_config(const mc_rbdyn::Robot & robot) %} method.</p>
+<p>By default, these configuration files are automatically loaded into the <pre>robots</pre> section of the controller's configuration, under each robot's module name. This behavior can be disabled or modified through {% doxygen mc_control::ControllerParameters %} that are given to the controller constructor.</p>
+
+<p>These configurations can also be accessed via the {% doxygen mc_control::MCController::robot_config(const mc_rbdyn::Robot & robot) %} method and its overload {% doxygen mc_control::MCController::robot_config(const std::string & name) %} .</p>

--- a/doc/_i18n/jp.yml
+++ b/doc/_i18n/jp.yml
@@ -80,6 +80,7 @@ tutorials:
             # ROSディストリビューションのミラーがセットアップされているものと仮定
             sudo apt install ros-${ROS_DISTRO}-mc-rtc-plugin ros-${ROS_DISTRO}-mc-rtc-tools
     configuration:
+      # FIXME Outdated translation
       title: 設定
     running-a-controller:
       title: コントローラの実行

--- a/doc/_i18n/jp/tutorials/introduction/configuration.html
+++ b/doc/_i18n/jp/tutorials/introduction/configuration.html
@@ -119,3 +119,5 @@
 {% endhighlight %}
   </div>
 </div>
+
+{% comment %}FIXME Missing part about controller configuration{% endcomment %}

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -759,7 +759,9 @@ public:
   /** Posture task for the main robot */
   std::shared_ptr<mc_tasks::PostureTask> postureTask;
   /* Controller's name */
-  std::string name_;
+  const std::string name_;
+  /** Stores the loading location provided by the loader via \ref set_loading_location */
+  const std::string loading_location_;
 
   /** Load a robot specific configuration (if any)
    *
@@ -778,9 +780,11 @@ public:
    */
   static void set_loading_location(std::string_view location);
 
-private:
-  /** Stores the loading location provided by the loader via \ref set_loading_location */
-  std::string loading_location_;
+  /** Called by \ref mc_rtc::ObjectLoader to set the name of the controller
+   *
+   * The value is stored in a thread_local variable and is meant to be used in the constructor of MCController
+   */
+  static void set_name(std::string_view name);
 };
 
 namespace details

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -48,6 +48,35 @@ struct MC_CONTROL_DLLAPI ControllerResetData
   const std::vector<std::vector<double>> q;
 };
 
+/** \brief Extra parameters that influence the creator construction */
+struct MC_CONTROL_DLLAPI ControllerParameters
+{
+  inline ControllerParameters() = default;
+  inline ControllerParameters(const ControllerParameters &) = default;
+  inline ControllerParameters(ControllerParameters &&) = default;
+  inline ControllerParameters & operator=(const ControllerParameters &) = default;
+  inline ControllerParameters & operator=(ControllerParameters &&) = default;
+
+#define ADD_PARAMETER(TYPE, NAME, DEFAULT) \
+  TYPE NAME##_ = DEFAULT;                  \
+  ControllerParameters & NAME(TYPE value)  \
+  {                                        \
+    NAME##_ = value;                       \
+    return *this;                          \
+  }
+  /** Backend used by this controller */
+  ADD_PARAMETER(mc_solver::QPSolver::Backend, backend, mc_solver::QPSolver::Backend::Tasks)
+  /** Whether to automatically load the robots' specific configuration (true by default) */
+  ADD_PARAMETER(bool, load_robot_config, true)
+  /** Where to load the robots' configuration config("robots") by default */
+  ADD_PARAMETER(std::vector<std::string>, load_robot_config_into, {"robots"})
+  /** Use the module name to find robot's specific values if true (default), use the robot's name otherwise */
+  ADD_PARAMETER(bool, load_robot_config_with_module_name, true)
+
+  /** For backward compatibility purpose */
+  inline ControllerParameters(mc_solver::QPSolver::Backend backend) : backend_(backend) {}
+};
+
 struct MCGlobalController;
 
 /** \class MCController
@@ -620,9 +649,9 @@ protected:
    *
    * \param dt Timestep of the controller
    *
-   * \param backend Backend for the solver
+   * \param params Extra-parameters for the constructor
    */
-  MCController(std::shared_ptr<mc_rbdyn::RobotModule> robot, double dt, Backend backend = Backend::Tasks);
+  MCController(std::shared_ptr<mc_rbdyn::RobotModule> robot, double dt, ControllerParameters params = {});
 
   /** Builds a controller with a single robot. The env/ground environment is automatically added
    *
@@ -632,12 +661,12 @@ protected:
    *
    * \param config Configuration of the controller
    *
-   * \param backend Backend for the solver
+   * \param params Extra-parameters for the constructor
    */
   MCController(std::shared_ptr<mc_rbdyn::RobotModule> robot,
                double dt,
                const mc_rtc::Configuration & config,
-               Backend backend = Backend::Tasks);
+               ControllerParameters params = {});
 
   /** Builds a controller with multiple robots
    *
@@ -645,11 +674,11 @@ protected:
    *
    * \param dt Timestep of the controller
    *
-   * \param backend Backend for the solver
+   * \param params Extra-parameters for the constructor
    */
   MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModule>> & robot_modules,
                double dt,
-               Backend backend = Backend::Tasks);
+               ControllerParameters params = {});
 
   /** Builds a controller with multiple robots
    *
@@ -659,12 +688,12 @@ protected:
    *
    * \param config Controller configuration
    *
-   * \param backend Backend for the solver
+   * \param params Extra-parameters for the constructor
    */
   MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModule>> & robot_modules,
                double dt,
                const mc_rtc::Configuration & config,
-               Backend backend = Backend::Tasks);
+               ControllerParameters params = {});
 
   /** Load an additional robot into the controller
    *
@@ -809,8 +838,9 @@ struct BackendSpecificController : public MCController
 
   BackendSpecificController(const std::vector<mc_rbdyn::RobotModulePtr> & robots,
                             double dt,
-                            const mc_rtc::Configuration & config = {})
-  : MCController(robots, dt, config, backend)
+                            const mc_rtc::Configuration & config = {},
+                            ControllerParameters params = {})
+  : MCController(robots, dt, config, params.backend(backend))
   {
   }
 

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -766,10 +766,13 @@ public:
   /** Load a robot specific configuration (if any)
    *
    * The following files are loaded (in that order):
-   * - ${loading_location}/${name}/${robot.name()}.conf|yaml
-   * - ${HOME}/.config/mc_rtc/controllers/${name}/${robot.name()}.conf|yaml (Linux/macOS)
-   * - ${APPDATA}/mc_rtc/controllers/${name}/${robot.name()}.conf|yaml (Windows)
+   * - ${loading_location}/${name()}/${robot_name}.conf|yaml
+   * - ${HOME}/.config/mc_rtc/controllers/${name()}/${robot_name}.conf|yaml (Linux/macOS)
+   * - ${APPDATA}/mc_rtc/controllers/${name()}/${robot_name}.conf|yaml (Windows)
    */
+  mc_rtc::Configuration robot_config(const std::string & robot_name) const;
+
+  /** Same as robot_config(robot.module().name) */
   mc_rtc::Configuration robot_config(const mc_rbdyn::Robot & robot) const;
 
   /** Called by \ref mc_rtc::ObjectLoader to inform the controller of its loading location

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -760,6 +760,27 @@ public:
   std::shared_ptr<mc_tasks::PostureTask> postureTask;
   /* Controller's name */
   std::string name_;
+
+  /** Load a robot specific configuration (if any)
+   *
+   * The following files are loaded (in that order):
+   * - ${loading_location}/${name}/${robot.name()}.conf|yaml
+   * - ${HOME}/.config/mc_rtc/controllers/${name}/${robot.name()}.conf|yaml (Linux/macOS)
+   * - ${APPDATA}/mc_rtc/controllers/${name}/${robot.name()}.conf|yaml (Windows)
+   */
+  mc_rtc::Configuration robot_config(const mc_rbdyn::Robot & robot) const;
+
+  /** Called by \ref mc_rtc::ObjectLoader to inform the controller of its loading location
+   * For example, if the CoM controller is loaded from the library in /usr/local/lib/mc_controller/com.so then this is
+   * /usr/local/lib/mc_controller/
+   *
+   * The value is stored in a thread_local variable and is meant to be used in the constructor of MCController
+   */
+  static void set_loading_location(std::string_view location);
+
+private:
+  /** Stores the loading location provided by the loader via \ref set_loading_location */
+  std::string loading_location_;
 };
 
 namespace details

--- a/include/mc_control/fsm/Controller.h
+++ b/include/mc_control/fsm/Controller.h
@@ -53,7 +53,7 @@ struct MC_CONTROL_FSM_DLLAPI Controller : public MCController
   Controller(mc_rbdyn::RobotModulePtr rm,
              double dt,
              const mc_rtc::Configuration & config,
-             Backend backend = Backend::Tasks);
+             ControllerParameters params = {});
 
   ~Controller() override;
 
@@ -175,8 +175,11 @@ namespace details
 template<MCController::Backend backend, typename SolverT>
 struct BackendSpecificController : public Controller
 {
-  BackendSpecificController(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & config)
-  : Controller(rm, dt, config, backend)
+  BackendSpecificController(mc_rbdyn::RobotModulePtr rm,
+                            double dt,
+                            const mc_rtc::Configuration & config,
+                            ControllerParameters params = {})
+  : Controller(rm, dt, config, params.backend(backend))
   {
   }
 

--- a/include/mc_rtc/loader.h
+++ b/include/mc_rtc/loader.h
@@ -117,6 +117,9 @@ struct MC_RTC_LOADER_DLLAPI LTDLHandle
     return path_;
   }
 
+  /** Access the library folder location */
+  std::string dir() const;
+
 private:
   std::string path_;
   std::string rpath_;

--- a/include/mc_rtc/loader.hpp
+++ b/include/mc_rtc/loader.hpp
@@ -26,6 +26,18 @@ struct has_set_loading_location
 template<typename T>
 inline constexpr bool has_set_loading_location_v = decltype(has_set_loading_location::test<T>(nullptr))::value;
 
+struct has_set_name
+{
+  template<typename T, std::enable_if_t<std::is_same_v<void, decltype(T::set_name(""))>, int> = 0>
+  static std::true_type test(T * p);
+
+  template<typename T>
+  static std::false_type test(...);
+};
+
+template<typename T>
+inline constexpr bool has_set_name_v = decltype(has_set_name::test<T>(nullptr))::value;
+
 } // namespace details
 
 template<typename SymT>
@@ -165,6 +177,10 @@ T * ObjectLoader<T>::create_from_handles(const std::string & name, Args... args)
   if constexpr(details::has_set_loading_location_v<T>)
   {
     T::set_loading_location(handles_[name]->dir());
+  }
+  if constexpr(details::has_set_name_v<T>)
+  {
+    T::set_name(name);
   }
   T * ptr = create_fn(name, args...);
   if(ptr == nullptr)

--- a/include/mc_rtc/loader.hpp
+++ b/include/mc_rtc/loader.hpp
@@ -11,6 +11,23 @@
 namespace mc_rtc
 {
 
+namespace details
+{
+
+struct has_set_loading_location
+{
+  template<typename T, std::enable_if_t<std::is_same_v<void, decltype(T::set_loading_location(""))>, int> = 0>
+  static std::true_type test(T * p);
+
+  template<typename T>
+  static std::false_type test(...);
+};
+
+template<typename T>
+inline constexpr bool has_set_loading_location_v = decltype(has_set_loading_location::test<T>(nullptr))::value;
+
+} // namespace details
+
 template<typename SymT>
 SymT LTDLHandle::get_symbol(const std::string & name)
 {
@@ -144,6 +161,10 @@ T * ObjectLoader<T>::create_from_handles(const std::string & name, Args... args)
   if(create_fn == nullptr)
   {
     mc_rtc::log::error_and_throw<LoaderException>("Failed to resolve create symbol in {}", handles_[name]->path());
+  }
+  if constexpr(details::has_set_loading_location_v<T>)
+  {
+    T::set_loading_location(handles_[name]->dir());
   }
   T * ptr = create_fn(name, args...);
   if(ptr == nullptr)

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -992,13 +992,13 @@ Gripper & MCController::gripper(const std::string & robot, const std::string & g
 mc_rtc::Configuration MCController::robot_config(const mc_rbdyn::Robot & robot) const
 {
   mc_rtc::Configuration result;
-  bfs::path system_path = bfs::path(loading_location_) / this->name_ / (robot.name() + ".conf");
+  bfs::path system_path = bfs::path(loading_location_) / this->name_ / (robot.module().name + ".conf");
 #ifndef WIN32
   bfs::path user_path = bfs::path(std::getenv("HOME")) / ".config/mc_rtc/controllers";
 #else
   bfs::path user_path = bfs::path(std::getenv("APPDATA")) / "mc_rtc/controllers";
 #endif
-  user_path = user_path / name_ / (robot.name() + ".conf");
+  user_path = user_path / name_ / (robot.module().name + ".conf");
   auto load_conf = [&result](const std::string & path) {
     result.load(path);
     mc_rtc::log::info("Controller's robot configuration loaded from {}", path);

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -991,14 +991,19 @@ Gripper & MCController::gripper(const std::string & robot, const std::string & g
 
 mc_rtc::Configuration MCController::robot_config(const mc_rbdyn::Robot & robot) const
 {
+  return robot_config(robot.module().name);
+}
+
+mc_rtc::Configuration MCController::robot_config(const std::string & robot) const
+{
   mc_rtc::Configuration result;
-  bfs::path system_path = bfs::path(loading_location_) / this->name_ / (robot.module().name + ".conf");
+  bfs::path system_path = bfs::path(loading_location_) / this->name_ / (robot + ".conf");
 #ifndef WIN32
   bfs::path user_path = bfs::path(std::getenv("HOME")) / ".config/mc_rtc/controllers";
 #else
   bfs::path user_path = bfs::path(std::getenv("APPDATA")) / "mc_rtc/controllers";
 #endif
-  user_path = user_path / name_ / (robot.module().name + ".conf");
+  user_path = user_path / name_ / (robot + ".conf");
   auto load_conf = [&result](const std::string & path) {
     result.load(path);
     mc_rtc::log::info("Controller's robot configuration loaded from {}", path);

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -74,6 +74,13 @@ void MCController::set_loading_location(std::string_view location)
   MC_CONTROLLER_LOADING_LOCATION = location;
 }
 
+static thread_local std::string MC_CONTROLLER_NAME = "";
+
+void MCController::set_name(std::string_view name)
+{
+  MC_CONTROLLER_NAME = name;
+}
+
 MCController::MCController(std::shared_ptr<mc_rbdyn::RobotModule> robot, double dt, Backend backend)
 : MCController(robot, dt, {}, backend)
 {
@@ -114,7 +121,7 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
 : qpsolver(make_solver(dt, backend)), outputRobots_(mc_rbdyn::Robots::make()),
   outputRealRobots_(mc_rbdyn::Robots::make()),
   logger_(std::make_shared<mc_rtc::Logger>(mc_rtc::Logger::Policy::NON_THREADED, "", "")),
-  gui_(std::make_shared<mc_rtc::gui::StateBuilder>()), config_(config), timeStep(dt),
+  gui_(std::make_shared<mc_rtc::gui::StateBuilder>()), config_(config), timeStep(dt), name_(MC_CONTROLLER_NAME),
   loading_location_(MC_CONTROLLER_LOADING_LOCATION)
 {
   /* Load robots */

--- a/src/mc_control/fsm/Controller.cpp
+++ b/src/mc_control/fsm/Controller.cpp
@@ -22,8 +22,11 @@ namespace fsm
 std::unique_ptr<StateFactory> Controller::factory_ptr_;
 #endif
 
-Controller::Controller(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & config, Backend backend)
-: MCController(std::vector<mc_rbdyn::RobotModulePtr>{rm}, dt, config, backend),
+Controller::Controller(mc_rbdyn::RobotModulePtr rm,
+                       double dt,
+                       const mc_rtc::Configuration & config,
+                       ControllerParameters params)
+: MCController(std::vector<mc_rbdyn::RobotModulePtr>{rm}, dt, config, params),
 #ifndef MC_RTC_BUILD_STATIC
   factory_(config("StatesLibraries", std::vector<std::string>{}),
            config("StatesFiles", std::vector<std::string>{}),

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -989,7 +989,6 @@ bool MCGlobalController::AddController(const std::string & name)
       controllers[name] = controller_loader->create_object(name, config.main_robot_module, config.timestep,
                                                            config.controllers_configs[name]);
     }
-    controllers[name]->name_ = name;
     controllers[name]->datastore().make_call("Global::EnableController",
                                              [this](const std::string & name) { return EnableController(name); });
     if(config.enable_log)

--- a/src/mc_rtc/loader.in.cpp
+++ b/src/mc_rtc/loader.in.cpp
@@ -147,6 +147,11 @@ void LTDLHandle::close()
 #endif
 }
 
+std::string LTDLHandle::dir() const
+{
+  return bfs::path(path_).parent_path().string();
+}
+
 Loader::callback_t Loader::default_cb = [](const std::string &, LTDLHandle &) {};
 
 std::string Loader::debug_suffix = "/debug";

--- a/tests/controllers/CMakeLists.txt
+++ b/tests/controllers/CMakeLists.txt
@@ -133,13 +133,15 @@ macro(controller_test_run NAME NRITER)
           INPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/etc/${VARIANT}.cmake.yaml")
       endif()
     endif()
-    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${NAME}.jvrc1.in.yaml")
-      configure_file(${NAME}.jvrc1.in.yaml "${TEST_CONTROLLER_PATH_BASE}/${VARIANT}/jvrc1.cmake.yaml")
-      file(GENERATE
-        OUTPUT "${TEST_CONTROLLER_PATH}/${VARIANT}/jvrc1.yaml"
-        INPUT "${TEST_CONTROLLER_PATH_BASE}/${VARIANT}/jvrc1.cmake.yaml"
-      )
-    endif()
+    foreach(ROBOT jvrc1 jvrc2)
+      if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${NAME}.${ROBOT}.in.yaml")
+        configure_file(${NAME}.${ROBOT}.in.yaml "${TEST_CONTROLLER_PATH_BASE}/${VARIANT}/${ROBOT}.cmake.yaml")
+        file(GENERATE
+          OUTPUT "${TEST_CONTROLLER_PATH}/${VARIANT}/${ROBOT}.yaml"
+          INPUT "${TEST_CONTROLLER_PATH_BASE}/${VARIANT}/${ROBOT}.cmake.yaml"
+        )
+      endif()
+    endforeach()
     if(TARGET ${VARIANT})
       set_target_properties(${VARIANT} PROPERTIES FOLDER tests/controllers/run/details)
     endif()

--- a/tests/controllers/CMakeLists.txt
+++ b/tests/controllers/CMakeLists.txt
@@ -64,6 +64,7 @@ macro(controller_test_common NAME)
   set(PYTHON_CONTROLLER_PATH "${CMAKE_BINARY_DIR}/src/mc_control/python")
   set(ROBOT_MODULE_PATH "${CMAKE_BINARY_DIR}/src/mc_robots")
   set(TEST_CONTROLLER_PATH "${CMAKE_CURRENT_BINARY_DIR}/${TEST_CONTROLLER_NAME}")
+  set(TEST_CONTROLLER_PATH_BASE "${TEST_CONTROLLER_PATH}")
   if(CMAKE_CONFIGURATION_TYPES)
     set(OBSERVER_MODULE_PATH "${OBSERVER_MODULE_PATH}/$<CONFIGURATION>")
     set(PYTHON_CONTROLLER_PATH "${PYTHON_CONTROLLER_PATH}/$<CONFIGURATION>")
@@ -131,6 +132,13 @@ macro(controller_test_run NAME NRITER)
           OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/etc/${VARIANT}.yaml"
           INPUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/etc/${VARIANT}.cmake.yaml")
       endif()
+    endif()
+    if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${NAME}.jvrc1.in.yaml")
+      configure_file(${NAME}.jvrc1.in.yaml "${TEST_CONTROLLER_PATH_BASE}/${VARIANT}/jvrc1.cmake.yaml")
+      file(GENERATE
+        OUTPUT "${TEST_CONTROLLER_PATH}/${VARIANT}/jvrc1.yaml"
+        INPUT "${TEST_CONTROLLER_PATH_BASE}/${VARIANT}/jvrc1.cmake.yaml"
+      )
     endif()
     if(TARGET ${VARIANT})
       set_target_properties(${VARIANT} PROPERTIES FOLDER tests/controllers/run/details)
@@ -261,6 +269,8 @@ controller_test_run(TestCoMInBoxController 4001)
 controller_test_run(TestCollisionController 2001)
 # mc_global_controller behavior test
 controller_test_run(TestCanonicalRobotController 2001)
+# Configuration test
+controller_test_run(TestRobotConfigurationController 1)
 
 # Test FSM generic state configuration option
 set(FSM_STATES_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/src/mc_control/fsm/states/")

--- a/tests/controllers/TestRobotConfigurationController.cpp
+++ b/tests/controllers/TestRobotConfigurationController.cpp
@@ -17,8 +17,11 @@ namespace mc_control
 struct MC_CONTROL_DLLAPI TestRobotConfigurationControllerController : public MCController
 {
 public:
-  TestRobotConfigurationControllerController(mc_rbdyn::RobotModulePtr rm, double dt, Backend backend)
-  : MCController(rm, dt, backend)
+  TestRobotConfigurationControllerController(mc_rbdyn::RobotModulePtr rm,
+                                             double dt,
+                                             const mc_rtc::Configuration & config,
+                                             Backend backend)
+  : MCController(rm, dt, config, backend)
   {
     // Check that the default constructor loads the robot + ground environment
     BOOST_CHECK_EQUAL(robots().size(), 2);
@@ -30,6 +33,7 @@ public:
     qpsolver->addConstraintSet(*compoundJointConstraint);
     qpsolver->addTask(postureTask.get());
     qpsolver->setContacts({});
+    check_controller_config();
     check_robot_config();
     mc_rtc::log::success("Created TestRobotConfigurationControllerController");
   }
@@ -42,15 +46,29 @@ public:
   virtual void reset(const ControllerResetData & reset_data) override
   {
     check_robot_config();
+    check_controller_config();
     MCController::reset(reset_data);
+  }
+
+  void check_config(const mc_rtc::Configuration & config)
+  {
+    BOOST_REQUIRE(config.has("MagicSetting"));
+    double setting = config("MagicSetting");
+    BOOST_REQUIRE(std::fabs(setting - 42.42) < 1e-6);
   }
 
   void check_robot_config()
   {
-    auto config = robot_config(robot());
-    BOOST_REQUIRE(config.has("MagicSetting"));
-    double setting = config("MagicSetting");
-    BOOST_REQUIRE(std::fabs(setting - 42.42) < 1e-6);
+    check_config(robot_config(robot()));
+  }
+
+  void check_controller_config()
+  {
+    BOOST_REQUIRE(config_.has("robots"));
+    auto c_robots = config_("robots");
+    BOOST_REQUIRE(c_robots.has("jvrc1"));
+    auto c_jvrc1 = c_robots("jvrc1");
+    check_config(c_jvrc1);
   }
 
 private:
@@ -61,6 +79,6 @@ private:
 using Controller = mc_control::TestRobotConfigurationControllerController;
 using Backend = mc_control::MCController::Backend;
 MULTI_CONTROLLERS_CONSTRUCTOR("TestRobotConfigurationController",
-                              Controller(rm, dt, Backend::Tasks),
+                              Controller(rm, dt, config, Backend::Tasks),
                               "TestRobotConfigurationController_TVM",
-                              Controller(rm, dt, Backend::TVM))
+                              Controller(rm, dt, config, Backend::TVM))

--- a/tests/controllers/TestRobotConfigurationController.cpp
+++ b/tests/controllers/TestRobotConfigurationController.cpp
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#ifdef BOOST_TEST_MAIN
+#  undef BOOST_TEST_MAIN
+#endif
+#include <mc_control/api.h>
+#include <mc_control/mc_controller.h>
+#include <mc_rtc/logging.h>
+
+#include <boost/test/unit_test.hpp>
+
+namespace mc_control
+{
+
+struct MC_CONTROL_DLLAPI TestRobotConfigurationControllerController : public MCController
+{
+public:
+  TestRobotConfigurationControllerController(mc_rbdyn::RobotModulePtr rm, double dt, Backend backend)
+  : MCController(rm, dt, backend)
+  {
+    // Check that the default constructor loads the robot + ground environment
+    BOOST_CHECK_EQUAL(robots().size(), 2);
+    // Check that JVRC-1 was loaded
+    BOOST_CHECK_EQUAL(robot().name(), "jvrc1");
+    qpsolver->addConstraintSet(contactConstraint);
+    qpsolver->addConstraintSet(kinematicsConstraint);
+    qpsolver->addConstraintSet(selfCollisionConstraint);
+    qpsolver->addConstraintSet(*compoundJointConstraint);
+    qpsolver->addTask(postureTask.get());
+    qpsolver->setContacts({});
+    check_robot_config();
+    mc_rtc::log::success("Created TestRobotConfigurationControllerController");
+  }
+
+  virtual bool run() override
+  {
+    return MCController::run();
+  }
+
+  virtual void reset(const ControllerResetData & reset_data) override
+  {
+    check_robot_config();
+    MCController::reset(reset_data);
+  }
+
+  void check_robot_config()
+  {
+    auto config = robot_config(robot());
+    BOOST_REQUIRE(config.has("MagicSetting"));
+    double setting = config("MagicSetting");
+    BOOST_REQUIRE(std::fabs(setting - 42.42) < 1e-6);
+  }
+
+private:
+};
+
+} // namespace mc_control
+
+using Controller = mc_control::TestRobotConfigurationControllerController;
+using Backend = mc_control::MCController::Backend;
+MULTI_CONTROLLERS_CONSTRUCTOR("TestRobotConfigurationController",
+                              Controller(rm, dt, Backend::Tasks),
+                              "TestRobotConfigurationController_TVM",
+                              Controller(rm, dt, Backend::TVM))

--- a/tests/controllers/TestRobotConfigurationController.in.yaml
+++ b/tests/controllers/TestRobotConfigurationController.in.yaml
@@ -1,0 +1,3 @@
+robots:
+  jvrc2:
+    module: JVRC1

--- a/tests/controllers/TestRobotConfigurationController.jvrc1.in.yaml
+++ b/tests/controllers/TestRobotConfigurationController.jvrc1.in.yaml
@@ -1,0 +1,1 @@
+MagicSetting: 42.42

--- a/tests/controllers/TestRobotConfigurationController.jvrc2.in.yaml
+++ b/tests/controllers/TestRobotConfigurationController.jvrc2.in.yaml
@@ -1,0 +1,1 @@
+MagicSetting: 100.0


### PR DESCRIPTION
See #325 for the motivation of this PR

This exposes a robot's specific configuration for given controllers that can be stored alongside the controller or in the user's home directory.

I have left out the other components that could benefit from this (e.g. observers and plugins) but this can be added based on the functionalities added here.