### PR TITLE
[mc_control] Add overwrite support for configuration

### DIFF
--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -68,10 +68,20 @@ struct MC_CONTROL_DLLAPI ControllerParameters
   ADD_PARAMETER(mc_solver::QPSolver::Backend, backend, mc_solver::QPSolver::Backend::Tasks)
   /** Whether to automatically load the robots' specific configuration (true by default) */
   ADD_PARAMETER(bool, load_robot_config, true)
-  /** Where to load the robots' configuration config("robots") by default */
-  ADD_PARAMETER(std::vector<std::string>, load_robot_config_into, {"robots"})
+  /** If true, the robot's config is loaded directly into the provided section, otherwise it is nested under the robot's
+   * module name */
+  ADD_PARAMETER(bool, overwrite_config, false)
   /** Use the module name to find robot's specific values if true (default), use the robot's name otherwise */
   ADD_PARAMETER(bool, load_robot_config_with_module_name, true)
+  /** Where to load the robots' configuration, config("robots") by default */
+  ADD_PARAMETER(std::vector<std::string>, load_robot_config_into, {"robots"})
+  /** Extra configuration file to look for and load into the specified section, furthermore:
+   * - the search path matches robots' configuration files
+   * - they are loaded after the robots' configuration files provided at construction and before the robots' specific
+   * file for dynamically specified robots, this is done to allow extra configuration files to load new robots when \ref
+   * overwrite_config is true and the configuration are loaded into the root
+   */
+  ADD_PARAMETER(std::vector<std::string>, extra_configurations, {})
 
   /** For backward compatibility purpose */
   inline ControllerParameters(mc_solver::QPSolver::Backend backend) : backend_(backend) {}

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -154,13 +154,16 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
     {
       const auto & r_name = params.load_robot_config_with_module_name_ ? robot.module().name : robot.name();
       auto load_into = load_robot_config_into;
-      if(load_into.has(r_name))
+      if(!params.overwrite_config_)
       {
-        load_into = load_into(r_name);
-      }
-      else
-      {
-        load_into = load_into.add(r_name);
+        if(load_into.has(r_name))
+        {
+          load_into = load_into(r_name);
+        }
+        else
+        {
+          load_into = load_into.add(r_name);
+        }
       }
       load_into.load(robot_config(r_name));
     }
@@ -168,6 +171,23 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   for(const auto & r : robots())
   {
     load_robot_config(r);
+  }
+  /** Load extra configuration files */
+  for(const auto & e : params.extra_configurations_)
+  {
+    auto load_into = load_robot_config_into;
+    if(!params.overwrite_config_)
+    {
+      if(load_into.has(e))
+      {
+        load_into = load_into(e);
+      }
+      else
+      {
+        load_into = load_into.add(e);
+      }
+    }
+    load_into.load(robot_config(e));
   }
 
   if(gui_)


### PR DESCRIPTION
Allow functionalities similar to those discussed in https://github.com/isri-aist/BaselineWalkingController/pull/12

The approach relies on installed files rather than nested keys in the configuration but can achieve the same effect, i.e., overwrite any main configuration entry from extraneous files

As noted in the doxygen, the extra configuration files are loaded after the robots' specific files for the robot that are provided at construction but after the ones loaded through the `robots` entry. Otherwise it would become really hard to track the loading order since those extra files can themselves specify extra robots to load.