### PR TITLE
[utils/mc_rtc_new_controller] Remove config from the controller members

### DIFF
--- a/utils/mc_rtc_new_controller.in.py
+++ b/utils/mc_rtc_new_controller.in.py
@@ -115,11 +115,11 @@ set_target_properties(${{PROJECT_NAME}} PROPERTIES COMPILE_FLAGS "-D{controller_
 
 struct {controller_class_name}_DLLAPI {controller_class_name} : public {base_class}
 {{
-    {controller_class_name}(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & config);
+  {controller_class_name}(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & config);
 
-    bool run() override;
+  bool run() override;
 
-    void reset(const mc_control::ControllerResetData & reset_data) override;
+  void reset(const mc_control::ControllerResetData & reset_data) override;
 }};""".format(controller_class_name = controller_class_name, base_class = base_class, extra_includes = extra_includes))
 
     with open(project_dir + '/src/' + controller_class_name + '.cpp', 'w') as fd:
@@ -128,8 +128,7 @@ struct {controller_class_name}_DLLAPI {controller_class_name} : public {base_cla
             base_init += ", config"
         base_init += ')'
         if min_code:
-            min_code = """  config_.load(config);
-  solver().addConstraintSet(contactConstraint);
+            min_code = """  solver().addConstraintSet(contactConstraint);
   solver().addConstraintSet(kinematicsConstraint);
   solver().addTask(postureTask);
   solver().setContacts({{}});

--- a/utils/mc_rtc_new_controller.in.py
+++ b/utils/mc_rtc_new_controller.in.py
@@ -120,8 +120,6 @@ struct {controller_class_name}_DLLAPI {controller_class_name} : public {base_cla
     bool run() override;
 
     void reset(const mc_control::ControllerResetData & reset_data) override;
-private:
-    mc_rtc::Configuration config_;
 }};""".format(controller_class_name = controller_class_name, base_class = base_class, extra_includes = extra_includes))
 
     with open(project_dir + '/src/' + controller_class_name + '.cpp', 'w') as fd:

--- a/utils/mc_rtc_new_fsm_controller.in.py
+++ b/utils/mc_rtc_new_fsm_controller.in.py
@@ -123,15 +123,13 @@ add_fsm_data_directory(data)
 
 struct {controller_name}_Initial : mc_control::fsm::State
 {{
+  void configure(const mc_rtc::Configuration & config) override;
 
-    void configure(const mc_rtc::Configuration & config) override;
+  void start(mc_control::fsm::Controller & ctl) override;
 
-    void start(mc_control::fsm::Controller & ctl) override;
+  bool run(mc_control::fsm::Controller & ctl) override;
 
-    bool run(mc_control::fsm::Controller & ctl) override;
-
-    void teardown(mc_control::fsm::Controller & ctl) override;
-private:
+  void teardown(mc_control::fsm::Controller & ctl) override;
 }};
 """.format(controller_name = controller_name))
     with open(project_dir + '/src/states/{}_Initial.cpp'.format(controller_name), 'w') as fd:


### PR DESCRIPTION
Since `config_` is a member of `MCController`, it would be confusing to have the same member in an inherited class.

https://github.com/jrl-umi3218/mc_rtc/blob/8d2ad7e5db5153c99fd929c0869da0acc0cb2dbf/include/mc_control/MCController.h#L715-L716