### PR TITLE
Introduce new log format to improve logging performances

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,9 @@ jobs:
         build-type: [Debug, RelWithDebInfo, script]
         compiler: [gcc, clang]
         exclude:
-          # Only default compiler on macos-latest and windows-latest
+          # Only default compiler on ubuntu-18.04, macos-latest and windows-latest
+          - os: ubuntu-18.04
+            compiler: clang
           - os: macos-latest
             compiler: clang
           - os: windows-latest

--- a/include/mc_rtc/log/Logger.h
+++ b/include/mc_rtc/log/Logger.h
@@ -167,8 +167,9 @@ public:
       log::error("Already logging an entry named {}", name);
       return;
     }
-    log_events_.push_back(KeyAddedEvent{log::callback_is_serializable<CallbackT>::log_type, name});
-    log_entries_.push_back({name, source, [get_fn](mc_rtc::MessagePackBuilder & builder) mutable {
+    auto log_type = log::callback_is_serializable<CallbackT>::log_type;
+    log_events_.push_back(KeyAddedEvent{log_type, name});
+    log_entries_.push_back({log_type, name, source, [get_fn](mc_rtc::MessagePackBuilder & builder) mutable {
                               mc_rtc::log::LogWriter<base_t>::write(get_fn(), builder);
                             }});
   }
@@ -297,6 +298,8 @@ private:
   /** Hold information about a log entry stored in this instance */
   struct LogEntry
   {
+    /** Type of the entry */
+    log::LogType type;
     /** Name of the entry */
     std::string key;
     /** What is the data source (can be nullptr) */

--- a/include/mc_rtc/log/Logger.h
+++ b/include/mc_rtc/log/Logger.h
@@ -10,6 +10,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <variant>
 
 namespace mc_rtc
 {
@@ -28,6 +29,11 @@ struct MC_RTC_UTILS_DLLAPI Logger
 public:
   /** Magic number used to identify binary logs */
   static const uint8_t magic[4];
+  /** Version of the log format
+   *
+   * This is stored in the binary file as data[3] - magic[3]
+   */
+  static const uint8_t version;
   /** A function that fills LogData vectors */
   typedef std::function<void(mc_rtc::MessagePackBuilder &)> serialize_fn;
   /*! \brief Defines available policies for the logger */
@@ -50,6 +56,24 @@ public:
      */
     THREADED = 1
   };
+
+  /*! \brief Data for a key added event */
+  struct KeyAddedEvent
+  {
+    /** Type of the key being added */
+    log::LogType type;
+    /** Name of the key being added */
+    std::string key;
+  };
+
+  /*! \brief Data for a key removed event */
+  struct KeyRemovedEvent
+  {
+    /** Name of the key being removed */
+    std::string key;
+  };
+
+  using LogEvent = std::variant<KeyAddedEvent, KeyRemovedEvent>;
 
 public:
   /*! \brief Constructor
@@ -137,15 +161,16 @@ public:
   {
     using ret_t = decltype(get_fn());
     using base_t = typename std::decay<ret_t>::type;
-    if(log_entries_.count(name))
+    auto it = find_entry(name);
+    if(it != log_entries_.end())
     {
       log::error("Already logging an entry named {}", name);
       return;
     }
-    log_entries_changed_ = true;
-    log_entries_[name] = {source, [get_fn](mc_rtc::MessagePackBuilder & builder) mutable {
-                            mc_rtc::log::LogWriter<base_t>::write(get_fn(), builder);
-                          }};
+    log_events_.push_back(KeyAddedEvent{log::callback_is_serializable<CallbackT>::log_type, name});
+    log_entries_.push_back({name, source, [get_fn](mc_rtc::MessagePackBuilder & builder) mutable {
+                              mc_rtc::log::LogWriter<base_t>::write(get_fn(), builder);
+                            }});
   }
 
   /** Add a log entry from a source and a compile-time pointer to member
@@ -272,6 +297,8 @@ private:
   /** Hold information about a log entry stored in this instance */
   struct LogEntry
   {
+    /** Name of the entry */
+    std::string key;
     /** What is the data source (can be nullptr) */
     const void * source;
     /** Callback to log data */
@@ -279,10 +306,12 @@ private:
   };
   /** Store implementation detail related to the logging policy */
   std::shared_ptr<LoggerImpl> impl_ = nullptr;
-  /** Set to true when log entries are added or removed */
-  bool log_entries_changed_ = false;
+  /** Events that happened since the last time we wrote to the log */
+  std::vector<LogEvent> log_events_;
   /** Contains all the log entries */
-  std::unordered_map<std::string, LogEntry> log_entries_;
+  std::vector<LogEntry> log_entries_;
+
+  std::vector<LogEntry>::iterator find_entry(const std::string & name);
 
   /** Terminal condition for addLogEntries */
   template<typename SourceT>

--- a/include/mc_rtc/log/utils.h
+++ b/include/mc_rtc/log/utils.h
@@ -120,6 +120,7 @@ struct GetLogType<Eigen::Ref<Type, Options, StrideType>>
 template<typename T>
 struct is_serializable
 {
+  static constexpr LogType type = GetLogType<T>::type;
   static constexpr bool value = GetLogType<T>::type != mc_rtc::log::LogType::None;
 };
 
@@ -167,6 +168,7 @@ struct callback_is_serializable<T, void_t<typename std::result_of<T()>::type>>
 {
   using ret_type = typename std::result_of<T()>::type;
   using base_type = typename std::decay<ret_type>::type;
+  static constexpr LogType log_type = is_serializable<base_type>::type;
   static constexpr bool value = is_serializable<base_type>::value;
 };
 
@@ -176,7 +178,6 @@ struct LogWriter
 {
   static void write(const T & data, mc_rtc::MessagePackBuilder & builder)
   {
-    builder.write(static_cast<typename std::underlying_type<LogType>::type>(GetLogType<T>::type));
     builder.write(data);
   }
 };

--- a/src/mc_rtc/Logger.cpp
+++ b/src/mc_rtc/Logger.cpp
@@ -234,16 +234,24 @@ void Logger::start(const std::string & ctl_name, double timestep, bool resume, d
   }
   if(impl_->log_.is_open())
   {
+    if(resume)
+    {
+      // Repeat the added key events
+      for(const auto & e : log_entries_)
+      {
+        log_events_.push_back(KeyAddedEvent{e.type, e.key});
+      }
+    }
+    else
+    {
+      impl_->log_iter_ = start_t;
+    }
     if(find_entry("t") == log_entries_.end())
     {
       addLogEntry("t", this, [this, timestep]() {
         impl_->log_iter_ += timestep;
         return impl_->log_iter_ - timestep;
       });
-    }
-    if(!resume)
-    {
-      impl_->log_iter_ = start_t;
     }
     impl_->valid_ = true;
   }

--- a/src/mc_rtc/Logger.cpp
+++ b/src/mc_rtc/Logger.cpp
@@ -304,7 +304,7 @@ void Logger::log()
       }
       else if constexpr(std::is_same_v<T, KeyRemovedEvent>)
       {
-        builder.start_array(3);
+        builder.start_array(2);
         builder.write(static_cast<uint8_t>(1));
         builder.write(event.key);
         builder.finish_array();

--- a/src/mc_rtc/Logger.cpp
+++ b/src/mc_rtc/Logger.cpp
@@ -18,6 +18,8 @@ namespace mc_rtc
 
 const uint8_t Logger::magic[4] = {0x41, 0x4e, 0x4e, 0x45};
 
+const uint8_t Logger::version = 1;
+
 struct LoggerImpl
 {
   LoggerImpl(const std::string & directory, const std::string & tmpl)
@@ -52,7 +54,10 @@ protected:
   {
     path_ = path;
     log_.open(path, std::ofstream::binary);
-    log_.write((const char *)&Logger::magic, sizeof(Logger::magic));
+    static_assert(sizeof(uint8_t) == sizeof(char));
+    log_.write((const char *)&Logger::magic, sizeof(Logger::magic) - sizeof(uint8_t));
+    const char version = static_cast<uint8_t>(Logger::magic[3] + Logger::version);
+    log_.write(&version, sizeof(uint8_t));
   }
 };
 
@@ -179,6 +184,11 @@ void Logger::setup(const Policy & policy, const std::string & directory, const s
   };
 }
 
+auto Logger::find_entry(const std::string & name) -> std::vector<LogEntry>::iterator
+{
+  return std::find_if(log_entries_.begin(), log_entries_.end(), [&](const auto & e) { return e.key == name; });
+}
+
 void Logger::start(const std::string & ctl_name, double timestep, bool resume, double start_t)
 {
   auto get_log_path = [this, &ctl_name]() {
@@ -224,7 +234,7 @@ void Logger::start(const std::string & ctl_name, double timestep, bool resume, d
   }
   if(impl_->log_.is_open())
   {
-    if(!log_entries_.count("t"))
+    if(find_entry("t") == log_entries_.end())
     {
       addLogEntry("t", this, [this, timestep]() {
         impl_->log_iter_ += timestep;
@@ -242,8 +252,7 @@ void Logger::start(const std::string & ctl_name, double timestep, bool resume, d
     impl_->valid_ = false;
     log::error("Failed to open log file {}", log_path.string());
   }
-  // Force rewrite of the log header
-  log_entries_changed_ = true;
+  // FIXME Maybe resume is broken if we can't reconstruct a full key list
 }
 
 void Logger::open(const std::string & file, double timestep, double start_t)
@@ -251,7 +260,7 @@ void Logger::open(const std::string & file, double timestep, double start_t)
   impl_->initialize(file);
   if(impl_->log_.is_open())
   {
-    if(!log_entries_.count("t"))
+    if(find_entry("t") == log_entries_.end())
     {
       addLogEntry("t", this, [this, timestep]() {
         impl_->log_iter_ += timestep;
@@ -272,24 +281,47 @@ void Logger::log()
 {
   mc_rtc::MessagePackBuilder builder(impl_->data_);
   builder.start_array(2);
-  if(log_entries_changed_)
+  if(log_events_.size())
   {
-    builder.start_array(log_entries_.size());
-    for(auto & e : log_entries_)
+    builder.start_array(log_events_.size());
+    auto event_visitor = [&builder](auto && event) {
+      using T = std::decay_t<decltype(event)>;
+      if constexpr(std::is_same_v<T, KeyAddedEvent>)
+      {
+        builder.start_array(3);
+        builder.write(static_cast<uint8_t>(0));
+        builder.write(static_cast<typename std::underlying_type<log::LogType>::type>(event.type));
+        builder.write(event.key);
+        builder.finish_array();
+      }
+      else if constexpr(std::is_same_v<T, KeyRemovedEvent>)
+      {
+        builder.start_array(3);
+        builder.write(static_cast<uint8_t>(1));
+        builder.write(event.key);
+        builder.finish_array();
+      }
+      else
+      {
+        static_assert(!std::is_same_v<T, T>, "non-exhaustive visitor");
+      }
+    };
+
+    for(auto & e : log_events_)
     {
-      builder.write(e.first);
+      std::visit(event_visitor, e);
     }
     builder.finish_array();
-    log_entries_changed_ = false;
+    log_events_.resize(0);
   }
   else
   {
     builder.write();
   }
-  builder.start_array(2 * log_entries_.size());
+  builder.start_array(log_entries_.size());
   for(auto & e : log_entries_)
   {
-    e.second.log_cb(builder);
+    e.log_cb(builder);
   }
   builder.finish_array();
   builder.finish_array();
@@ -299,10 +331,11 @@ void Logger::log()
 
 void Logger::removeLogEntry(const std::string & name)
 {
-  if(log_entries_.count(name))
+  auto it = find_entry(name);
+  if(it != log_entries_.end())
   {
-    log_entries_changed_ = true;
-    log_entries_.erase(name);
+    log_events_.push_back(KeyRemovedEvent{name});
+    log_entries_.erase(it);
   }
 }
 
@@ -310,9 +343,9 @@ void Logger::removeLogEntries(const void * source)
 {
   for(auto it = log_entries_.begin(); it != log_entries_.end();)
   {
-    if(it->second.source == source)
+    if(it->source == source)
     {
-      log_entries_changed_ = true;
+      log_events_.push_back(KeyRemovedEvent{it->key});
       it = log_entries_.erase(it);
     }
     else

--- a/src/mc_rtc/internals/LogEntry.h
+++ b/src/mc_rtc/internals/LogEntry.h
@@ -3,6 +3,8 @@
 #include <mc_rtc/log/FlatLog.h>
 #include <mc_rtc/logging.h>
 
+#include <optional>
+
 #include "mpack.h"
 
 namespace mc_rtc


### PR DESCRIPTION
This PR changes  the way the log information is stored in the log.

- Record the callback type only once
  - Small reduction in output size
  - Small reduction in logging workload at runtime
  - Slightly higher complexity for parsing the output
  - Pave the way to events' logging
- Run through the callbacks in the order they were called
  - Required by the parser to reconstruct correctly
  - Better cache locality (maybe?)

Overall, it improves the logging performance by about 25% on e.g. BaseLineWalkingController

Old logs are still compatible with all the tools in the framework.