### PR TITLE
[mc_control] Allow r1 and/or r2 to be omitted in contact yaml

### DIFF
--- a/binding/python/mc_control/c_mc_control.pxd
+++ b/binding/python/mc_control/c_mc_control.pxd
@@ -29,13 +29,19 @@ cdef extern from "<memory>" namespace "std" nogil:
     unique_ptr(T*)
     T* get()
 
+cdef extern from "<optional>" namespace "std" nogil:
+  cdef cppclass optional[T]:
+    cppbool has_value()
+    T& value()
+    optional& operator=(T&)
+
 cdef extern from "<mc_control/Contact.h>" namespace "mc_control":
   cdef cppclass Contact:
     Contact()
     Contact(const string&, const string&, const string&, const string&, double)
     Contact(const string&, const string&, const string&, const string&, double, const Vector6d)
-    string r1
-    string r2
+    optional[string] r1
+    optional[string] r2
     string r1Surface
     string r2Surface
     double friction

--- a/binding/python/mc_control/mc_control.pyx
+++ b/binding/python/mc_control/mc_control.pyx
@@ -69,11 +69,14 @@ cdef class Contact(object):
       self.__ctor__(*args)
   property r1:
     def __get__(self):
-      return self.impl.r1
+      if self.impl.r1.has_value():
+        return self.impl.r1.value()
+      else:
+        return None
     def __set__(self, r1):
       if isinstance(r1, unicode):
         r1 = r1.encode(u'ascii')
-      self.impl.r1 = r1
+      self.impl.r1 = <string>(r1)
   property r1Surface:
     def __get__(self):
       return self.impl.r1Surface
@@ -83,11 +86,14 @@ cdef class Contact(object):
       self.impl.r1Surface = r1Surface
   property r2:
     def __get__(self):
-      return self.impl.r2
+      if self.impl.r2.has_value():
+        return self.impl.r2.value()
+      else:
+        return None
     def __set__(self, r2):
       if isinstance(r2, unicode):
         r2 = r2.encode(u'ascii')
-      self.impl.r2 = r2
+      self.impl.r2 = <string>(r2)
   property r2Surface:
     def __get__(self):
       return self.impl.r2Surface

--- a/include/mc_control/Contact.h
+++ b/include/mc_control/Contact.h
@@ -19,13 +19,15 @@ struct MCController;
  *
  * A lightweight variant of mc_rbdyn::Contact meant to simplify contact manipulations
  *
+ * If \ref r1 or \ref r2 is std::nullopt then the controller will use the main robot instead
+ *
  */
 struct MC_CONTROL_DLLAPI Contact
 {
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
 
-  Contact(const std::string & r1,
-          const std::string & r2,
+  Contact(const std::optional<std::string> & r1,
+          const std::optional<std::string> & r2,
           const std::string & r1Surface,
           const std::string & r2Surface,
           double friction = mc_rbdyn::Contact::defaultFriction,
@@ -34,8 +36,8 @@ struct MC_CONTROL_DLLAPI Contact
   {
   }
 
-  std::string r1;
-  std::string r2;
+  std::optional<std::string> r1;
+  std::optional<std::string> r2;
   std::string r1Surface;
   std::string r2Surface;
   mutable double friction;
@@ -78,7 +80,7 @@ struct hash<mc_control::Contact>
       h ^= std::hash<std::string>{}(surface) + 0x9e3779b9 + (h << 6) + (h >> 2);
       return h;
     };
-    return hash_combine(c.r1, c.r1Surface) ^ hash_combine(c.r2, c.r2Surface);
+    return hash_combine(c.r1.value_or(""), c.r1Surface) ^ hash_combine(c.r2.value_or(""), c.r2Surface);
   }
 };
 

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -19,6 +19,7 @@
 #include <exception>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <string_view>

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -617,6 +617,24 @@ public:
     return ConfigurationLoader<T>::load(*this);
   }
 
+  /*! \brief Retrieves an optional<T>
+   *
+   * Returns nullopt if the conversion fails
+   */
+  template<typename T>
+  operator std::optional<T>() const
+  {
+    try
+    {
+      return this->convert<T>();
+    }
+    catch(Exception & exc)
+    {
+      exc.silence();
+      return std::nullopt;
+    }
+  }
+
   /*! \brief Creates an empty configuration */
   Configuration();
 
@@ -826,7 +844,7 @@ public:
   {
     try
     {
-      return (*this)[i];
+      return (*this)[i].convert<T>();
     }
     catch(Exception & exc)
     {
@@ -852,7 +870,7 @@ public:
   {
     try
     {
-      v = (*this)(key);
+      v = (*this)(key).convert<T>();
     }
     catch(Exception & exc)
     {
@@ -875,7 +893,7 @@ public:
   {
     try
     {
-      return (*this)(key);
+      return (*this)(key).convert<T>();
     }
     catch(Exception & exc)
     {
@@ -1623,6 +1641,19 @@ public:
 private:
   Json v;
   Configuration(const Json & v);
+
+  template<typename T>
+  T convert() const
+  {
+    if constexpr(std::is_same_v<T, Configuration>)
+    {
+      return *this;
+    }
+    else
+    {
+      return this->operator T();
+    }
+  }
 };
 
 struct MC_RTC_UTILS_DLLAPI ConfigurationArrayIterator

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -622,7 +622,7 @@ public:
    * Returns nullopt if the conversion fails
    */
   template<typename T>
-  operator std::optional<T>() const
+  explicit operator std::optional<T>() const
   {
     try
     {

--- a/src/mc_control/samples/LIPMStabilizer/CMakeLists.txt
+++ b/src/mc_control/samples/LIPMStabilizer/CMakeLists.txt
@@ -3,7 +3,7 @@ add_subdirectory(src)
 mc_rtc_set_prefix(STATES mc_controller/fsm/states)
 set(LIPMStabilizer_STATES_DESTINATION_PREFIX "${MC_STATES_RUNTIME_DESTINATION_PREFIX}")
 set(LIPMStabilizer_STATES_DATA_DESTINATION_PREFIX "${MC_STATES_RUNTIME_DESTINATION_PREFIX}/data")
-set(LIPMStabilizer_INIT_STATE "Pause_2s")
+set(LIPMStabilizer_INIT_STATE "LIPMStabilizer::Pause_2s")
 configure_file(etc/LIPMStabilizer.in.yaml "${CMAKE_CURRENT_BINARY_DIR}/etc/LIPMStabilizer.yaml")
 configure_file(etc/LIPMStabilizer.in.yaml "${CMAKE_CURRENT_BINARY_DIR}/etc/LIPMStabilizer_TVM.yaml")
 

--- a/src/mc_control/samples/LIPMStabilizer/etc/LIPMStabilizer.in.yaml
+++ b/src/mc_control/samples/LIPMStabilizer/etc/LIPMStabilizer.in.yaml
@@ -57,76 +57,14 @@ states:
     # Note that in order for the stabilizer to work, roll and pitch DoF need to be free to allow for admittance
     # control of the feet, and vertical DoF to allow for foot force-difference control.
     AddContacts:
-    - r1: hrp2_drc
-      r2: ground
+    - r2: ground
       r1Surface: LeftFoot
       r2Surface: AllGround
       dof: [0, 0, 1, 1, 1, 0]
-    - r1: hrp2_drc
-      r2: ground
+    - r2: ground
       r1Surface: RightFoot
       r2Surface: AllGround
       dof: [0, 0, 1, 1, 1, 0]
-
-    StabilizerConfig:
-      enabled: true
-
-      ###########################
-      ## Stabilizer configuration
-      ###########################
-      # Default values for these robot-specific parameters are set in the corresponding robot module.
-      # You may choose to override any of them here, with due caution.
-      hrp2_drc:
-        leftFootSurface: LeftFoot
-        rightFootSurface: RightFoot
-        friction: 0.8
-        torsoBodyName: CHEST_LINK1
-        # Configuration  of the QP tasks used by the stabilizer
-        tasks:
-          com:
-            stiffness: [1000, 1000, 100]
-            weight: 1000
-            active_joints: [Root, RLEG_JOINT0, RLEG_JOINT1, RLEG_JOINT2, RLEG_JOINT3, RLEG_JOINT4, RLEG_JOINT5, LLEG_JOINT0, LLEG_JOINT1, LLEG_JOINT2, LLEG_JOINT3, LLEG_JOINT4, LLEG_JOINT5]
-            height: 0.87
-          contact:
-            damping: 300
-            stiffness: 1
-            weight: 10000
-
-        # Weights for the force-distribution QP
-        fdqp_weights:
-          net_wrench: 10000
-          ankle_torque: 100
-          pressure: 1
-
-        # Vertical drift frequency
-        vdc:
-          frequency: 1
-          stiffness: 1000
-
-        # Admittance coefficients (force-control)
-        admittance:
-          cop: [0.001, 0.001]
-
-        ########################
-        # Gains for DCM tracking
-        ########################
-        # These are the main gains of the stabilizer.
-        dcm_tracking:
-          gains:
-            prop: 3
-            integral: 20
-            deriv: 0.5
-          derivator_time_constant: 5
-          integrator_time_constant: 30
-
-      # Change some parameters for another robot
-      jvrc1:
-        dcm_tracking:
-          gains:
-            prop: 4
-            integral: 10
-            deriv: 0.5
 
   ###
   # Simple foot lifting
@@ -191,18 +129,36 @@ states:
   LIPMStabilizer::Stabilized::LiftRightFoot:
     base: Parallel
     states: [Stabilizer::LeftSupport, LIPMStabilizer::LiftRightFoot]
+    RemoveContacts:
+      - r2: ground
+        r1Surface: RightFoot
+        r2Surface: AllGround
 
   LIPMStabilizer::Stabilized::LiftLeftFoot:
     base: Parallel
     states: [Stabilizer::RightSupport, LIPMStabilizer::LiftLeftFoot]
+    RemoveContacts:
+      - r2: ground
+        r1Surface: LeftFoot
+        r2Surface: AllGround
 
   LIPMStabilizer::Stabilized::PutRightFoot:
     base: Parallel
     states: [Stabilizer::LeftSupport, LIPMStabilizer::PutRightFoot]
+    AddContactsAfter:
+      - r2: ground
+        r1Surface: RightFoot
+        r2Surface: AllGround
+        dof: [0, 0, 1, 1, 1, 0]
 
   LIPMStabilizer::Stabilized::PutLeftFoot:
     base: Parallel
     states: [Stabilizer::RightSupport, LIPMStabilizer::PutLeftFoot]
+    AddContactsAfter:
+      - r2: ground
+        r1Surface: LeftFoot
+        r2Surface: AllGround
+        dof: [0, 0, 1, 1, 1, 0]
 
   LIPMStabilizer::Stabilized::StayLeft:
     base: Stabilizer::GoLeft
@@ -293,10 +249,28 @@ states:
   LIPMStabilizer::Stabilized::LeftFootTrajectory:
     base: Parallel
     states: [Stabilizer::RightSupport, LIPMStabilizer::LeftFootTrajectory]
+    RemoveContacts:
+      - r2: ground
+        r1Surface: LeftFoot
+        r2Surface: AllGround
+    AddContactsAfter:
+      - r2: ground
+        r1Surface: LeftFoot
+        r2Surface: AllGround
+        dof: [0, 0, 1, 1, 1, 0]
 
   LIPMStabilizer::Stabilized::RightFootTrajectory:
     base: Parallel
     states: [Stabilizer::LeftSupport, LIPMStabilizer::RightFootTrajectory]
+    RemoveContacts:
+      - r2: ground
+        r1Surface: RightFoot
+        r2Surface: AllGround
+    AddContactsAfter:
+      - r2: ground
+        r1Surface: RightFoot
+        r2Surface: AllGround
+        dof: [0, 0, 1, 1, 1, 0]
 
   LIPMStabilizer::WalkingFSM::RightStep:
     base: Meta
@@ -347,10 +321,28 @@ states:
   LIPMStabilizer::Stabilized::LeftFootBackwardTrajectory:
     base: Parallel
     states: [Stabilizer::RightSupport, LIPMStabilizer::LeftFootBackwardTrajectory]
+    RemoveContacts:
+      - r2: ground
+        r1Surface: LeftFoot
+        r2Surface: AllGround
+    AddContactsAfter:
+      - r2: ground
+        r1Surface: LeftFoot
+        r2Surface: AllGround
+        dof: [0, 0, 1, 1, 1, 0]
 
   LIPMStabilizer::Stabilized::RightFootBackwardTrajectory:
     base: Parallel
     states: [Stabilizer::LeftSupport, LIPMStabilizer::RightFootBackwardTrajectory]
+    RemoveContacts:
+      - r2: ground
+        r1Surface: RightFoot
+        r2Surface: AllGround
+    AddContactsAfter:
+      - r2: ground
+        r1Surface: RightFoot
+        r2Surface: AllGround
+        dof: [0, 0, 1, 1, 1, 0]
 
   LIPMStabilizer::WalkingFSM::RightBackwardStep:
     base: Meta
@@ -384,20 +376,20 @@ states:
 ###
 transitions:
   # Stand from left to right support and lift and put down feet
-- [LIPMStabilizer::Pause_2s, OK, Stabilizer::Standing, Auto]
-- [Stabilizer::Standing, Lift feet, LIPMStabilizer::StandingFSM::AlternateFeetLifting, Auto]
-- [LIPMStabilizer::StandingFSM::AlternateFeetLifting, OK, Stabilizer::Standing, Auto]
+- [LIPMStabilizer::Pause_2s, OK, LIPMStabilizer::CustomConfiguration, Auto]
+- [LIPMStabilizer::CustomConfiguration, Lift feet, LIPMStabilizer::StandingFSM::AlternateFeetLifting, Auto]
+- [LIPMStabilizer::StandingFSM::AlternateFeetLifting, OK, LIPMStabilizer::CustomConfiguration, Auto]
   # Stand from left to right support and lift and put down feet (manual user input)
-- [Stabilizer::Standing, Lift feet (Manual), LIPMStabilizer::StandingFSM::AlternateFeetLiftingManual, Auto]
-- [LIPMStabilizer::StandingFSM::AlternateFeetLiftingManual, OK, Stabilizer::Standing, Auto]
+- [LIPMStabilizer::CustomConfiguration, Lift feet (Manual), LIPMStabilizer::StandingFSM::AlternateFeetLiftingManual, Auto]
+- [LIPMStabilizer::StandingFSM::AlternateFeetLiftingManual, OK, LIPMStabilizer::CustomConfiguration, Auto]
   # Walk one step forward in a stabilized semi quasi-static way
-- [Stabilizer::Standing, Step Forward, LIPMStabilizer::WalkingFSM::StepForward, Auto]
-- [LIPMStabilizer::WalkingFSM::StepForward, OK, Stabilizer::Standing, Auto]
+- [LIPMStabilizer::CustomConfiguration, Step Forward, LIPMStabilizer::WalkingFSM::StepForward, Auto]
+- [LIPMStabilizer::WalkingFSM::StepForward, OK, LIPMStabilizer::CustomConfiguration, Auto]
   # Walk one step backwards in a stabilized semi quasi-static way
-- [Stabilizer::Standing, Step Backward, LIPMStabilizer::WalkingFSM::StepBackward, Auto]
-- [LIPMStabilizer::WalkingFSM::StepBackward, OK, Stabilizer::Standing, Auto]
-#   # Go back to list of choices
-- [Stabilizer::GoCenter, OK, Stabilizer::Standing]
+- [LIPMStabilizer::CustomConfiguration, Step Backward, LIPMStabilizer::WalkingFSM::StepBackward, Auto]
+- [LIPMStabilizer::WalkingFSM::StepBackward, OK, LIPMStabilizer::CustomConfiguration, Auto]
+  # Go back to list of choices
+- [Stabilizer::GoCenter, OK, LIPMStabilizer::CustomConfiguration]
 
 # Initial state
 init: @LIPMStabilizer_INIT_STATE@

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -176,6 +176,8 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
   /*! Check that accessing a non-existing entry throws */
   BOOST_CHECK_THROW(config("NONE"), mc_rtc::Configuration::Exception);
 
+  BOOST_CHECK(config("NONE", std::optional<mc_rtc::Configuration>{}) == std::nullopt);
+
   /* int tests */
   {
     /*! Check that we can access a direct int entry */
@@ -208,6 +210,18 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
     int g = 0;
     config("dict")("int", g);
     BOOST_CHECK_EQUAL(g, 42);
+
+    /*! Similar checks with optional */
+
+    std::optional<int> h = config("int");
+    BOOST_CHECK(h.has_value() && h.value() == 42);
+
+    std::optional<int> i;
+    config("int", i);
+    BOOST_CHECK(i.has_value() && i.value() == 42);
+
+    std::optional<int> j = config("double").operator std::optional<int>();
+    BOOST_CHECK(!j.has_value());
   }
 
   /* unsigned int tests */

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -220,8 +220,11 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
     config("int", i);
     BOOST_CHECK(i.has_value() && i.value() == 42);
 
-    std::optional<int> j = config("double").operator std::optional<int>();
+    auto j = config("double").operator std::optional<int>();
     BOOST_CHECK(!j.has_value());
+
+    auto k = config("double", std::optional<int>{std::nullopt});
+    BOOST_CHECK(k == std::nullopt);
   }
 
   /* unsigned int tests */

--- a/utils/mc_rtc_new_fsm_controller.in.py
+++ b/utils/mc_rtc_new_fsm_controller.in.py
@@ -56,12 +56,10 @@ collisions:
   useMinimal: true
 # Initial set of contacts
 contacts:
-- r1: jvrc1
-  r2: ground
+- r2: ground
   r1Surface: LeftFoot
   r2Surface: AllGround
-- r1: jvrc1
-  r2: ground
+- r2: ground
   r1Surface: RightFoot
   r2Surface: AllGround
 


### PR DESCRIPTION
The benefit of this is illustrated in the LIPMStabilizer sample which now enables solver contacts with any biped robot.

To support this, `mc_rtc::Configuration` now also supports `std::optional<T>` with the following caveat.

Conversion might have to be more explicit than usual, for example, given this yaml:
```yaml
double: 42.42
```

The following could be expected:
```cpp
// int i = config("double"); // <-- Throws because the types do no match
std::optional<int> o = config("double"); // <-- Should return std::nullopt
```

But it actually throws because `config("double")` can be converted to an `int` and is thus used by the assignment operator of `std::optional<int>` instead of the conversion from `Configuration` to `std::optional<int>`

To use the `std::optional` conversion in such a context, one needs to call the conversion operator explicitly:
```cpp
auto o = config("double").operator std::optional<int>();
```