### PR TITLE
[utils][mc_bin_to_log] check for input file extension

### DIFF
--- a/utils/mc_bin_to_log_main.cpp
+++ b/utils/mc_bin_to_log_main.cpp
@@ -21,6 +21,11 @@ int main(int argc, char * argv[])
     usage(argv[0]);
     return 1;
   }
+  if(bfs::path(argv[1]).filename().extension().string() != ".bin")
+  {
+    mc_rtc::log::error("Input file name (\"{}\") should end with .bin", argv[1]);
+    return 1;
+  }
   std::string in = argv[1];
   std::string out = "";
   if(argc == 3)


### PR DESCRIPTION
Throw error if `argv[1]` does not have a `.bin` extension