### PR TITLE
New method for force distribution based on horizon reference

### DIFF
--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -431,8 +431,15 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   Eigen::Vector3d comDimWeight = Eigen::Vector3d::Ones(); /**< Dimensional weight of CoM IK task */
   double comHeight = 0.84; /**< Desired height of the CoM */
 
+  std::vector<std::string> leftCopActiveJoints; /**< Joints used by CoP Admittance task */
+  std::vector<std::string> rightCopActiveJoints; /**< Joints used by CoP Admittance task */
+
+
+  Eigen::Vector2d copSlope = Eigen::Vector2d::Zero();
+  Eigen::Vector2d lambdaCoPSupportFoot = Eigen::Vector2d::Ones() * 100;
   Eigen::Vector3d lambdaCoP =
       Eigen::Vector3d::Ones() * 100; /**< 1st order gain constant between a reference CoP and the real */
+
   double delayCoP = 0;
 
   std::string torsoBodyName; /**< Name of the torso body */
@@ -507,6 +514,17 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       auto admittance = config("admittance");
       admittance("cop", copAdmittance);
       admittance("copLambda", lambdaCoP);
+      lambdaCoPSupportFoot = lambdaCoP.segment(0,2);
+      admittance("copLambdaSupportFoot", lambdaCoPSupportFoot);
+      leftCopActiveJoints = comActiveJoints;
+      rightCopActiveJoints = comActiveJoints;
+      if(admittance.has("copActiveJoints"))
+      {
+        auto copJoints = admittance("copActiveJoints");
+        copJoints("left",leftCopActiveJoints);
+        copJoints("right",rightCopActiveJoints);
+      }
+      admittance("copSlope", copSlope);
       admittance("copDelay", delayCoP);
       admittance("maxVel", copMaxVel);
       admittance("velFilterGain", mc_filter::utils::clamp(copVelFilterGain, 0, 1));

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -431,15 +431,8 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   Eigen::Vector3d comDimWeight = Eigen::Vector3d::Ones(); /**< Dimensional weight of CoM IK task */
   double comHeight = 0.84; /**< Desired height of the CoM */
 
-  std::vector<std::string> leftCopActiveJoints; /**< Joints used by CoP Admittance task */
-  std::vector<std::string> rightCopActiveJoints; /**< Joints used by CoP Admittance task */
-
-
-  Eigen::Vector2d copSlope = Eigen::Vector2d::Zero();
-  Eigen::Vector2d lambdaCoPSupportFoot = Eigen::Vector2d::Ones() * 100;
   Eigen::Vector3d lambdaCoP =
       Eigen::Vector3d::Ones() * 100; /**< 1st order gain constant between a reference CoP and the real */
-
   double delayCoP = 0;
 
   std::string torsoBodyName; /**< Name of the torso body */
@@ -514,17 +507,6 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       auto admittance = config("admittance");
       admittance("cop", copAdmittance);
       admittance("copLambda", lambdaCoP);
-      lambdaCoPSupportFoot = lambdaCoP.segment(0,2);
-      admittance("copLambdaSupportFoot", lambdaCoPSupportFoot);
-      leftCopActiveJoints = comActiveJoints;
-      rightCopActiveJoints = comActiveJoints;
-      if(admittance.has("copActiveJoints"))
-      {
-        auto copJoints = admittance("copActiveJoints");
-        copJoints("left",leftCopActiveJoints);
-        copJoints("right",rightCopActiveJoints);
-      }
-      admittance("copSlope", copSlope);
       admittance("copDelay", delayCoP);
       admittance("maxVel", copMaxVel);
       admittance("velFilterGain", mc_filter::utils::clamp(copVelFilterGain, 0, 1));

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -428,6 +428,8 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   Eigen::Vector3d comDimWeight = Eigen::Vector3d::Ones(); /**< Dimensional weight of CoM IK task */
   double comHeight = 0.84; /**< Desired height of the CoM */
 
+  Eigen::Vector2d lambdaCoP = Eigen::Vector2d::Ones() * 100; /**< 1st order gain constant between a reference CoP and the real */ 
+
   std::string torsoBodyName; /**< Name of the torso body */
   double torsoPitch = 0; /**< Target world pitch angle for the torso */
   double torsoStiffness = 10; /**< Stiffness of the torso task. */

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -411,7 +411,6 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   ZMPCCConfiguration zmpcc; /**< Configuration of ZMPCC (CoM admittance) */
 
   mc_rbdyn::Gains3d dfAdmittance = {0, 0, 1e-4}; /**< Admittance for foot force difference control */
-  mc_rbdyn::Gains3d dfAdmittanceSupportFoot = {0, 0, 1e-4}; /**< Admittance for foot force difference control for the future support foot, by default set to dfAdmittance */
   mc_rbdyn::Gains3d dfDamping = 0.; /**< Damping term in foot force difference control */
 
   mc_rbdyn::Gains2d dcmPropGain = 1.; /**< Proportional gain on DCM error */
@@ -479,7 +478,6 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     clampInPlaceAndWarn(comdErrorGain, 0., s.MAX_COMD_GAIN, "CoMd gain");
     clampInPlaceAndWarn(zmpdGain, 0., s.MAX_ZMPD_GAIN, "ZMPd gain");
     clampInPlaceAndWarn(dfAdmittance, 0., s.MAX_DF_ADMITTANCE, "DF admittance");
-    clampInPlaceAndWarn(dfAdmittanceSupportFoot, 0., s.MAX_DF_ADMITTANCE, "DF admittance");
     clampInPlaceAndWarn(dfDamping, 0., s.MAX_DF_DAMPING, "DF admittance");
   }
 
@@ -520,12 +518,6 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       else
       {
         admittance("df", dfAdmittance);
-
-      }
-      dfAdmittanceSupportFoot = dfAdmittance; 
-      if(admittance.has("dfSupportFoot"))
-      {
-        dfAdmittanceSupportFoot = admittance("dfSupportFoot");
       }
       if(admittance.has("dfz_damping"))
       {
@@ -657,7 +649,6 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     conf.add("admittance");
     conf("admittance").add("cop", copAdmittance);
     conf("admittance").add("df", dfAdmittance);
-    conf("admittance").add("dfSupportFoot", dfAdmittanceSupportFoot);
     conf("admittance").add("df_damping", dfDamping);
     conf("admittance").add("maxVel", copMaxVel);
     conf("admittance").add("velFilterGain", copVelFilterGain);

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -430,8 +430,9 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   Eigen::Vector3d comDimWeight = Eigen::Vector3d::Ones(); /**< Dimensional weight of CoM IK task */
   double comHeight = 0.84; /**< Desired height of the CoM */
 
-  Eigen::Vector3d lambdaCoP =
-      Eigen::Vector3d::Ones() * 100; /**< 1st order gain constant between a reference CoP and the real */
+  Eigen::Vector3d lambda_CoP_Fz =
+      Eigen::Vector3d::Ones()
+      * 100; /**< 1st order gain constant between a reference CoP and vertical force and the real */
   double delayCoP = 0;
 
   std::string torsoBodyName; /**< Name of the torso body */
@@ -504,8 +505,8 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     {
       auto admittance = config("admittance");
       admittance("cop", copAdmittance);
-      admittance("copLambda", lambdaCoP);
-      admittance("copDelay", delayCoP);
+      admittance("copFzLambda", lambda_CoP_Fz);
+      admittance("copFzDelay", delayCoP);
       admittance("maxVel", copMaxVel);
       admittance("velFilterGain", mc_filter::utils::clamp(copVelFilterGain, 0, 1));
       if(admittance.has("dfz"))

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -411,6 +411,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   ZMPCCConfiguration zmpcc; /**< Configuration of ZMPCC (CoM admittance) */
 
   mc_rbdyn::Gains3d dfAdmittance = {0, 0, 1e-4}; /**< Admittance for foot force difference control */
+  mc_rbdyn::Gains3d dfAdmittanceSupportFoot = {0, 0, 1e-4}; /**< Admittance for foot force difference control for the future support foot, by default set to dfAdmittance */
   mc_rbdyn::Gains3d dfDamping = 0.; /**< Damping term in foot force difference control */
 
   mc_rbdyn::Gains2d dcmPropGain = 1.; /**< Proportional gain on DCM error */
@@ -476,6 +477,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     clampInPlaceAndWarn(comdErrorGain, 0., s.MAX_COMD_GAIN, "CoMd gain");
     clampInPlaceAndWarn(zmpdGain, 0., s.MAX_ZMPD_GAIN, "ZMPd gain");
     clampInPlaceAndWarn(dfAdmittance, 0., s.MAX_DF_ADMITTANCE, "DF admittance");
+    clampInPlaceAndWarn(dfAdmittanceSupportFoot, 0., s.MAX_DF_ADMITTANCE, "DF admittance");
     clampInPlaceAndWarn(dfDamping, 0., s.MAX_DF_DAMPING, "DF admittance");
   }
 
@@ -516,6 +518,12 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       else
       {
         admittance("df", dfAdmittance);
+
+      }
+      dfAdmittanceSupportFoot = dfAdmittance; 
+      if(admittance.has("dfSupportFoot"))
+      {
+        dfAdmittanceSupportFoot = admittance("dfSupportFoot");
       }
       if(admittance.has("dfz_damping"))
       {
@@ -647,6 +655,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     conf.add("admittance");
     conf("admittance").add("cop", copAdmittance);
     conf("admittance").add("df", dfAdmittance);
+    conf("admittance").add("dfSupportFoot", dfAdmittanceSupportFoot);
     conf("admittance").add("df_damping", dfDamping);
     conf("admittance").add("maxVel", copMaxVel);
     conf("admittance").add("velFilterGain", copVelFilterGain);

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -501,7 +501,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     {
       auto admittance = config("admittance");
       admittance("cop", copAdmittance);
-      admittance("copLambda",lambdaCoP);
+      admittance("copLambda", lambdaCoP);
       admittance("maxVel", copMaxVel);
       admittance("velFilterGain", mc_filter::utils::clamp(copVelFilterGain, 0, 1));
       if(admittance.has("dfz"))

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -430,6 +430,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
 
   Eigen::Vector2d lambdaCoP =
       Eigen::Vector2d::Ones() * 100; /**< 1st order gain constant between a reference CoP and the real */
+  double delayCoP = 0;
 
   std::string torsoBodyName; /**< Name of the torso body */
   double torsoPitch = 0; /**< Target world pitch angle for the torso */
@@ -502,6 +503,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       auto admittance = config("admittance");
       admittance("cop", copAdmittance);
       admittance("copLambda", lambdaCoP);
+      admittance("copDelay",delayCoP);
       admittance("maxVel", copMaxVel);
       admittance("velFilterGain", mc_filter::utils::clamp(copVelFilterGain, 0, 1));
       if(admittance.has("dfz"))

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -428,7 +428,8 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   Eigen::Vector3d comDimWeight = Eigen::Vector3d::Ones(); /**< Dimensional weight of CoM IK task */
   double comHeight = 0.84; /**< Desired height of the CoM */
 
-  Eigen::Vector2d lambdaCoP = Eigen::Vector2d::Ones() * 100; /**< 1st order gain constant between a reference CoP and the real */ 
+  Eigen::Vector2d lambdaCoP =
+      Eigen::Vector2d::Ones() * 100; /**< 1st order gain constant between a reference CoP and the real */
 
   std::string torsoBodyName; /**< Name of the torso body */
   double torsoPitch = 0; /**< Target world pitch angle for the torso */

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -501,6 +501,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     {
       auto admittance = config("admittance");
       admittance("cop", copAdmittance);
+      admittance("copLambda",lambdaCoP);
       admittance("maxVel", copMaxVel);
       admittance("velFilterGain", mc_filter::utils::clamp(copVelFilterGain, 0, 1));
       if(admittance.has("dfz"))

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -423,6 +423,8 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       15.; /**< Time window for exponential moving average filter of the DCM integrator */
   double dcmDerivatorTimeConstant = 1.; /**< Cutoff Period of the DCM derivator filter */
 
+  double fSumFilter_T = 20.; /**<Cutoff Period of the estimation of the sum of forces*/
+
   std::vector<std::string> comActiveJoints; /**< Joints used by CoM IK task */
   Eigen::Vector3d comStiffness = {1000., 1000., 100.}; /**< Stiffness of CoM IK task */
   double comWeight = 1000.; /**< Weight of CoM IK task */

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -428,8 +428,8 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
   Eigen::Vector3d comDimWeight = Eigen::Vector3d::Ones(); /**< Dimensional weight of CoM IK task */
   double comHeight = 0.84; /**< Desired height of the CoM */
 
-  Eigen::Vector2d lambdaCoP =
-      Eigen::Vector2d::Ones() * 100; /**< 1st order gain constant between a reference CoP and the real */
+  Eigen::Vector3d lambdaCoP =
+      Eigen::Vector3d::Ones() * 100; /**< 1st order gain constant between a reference CoP and the real */
   double delayCoP = 0;
 
   std::string torsoBodyName; /**< Name of the torso body */

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -503,7 +503,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
       auto admittance = config("admittance");
       admittance("cop", copAdmittance);
       admittance("copLambda", lambdaCoP);
-      admittance("copDelay",delayCoP);
+      admittance("copDelay", delayCoP);
       admittance("maxVel", copMaxVel);
       admittance("velFilterGain", mc_filter::utils::clamp(copVelFilterGain, 0, 1));
       if(admittance.has("dfz"))

--- a/include/mc_tasks/lipm_stabilizer/Contact.h
+++ b/include/mc_tasks/lipm_stabilizer/Contact.h
@@ -133,6 +133,11 @@ struct MC_TASKS_DLLAPI Contact
     return halfLength_;
   }
 
+  double friction() const
+  {
+    return friction_;
+  }
+
   /**
    * World position of projected ankle frame into surface frame.
    * Orientation is that of the target contact frame.

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -793,9 +793,9 @@ private:
    * The dynamic of the contact CoP is expected to follow a 1st order dynamic w.r.t the CoP reference using prameter lambda_CoP
    * 
    * @param zmp_ref  each zmp reference piecewise constant over duration/zmp_ref vector lenght in the world frame
-   * @param duration horizon duration
+   * @param delta horizon timestep
    */
-  void distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref,const double duration);
+  void distributeCoPonHorizon(const sva::ForceVecd & desiredWrench, const std::vector<Eigen::Vector2d> & zmp_ref,const double delta);
   
 
   /** Project desired wrench to single support foot.

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -377,6 +377,16 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return zmpdTarget_;
   }
 
+  inline const ContactState & supportFoot() const noexcept
+  {
+    return supportFoot_;
+  }
+
+  void supportFoot(const ContactState & foot)
+  {
+    supportFoot_ = foot;
+  }
+
   /**
    * @brief Set the reference zmp sequence to distribute between the CoP task (Only in double support)
    *
@@ -444,7 +454,7 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     {
       return dcmEstimator_.getUnbiasedDCM();
     }
-    return measuredDCM_.segment(0,2);
+    return measuredDCM_.segment(0, 2);
   }
 
   inline const Eigen::Vector3d & measuredZMP() noexcept
@@ -1084,16 +1094,18 @@ protected:
   double delayedTargetFzLeft_ = 0; /**< Considered target for the delay*/
   double delayedTargetFzRight_ = 0; /**< Considered target for the delay*/
 
-  double tComputation_ = 0.; /**< time when the distribution has been computed */
+  double tComputation_ = 0.; /**< time when the Horizon based force distribution has been computed */
   double modeledFzRight_ = 0.; /**< Used for logging*/
   double modeledFzLeft_ = 0.; /**< Used for logging*/
   double desiredFzLeft_ = 0.; /**< Used for logging*/
   double desiredFzRight_ = 0.; /**< Used for logging*/
-  Eigen::Vector2d errQPzmp = Eigen::Vector2d::Zero();
-  Eigen::Vector2d QPCoPLeft_ = Eigen::Vector2d::Zero();
-  Eigen::Vector2d QPCoPRight_ = Eigen::Vector2d::Zero();
-  Eigen::Vector2d distribCheck_ = Eigen::Vector2d::Zero();
-  mc_filter::LowPass<Eigen::Vector3d> fSumFilter_; 
+  Eigen::Vector2d QPCoPLeft_ =
+      Eigen::Vector2d::Zero(); /**<Get the next modeled CoP by the Horizon based force distribution QP */
+  Eigen::Vector2d QPCoPRight_ =
+      Eigen::Vector2d::Zero(); /**<Get the next modeled CoP by the Horizon based force distribution QP */
+  Eigen::Vector2d distribCheck_ = Eigen::Vector2d::Zero(); /**<Error between the computed ZMP byt the  Horizon based
+                                                              force distribution QP and the reference zmp>*/
+  mc_filter::LowPass<Eigen::Vector3d> fSumFilter_; /**<Low pass filter that sum the forces on both foot>*/
   ContactState supportFoot_ = ContactState::Left; /**< Future support foot  */
 
   //}

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -377,12 +377,14 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return zmpdTarget_;
   }
 
-  inline const ContactState & supportFoot() const noexcept
+  /* Return the defined support foot */
+  inline const ContactState supportFoot() const noexcept
   {
     return supportFoot_;
   }
 
-  void supportFoot(const ContactState & foot)
+  /* Return the defined support foot */
+  void supportFoot(const ContactState & foot )
   {
     supportFoot_ = foot;
   }

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -474,6 +474,11 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return measuredCoMd_;
   }
 
+  inline const Eigen::Vector3d & measuredFilteredNetForces() noexcept
+  {
+    return fSumFilter_.eval();
+  }
+
   inline const Eigen::Vector3d & comOffsetTarget() noexcept
   {
     return comOffsetTarget_;

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -337,13 +337,11 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
    * \see targetCoM()
    **/
 
-
-  void horizonReference(const std::vector<Eigen::Vector2d> & ref , const double delta)
+  void horizonReference(const std::vector<Eigen::Vector2d> & ref, const double delta)
   {
     horizonZmpRef_ = ref;
     horizonDelta_ = delta;
     horizonCoPDistribution_ = true;
-
   }
 
   inline const Eigen::Vector3d & targetCoMRaw() const noexcept
@@ -790,13 +788,15 @@ private:
   /**
    * @brief Generate a CoP reference for each contact under the future zmp refence along a horizon.
    * The dynamic of the contact CoPreference zmp is expected to follow a 1st order dynamic w.r.t the CoP reference
-   * The dynamic of the contact CoP is expected to follow a 1st order dynamic w.r.t the CoP reference using prameter lambda_CoP
-   * 
+   * The dynamic of the contact CoP is expected to follow a 1st order dynamic w.r.t the CoP reference using prameter
+   * lambda_CoP
+   *
    * @param zmp_ref  each zmp reference piecewise constant over duration/zmp_ref vector lenght in the world frame
    * @param delta horizon timestep
    */
-  void distributeCoPonHorizon(const sva::ForceVecd & desiredWrench, const std::vector<Eigen::Vector2d> & zmp_ref,const double delta);
-  
+  void distributeCoPonHorizon(const sva::ForceVecd & desiredWrench,
+                              const std::vector<Eigen::Vector2d> & zmp_ref,
+                              const double delta);
 
   /** Project desired wrench to single support foot.
    *

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -377,18 +377,6 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return zmpdTarget_;
   }
 
-  /* Return the defined support foot */
-  inline const ContactState supportFoot() const noexcept
-  {
-    return supportFoot_;
-  }
-
-  /* Return the defined support foot */
-  void supportFoot(const ContactState & foot )
-  {
-    supportFoot_ = foot;
-  }
-
   /**
    * @brief Set the reference zmp sequence to distribute between the CoP task (Only in double support)
    *
@@ -702,11 +690,6 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
   inline void dfAdmittance(Eigen::Vector3d dfAdmittance) noexcept
   {
     c_.dfAdmittance = clamp(dfAdmittance, 0., c_.safetyThresholds.MAX_DF_ADMITTANCE);
-  }
-
-  inline void dfAdmittanceSupportFoot(Eigen::Vector3d dfAdmittance) noexcept
-  {
-    c_.dfAdmittanceSupportFoot = clamp(dfAdmittance, 0., c_.safetyThresholds.MAX_DF_ADMITTANCE);
   }
 
   inline void dfDamping(Eigen::Vector3d dfDamping) noexcept

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -438,6 +438,15 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return Eigen::Vector2d::Zero();
   }
 
+  inline const Eigen::Vector2d filteredDCM() noexcept
+  {
+    if(c_.dcmBias.withDCMBias)
+    {
+      return dcmEstimator_.getUnbiasedDCM();
+    }
+    return measuredDCM_.segment(0,2);
+  }
+
   inline const Eigen::Vector3d & measuredZMP() noexcept
   {
     return measuredZMP_;
@@ -505,6 +514,11 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
   inline void torsoPitch(double pitch) noexcept
   {
     c_.torsoPitch = pitch;
+  }
+
+  inline double omega()
+  {
+    return omega_;
   }
 
   inline void torsoWeight(double weight) noexcept
@@ -968,7 +982,7 @@ protected:
   Eigen::Vector3d zmpTarget_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d zmpdTarget_ = Eigen::Vector3d::Zero();
   Eigen::Vector3d dcmTarget_ = Eigen::Vector3d::Zero();
-  double omega_;
+  double omega_ = 3.4;
 
   double t_ = 0.; /**< Time elapsed since the task is running */
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -1107,6 +1107,8 @@ protected:
   double desiredFzLeft_ = 0.; /**< Used for logging*/
   double desiredFzRight_ = 0.; /**< Used for logging*/
   Eigen::Vector2d errQPzmp = Eigen::Vector2d::Zero();
+  Eigen::Vector2d QPCoPLeft_ = Eigen::Vector2d::Zero();
+  Eigen::Vector2d QPCoPRight_ = Eigen::Vector2d::Zero();
   mc_filter::LowPass<Eigen::Vector3d> fSumFilter_; 
   ContactState supportFoot_ = ContactState::Left; /**< Future support foot  */
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -377,14 +377,14 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return zmpdTarget_;
   }
 
-  /* Return the defined support foot */
+  /* Return the current support foot */
   inline const ContactState supportFoot() const noexcept
   {
     return supportFoot_;
   }
 
-  /* Return the defined support foot */
-  void supportFoot(const ContactState & foot )
+  /* Set the current support foot */
+  inline void supportFoot(const ContactState & foot) noexcept
   {
     supportFoot_ = foot;
   }
@@ -392,11 +392,13 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
   /**
    * @brief Set the reference zmp sequence to distribute between the CoP task (Only in double support)
    *
+   * It is advised to provide the future support foot name when using this method using the supportFoot method
+   *
    * @param ref Reference zmp sequence
    * @param delta Sequence sampling time
    *
    */
-  void horizonReference(const std::vector<Eigen::Vector2d> & ref, const double delta)
+  inline void horizonReference(const std::vector<Eigen::Vector2d> & ref, const double delta) noexcept
   {
     horizonZmpRef_ = ref;
     horizonDelta_ = delta;
@@ -450,7 +452,7 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return Eigen::Vector2d::Zero();
   }
 
-  inline const Eigen::Vector2d filteredDCM() noexcept
+  inline Eigen::Vector2d filteredDCM() const noexcept
   {
     if(c_.dcmBias.withDCMBias)
     {
@@ -474,7 +476,7 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return measuredCoMd_;
   }
 
-  inline const Eigen::Vector3d & measuredFilteredNetForces() noexcept
+  inline const Eigen::Vector3d & measuredFilteredNetForces() const noexcept
   {
     return fSumFilter_.eval();
   }
@@ -533,7 +535,7 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     c_.torsoPitch = pitch;
   }
 
-  inline double omega()
+  inline double omega() const
   {
     return omega_;
   }
@@ -835,10 +837,12 @@ private:
    * The desired vertical forces are computed using the ratio (p_left - zmp_ref) / (p_left - p_right).
    * This choice limits the torque at each contact ankle
    *
+   * It is advised to provide the future support foot name when using this method using supportFoot method
+   *
    * @param zmp_ref  each zmp reference piecewise constant over delta vector lenght in the world frame
    * @param delta horizon timestep
    */
-  void distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, const double delta);
+  void distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, double delta);
 
   /** Project desired wrench to single support foot.
    *
@@ -1086,8 +1090,8 @@ protected:
   //{
   std::vector<Eigen::Vector2d> horizonZmpRef_; /**< Future ZMP reference during tHorizon */
   double horizonDelta_ = 0.05; /**< Sequence sampling period */
-  bool horizonCoPDistribution_ =
-      false; /**<Is set to true when a new zmp sequence is provided and overided classical distribution */
+  /**<Is set to true when a new zmp sequence is provided and overided classical distribution */
+  bool horizonCoPDistribution_ = false;
   Eigen::Vector2d modeledCoPLeft_ = Eigen::Vector2d::Zero(); /**< Used for logging*/
   Eigen::Vector2d modeledCoPRight_ = Eigen::Vector2d::Zero(); /**< Used for logging*/
 
@@ -1105,9 +1109,9 @@ protected:
       Eigen::Vector2d::Zero(); /**<Get the next modeled CoP by the Horizon based force distribution QP */
   Eigen::Vector2d QPCoPRight_ =
       Eigen::Vector2d::Zero(); /**<Get the next modeled CoP by the Horizon based force distribution QP */
-  Eigen::Vector2d distribCheck_ = Eigen::Vector2d::Zero(); /**<Error between the computed ZMP byt the  Horizon based
-                                                              force distribution QP and the reference zmp>*/
-  mc_filter::LowPass<Eigen::Vector3d> fSumFilter_; /**<Low pass filter that sum the forces on both foot>*/
+  /**<Error between the computed ZMP byt the  Horizon based force distribution QP and the reference zmp>*/
+  Eigen::Vector2d distribCheck_ = Eigen::Vector2d::Zero();
+  mc_filter::LowPass<Eigen::Vector3d> fSumFilter_; /**<Low pass filter that sum the forces on both feet>*/
   ContactState supportFoot_ = ContactState::Left; /**< Future support foot  */
 
   //}

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -337,9 +337,10 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
    * \see targetCoM()
    **/
 
-  void horizonReference(const std::vector<Eigen::Vector2d> & ref, const double delta)
+  void horizonReference(const std::vector<Eigen::Vector2d> & ref,const std::vector<Eigen::Vector2d> & u_ref, const double delta)
   {
     horizonZmpRef_ = ref;
+    horizonURef_ = u_ref;
     horizonDelta_ = delta;
     horizonCoPDistribution_ = true;
   }
@@ -795,7 +796,7 @@ private:
    * @param delta horizon timestep
    */
   void distributeCoPonHorizon(const sva::ForceVecd & desiredWrench,
-                              const std::vector<Eigen::Vector2d> & zmp_ref,
+                              const std::vector<Eigen::Vector2d> & zmp_ref,const std::vector<Eigen::Vector2d> & u_ref,
                               const double delta);
 
   /** Project desired wrench to single support foot.
@@ -1041,6 +1042,7 @@ protected:
   sva::PTransformd zmpFrame_ = sva::PTransformd::Identity(); /**< Frame in which the ZMP is computed */
 
   std::vector<Eigen::Vector2d> horizonZmpRef_; /**< Future ZMP reference during tHorizon */
+  std::vector<Eigen::Vector2d> horizonURef_; /**< Future ZMP reference during tHorizon */
   double horizonDelta_ = 0.05;
   bool horizonCoPDistribution_ = false;
   Eigen::Vector2d modeledCoPLeft_ = Eigen::Vector2d::Zero();

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -377,6 +377,18 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return zmpdTarget_;
   }
 
+  /* Return the defined support foot */
+  inline const ContactState supportFoot() const noexcept
+  {
+    return supportFoot_;
+  }
+
+  /* Return the defined support foot */
+  void supportFoot(const ContactState & foot )
+  {
+    supportFoot_ = foot;
+  }
+
   /**
    * @brief Set the reference zmp sequence to distribute between the CoP task (Only in double support)
    *
@@ -685,6 +697,11 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
   inline void dfAdmittance(Eigen::Vector3d dfAdmittance) noexcept
   {
     c_.dfAdmittance = clamp(dfAdmittance, 0., c_.safetyThresholds.MAX_DF_ADMITTANCE);
+  }
+
+  inline void dfAdmittanceSupportFoot(Eigen::Vector3d dfAdmittance) noexcept
+  {
+    c_.dfAdmittanceSupportFoot = clamp(dfAdmittance, 0., c_.safetyThresholds.MAX_DF_ADMITTANCE);
   }
 
   inline void dfDamping(Eigen::Vector3d dfDamping) noexcept
@@ -1085,6 +1102,9 @@ protected:
   double desiredFzLeft_ = 0.; /**< Used for logging*/
   double desiredFzRight_ = 0.; /**< Used for logging*/
   Eigen::Vector2d errQPzmp = Eigen::Vector2d::Zero();
+  mc_filter::LowPass<Eigen::Vector3d> fSumFilter_; 
+  ContactState supportFoot_ = ContactState::Left; /**< Future support foot  */
+
   //}
 };
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -337,10 +337,9 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
    * \see targetCoM()
    **/
 
-  void horizonReference(const std::vector<Eigen::Vector2d> & ref,const std::vector<Eigen::Vector2d> & u_ref, const double delta)
+  void horizonReference(const std::vector<Eigen::Vector2d> & ref, const double delta)
   {
     horizonZmpRef_ = ref;
-    horizonURef_ = u_ref;
     horizonDelta_ = delta;
     horizonCoPDistribution_ = true;
   }
@@ -792,11 +791,10 @@ private:
    * The dynamic of the contact CoP is expected to follow a 1st order dynamic w.r.t the CoP reference using prameter
    * lambda_CoP
    *
-   * @param zmp_ref  each zmp reference piecewise constant over duration/zmp_ref vector lenght in the world frame
+   * @param zmp_ref  each zmp reference piecewise constant over delta vector lenght in the world frame
    * @param delta horizon timestep
    */
-  void distributeCoPonHorizon(const sva::ForceVecd & desiredWrench,
-                              const std::vector<Eigen::Vector2d> & zmp_ref,const std::vector<Eigen::Vector2d> & u_ref,
+  void distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref,
                               const double delta);
 
   /** Project desired wrench to single support foot.
@@ -1041,12 +1039,14 @@ protected:
       Eigen::Vector3d::Zero(); /**< ZMP corresponding to force distribution result (desired ZMP) */
   sva::PTransformd zmpFrame_ = sva::PTransformd::Identity(); /**< Frame in which the ZMP is computed */
 
+  //CoP distribution over an horizon
+  //{
   std::vector<Eigen::Vector2d> horizonZmpRef_; /**< Future ZMP reference during tHorizon */
-  std::vector<Eigen::Vector2d> horizonURef_; /**< Future ZMP reference during tHorizon */
   double horizonDelta_ = 0.05;
   bool horizonCoPDistribution_ = false;
   Eigen::Vector2d modeledCoPLeft_ = Eigen::Vector2d::Zero();
   Eigen::Vector2d modeledCoPRight_ = Eigen::Vector2d::Zero();
+
   Eigen::Vector2d delayedTargetCoPLeft_ = Eigen::Vector2d::Zero();
   Eigen::Vector2d delayedTargetCoPRight_ = Eigen::Vector2d::Zero();
   double delayedTargetFzLeft_ = 0;
@@ -1057,6 +1057,7 @@ protected:
   double modeledFzLeft_ = 0;
   double desiredFzLeft_ = 0;
   double desiredFzRight_ = 0;
+  //}
 };
 
 extern template void StabilizerTask::computeWrenchOffsetAndCoefficient<&StabilizerTask::ExternalWrench::target>(

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -1109,6 +1109,7 @@ protected:
   Eigen::Vector2d errQPzmp = Eigen::Vector2d::Zero();
   Eigen::Vector2d QPCoPLeft_ = Eigen::Vector2d::Zero();
   Eigen::Vector2d QPCoPRight_ = Eigen::Vector2d::Zero();
+  Eigen::Vector2d distribCheck_ = Eigen::Vector2d::Zero();
   mc_filter::LowPass<Eigen::Vector3d> fSumFilter_; 
   ContactState supportFoot_ = ContactState::Left; /**< Future support foot  */
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -336,6 +336,16 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
    *
    * \see targetCoM()
    **/
+
+
+  void horizonReference(const std::vector<Eigen::Vector2d> & ref , const double delta)
+  {
+    horizonZmpRef_ = ref;
+    horizonDelta_ = delta;
+    horizonCoPDistribution_ = true;
+
+  }
+
   inline const Eigen::Vector3d & targetCoMRaw() const noexcept
   {
     return comTargetRaw_;
@@ -777,6 +787,17 @@ private:
    */
   void distributeWrench(const sva::ForceVecd & desiredWrench);
 
+  /**
+   * @brief Generate a CoP reference for each contact under the future zmp refence along a horizon.
+   * The dynamic of the contact CoPreference zmp is expected to follow a 1st order dynamic w.r.t the CoP reference
+   * The dynamic of the contact CoP is expected to follow a 1st order dynamic w.r.t the CoP reference using prameter lambda_CoP
+   * 
+   * @param zmp_ref  each zmp reference piecewise constant over duration/zmp_ref vector lenght in the world frame
+   * @param duration horizon duration
+   */
+  void distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref,const double duration);
+  
+
   /** Project desired wrench to single support foot.
    *
    * \param desiredWrench Desired resultant reaction wrench.
@@ -1018,6 +1039,12 @@ protected:
   Eigen::Vector3d distribZMP_ =
       Eigen::Vector3d::Zero(); /**< ZMP corresponding to force distribution result (desired ZMP) */
   sva::PTransformd zmpFrame_ = sva::PTransformd::Identity(); /**< Frame in which the ZMP is computed */
+
+  std::vector<Eigen::Vector2d> horizonZmpRef_; /**< Future ZMP reference during tHorizon */
+  double horizonDelta_ = 0.05;
+  bool horizonCoPDistribution_ = false;
+  Eigen::Vector2d modeledCoPLeft_ = Eigen::Vector2d::Zero();
+  Eigen::Vector2d modeledCoPRight_ = Eigen::Vector2d::Zero();
 };
 
 extern template void StabilizerTask::computeWrenchOffsetAndCoefficient<&StabilizerTask::ExternalWrench::target>(

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -1079,11 +1079,12 @@ protected:
   double delayedTargetFzLeft_ = 0; /**< Considered target for the delay*/
   double delayedTargetFzRight_ = 0; /**< Considered target for the delay*/
 
-  double tComputation_ = 0; /**< time when the distribution has been computed */
-  double modeledFzRight_ = 0; /**< Used for logging*/
-  double modeledFzLeft_ = 0; /**< Used for logging*/
-  double desiredFzLeft_ = 0; /**< Used for logging*/
-  double desiredFzRight_ = 0; /**< Used for logging*/
+  double tComputation_ = 0.; /**< time when the distribution has been computed */
+  double modeledFzRight_ = 0.; /**< Used for logging*/
+  double modeledFzLeft_ = 0.; /**< Used for logging*/
+  double desiredFzLeft_ = 0.; /**< Used for logging*/
+  double desiredFzRight_ = 0.; /**< Used for logging*/
+  Eigen::Vector2d errQPzmp = Eigen::Vector2d::Zero();
   //}
 };
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -1047,6 +1047,16 @@ protected:
   bool horizonCoPDistribution_ = false;
   Eigen::Vector2d modeledCoPLeft_ = Eigen::Vector2d::Zero();
   Eigen::Vector2d modeledCoPRight_ = Eigen::Vector2d::Zero();
+  Eigen::Vector2d delayedTargetCoPLeft_ = Eigen::Vector2d::Zero();
+  Eigen::Vector2d delayedTargetCoPRight_ = Eigen::Vector2d::Zero();
+  double delayedTargetFzLeft_ = 0;
+  double delayedTargetFzRight_ = 0;
+
+  double tComputation_ = 0; /**< time when the distribution has been computed*/
+  double modeledFzRight_ = 0;
+  double modeledFzLeft_ = 0;
+  double desiredFzLeft_ = 0;
+  double desiredFzRight_ = 0;
 };
 
 extern template void StabilizerTask::computeWrenchOffsetAndCoefficient<&StabilizerTask::ExternalWrench::target>(

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -794,8 +794,7 @@ private:
    * @param zmp_ref  each zmp reference piecewise constant over delta vector lenght in the world frame
    * @param delta horizon timestep
    */
-  void distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref,
-                              const double delta);
+  void distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, const double delta);
 
   /** Project desired wrench to single support foot.
    *
@@ -1039,7 +1038,7 @@ protected:
       Eigen::Vector3d::Zero(); /**< ZMP corresponding to force distribution result (desired ZMP) */
   sva::PTransformd zmpFrame_ = sva::PTransformd::Identity(); /**< Frame in which the ZMP is computed */
 
-  //CoP distribution over an horizon
+  // CoP distribution over an horizon
   //{
   std::vector<Eigen::Vector2d> horizonZmpRef_; /**< Future ZMP reference during tHorizon */
   double horizonDelta_ = 0.05;

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -457,6 +457,11 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return comOffsetMeasured_;
   }
 
+  inline const double zmpCoeffMEasured() const noexcept
+  {
+    return zmpCoefMeasured_;
+  }
+
   inline bool inContact(ContactState state) const noexcept
   {
     return contacts_.count(state);

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -457,7 +457,7 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     return comOffsetMeasured_;
   }
 
-  inline const double zmpCoeffMEasured() const noexcept
+  inline const double zmpCoeffMeasured() const noexcept
   {
     return zmpCoefMeasured_;
   }

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1410,8 +1410,8 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
   Aineq.block(4 * nbReferences, 2 * nbReferences, 4 * nbReferences, 2 * nbReferences) =
       Aineq.block(0, 0, 4 * nbReferences, 2 * nbReferences);
 
-  Eigen::MatrixXd Q = Mcop.transpose() * Mcop + 1e-4 * McopDiff.transpose() * McopDiff + 1e-4* (McopReg.transpose() * McopReg);
-  Eigen::VectorXd c = (-Mcop.transpose() * bcop) + 1e-4 * (-McopReg.transpose() * bcopReg);
+  Eigen::MatrixXd Q = Mcop.transpose() * Mcop + 1e-6 * McopDiff.transpose() * McopDiff + 1e-6 * (McopReg.transpose() * McopReg);
+  Eigen::VectorXd c = (-Mcop.transpose() * bcop) + 1e-6 * (-McopReg.transpose() * bcopReg);
 
   qpSolver_.problem(nbVariables, 0, nbIneqCstr);
   Eigen::MatrixXd Aeq(0, 0);

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -528,7 +528,7 @@ void StabilizerTask::addContact(ContactState contactState, const Contact & conta
   supportPolygons_.push_back(contact.polygon());
 
   // Configure support foot task
-  footTask->reset();
+  // footTask->reset();
   footTask->weight(c_.contactWeight);
   footTask->targetPose(contact.surfacePose());
 

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -785,11 +785,15 @@ void StabilizerTask::run()
   {
     saturateWrench(desiredWrench_, footTasks[ContactState::Left], contacts_.at(ContactState::Left));
     footTasks[ContactState::Right]->setZeroTargetWrench();
+    delayedTargetCoPRight_ = footTasks[ContactState::Right]->targetCoP();
+    delayedTargetFzRight_ = footTasks[ContactState::Right]->targetWrench().force().z();
   }
   else
   {
     saturateWrench(desiredWrench_, footTasks[ContactState::Right], contacts_.at(ContactState::Right));
     footTasks[ContactState::Left]->setZeroTargetWrench();
+    delayedTargetCoPLeft_ = footTasks[ContactState::Left]->targetCoP();
+    delayedTargetFzLeft_ = footTasks[ContactState::Left]->targetWrench().force().z();
   }
 
   distribZMP_ = mc_rbdyn::zmp(distribWrench_, zmpFrame_);
@@ -1195,11 +1199,6 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
     modeledCoPRight_ = measuredRightCoP;
     modeledFzLeft_ = measuredFzLeft;
     modeledFzRight_ = measuredFzRight;
-
-    delayedTargetCoPLeft_ = footTasks[ContactState::Left]->targetCoP();
-    delayedTargetCoPRight_ = footTasks[ContactState::Right]->targetCoP();
-    delayedTargetFzLeft_ = footTasks[ContactState::Left]->targetWrench().force().z();
-    delayedTargetFzRight_ = footTasks[ContactState::Right]->targetWrench().force().z();
   
     Eigen::Vector3d targetForceLeft = Eigen::Vector3d::Zero();
     Eigen::Vector3d targetForceRight = Eigen::Vector3d::Zero();
@@ -1391,6 +1390,13 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
                                           targetForceLeft};
     sva::ForceVecd w_r_rc = sva::ForceVecd{Eigen::Vector3d{rightCoP.y() * targetForceRight.z(), -rightCoP.x() * targetForceRight.z(), 0},
                                           targetForceRight};
+   
+
+    delayedTargetCoPLeft_ = footTasks[ContactState::Left]->targetCoP();
+    delayedTargetCoPRight_ = footTasks[ContactState::Right]->targetCoP();
+    delayedTargetFzLeft_ = footTasks[ContactState::Left]->targetWrench().force().z();
+    delayedTargetFzRight_ = footTasks[ContactState::Right]->targetWrench().force().z();
+
     footTasks[ContactState::Left]->targetCoP(leftCoP);
     footTasks[ContactState::Left]->targetForce(w_l_lc.force());
     footTasks[ContactState::Right]->targetCoP(rightCoP);

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -577,7 +577,6 @@ void StabilizerTask::computeLeftFootRatio()
     Eigen::Vector3d t_lankle_rankle = rankle - lankle;
     double d_proj = t_lankle_com.dot(t_lankle_rankle.normalized());
     leftFootRatio_ = clamp(d_proj / t_lankle_rankle.norm(), 0., 1.);
-    
   }
   else if(inContact(ContactState::Left))
   {
@@ -774,7 +773,7 @@ void StabilizerTask::run()
   {
     if(horizonCoPDistribution_)
     {
-      distributeCoPonHorizon(desiredWrench_,horizonZmpRef_,horizonDelta_);
+      distributeCoPonHorizon(desiredWrench_, horizonZmpRef_, horizonDelta_);
       horizonCoPDistribution_ = false;
     }
     else
@@ -1137,28 +1136,29 @@ void StabilizerTask::distributeWrench(const sva::ForceVecd & desiredWrench)
   footTasks[ContactState::Right]->targetForce(w_r_rc.force());
 }
 
-void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench, const std::vector<Eigen::Vector2d> & zmp_ref,const double delta)
+void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench,
+                                            const std::vector<Eigen::Vector2d> & zmp_ref,
+                                            const double delta)
 {
   // Variables
   // ---------
   // sequence [ul_1_x,ul_1_y, ..., ul_n_x,ul_n_y,ur_1_x,ur_1_y, ..., ur_n_x,ur_n_y,f_l_x,f_l_y,f_r_x,f_r_y]
-  // [ur_i_x,ur_i_y]: Right CoP reference in the foot frame at the ith iteration 
+  // [ur_i_x,ur_i_y]: Right CoP reference in the foot frame at the ith iteration
   // [ul_i_x,ul_i_y]: Left  CoP reference in the foot frame at the ith iteration
   // Objective
   // ---------
   // Weighted minimization of the following tasks:
-  // 
+  //
   // [ur_i_x,ur_i_y] == [0,0] -- minimize the CoP position for each foot
   // f_l_x + f_r_x = desiredWrench_fx
   // f_l_y + f_r_y = desiredWrench_fy
   //
   // Constraints
   // -----------
-  // (fr_i_z * ur_i_x + fl_i_z * ul_i_x)/(fl_i_z + fr_i_z) == zmp_ref_i  -- CoP reference must match zmp reference (same for y)
-  // CoP within the contact polygone
+  // (fr_i_z * ur_i_x + fl_i_z * ul_i_x)/(fl_i_z + fr_i_z) == zmp_ref_i  -- CoP reference must match zmp reference (same
+  // for y) CoP within the contact polygone
   //  -- left foot wrench within contact wrench cone
   //  -- right foot wrench within contact wrench cone
- 
 
   if(zmp_ref.size() == 0)
   {
@@ -1174,122 +1174,119 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
   const Eigen::Vector3d t_lankle_rankle = rankle - lankle;
 
   const int nbReferences = static_cast<int>(zmp_ref.size());
-  const int nbVariables = 2 * 2 * nbReferences + 4 ;
+  const int nbVariables = 2 * 2 * nbReferences + 4;
   const int nbIneqCstr = 8 * nbReferences + 2 * 2 + 2 * 2;
-  const int nbEqCstr = 2 * nbReferences ;
-  Eigen::MatrixXd Aeq = Eigen::MatrixXd::Zero( nbEqCstr , nbVariables);
+  const int nbEqCstr = 2 * nbReferences;
+  Eigen::MatrixXd Aeq = Eigen::MatrixXd::Zero(nbEqCstr, nbVariables);
   Eigen::VectorXd beq = Eigen::VectorXd::Zero(Aeq.rows());
 
-  Eigen::MatrixXd Aineq = Eigen::MatrixXd::Zero( nbIneqCstr , nbVariables);
+  Eigen::MatrixXd Aineq = Eigen::MatrixXd::Zero(nbIneqCstr, nbVariables);
   Eigen::VectorXd bineq = Eigen::VectorXd::Zero(Aineq.rows());
-  Eigen::MatrixXd normals = Eigen::MatrixXd::Zero( 4 , 2); //normals matrix for CoP constraints
+  Eigen::MatrixXd normals = Eigen::MatrixXd::Zero(4, 2); // normals matrix for CoP constraints
   Eigen::VectorXd offsetLeft = Eigen::VectorXd::Zero(normals.rows());
   Eigen::VectorXd offsetRight = Eigen::VectorXd::Zero(normals.rows());
-  normals << 1,0,
-            -1,0,
-             0,1,
-             0,-1;
-  offsetLeft << leftContact.halfLength() , leftContact.halfLength(), 
-                leftContact.halfWidth()  , leftContact.halfWidth();
+  normals << 1, 0, -1, 0, 0, 1, 0, -1;
+  offsetLeft << leftContact.halfLength(), leftContact.halfLength(), leftContact.halfWidth(), leftContact.halfWidth();
 
-  offsetRight << rightContact.halfLength() , rightContact.halfLength(), 
-                 rightContact.halfWidth()  , rightContact.halfWidth();
+  offsetRight << rightContact.halfLength(), rightContact.halfLength(), rightContact.halfWidth(),
+      rightContact.halfWidth();
 
   const double fz_tot = robot().mass() * constants::GRAVITY;
-  //The vertical forces are splitted using the ratio obtained between the reference zmp pose and the contact pose;
+  // The vertical forces are splitted using the ratio obtained between the reference zmp pose and the contact pose;
   double first_ratio = 0.5;
-  for (Eigen::Index i = 0 ; i < nbReferences ; i++ )
-  {   
-   
-    Eigen::Vector2d t_lankle_com = zmp_ref[i] - lankle.segment(0,2);
-    double d_proj = t_lankle_com.dot(t_lankle_rankle.segment(0,2).normalized());
+  for(Eigen::Index i = 0; i < nbReferences; i++)
+  {
+
+    Eigen::Vector2d t_lankle_com = zmp_ref[i] - lankle.segment(0, 2);
+    double d_proj = t_lankle_com.dot(t_lankle_rankle.segment(0, 2).normalized());
     // 1 : rightfoot 0 : leftFoot
     double ratio = clamp(d_proj / t_lankle_rankle.norm(), 0., 1.);
 
-    if(i==0){first_ratio = ratio;}
-
-    Aeq.block(2 * i, 2 * i, 2 , 2) = X_0_lc.inv().rotation().block(0,0,2,2) * (1 - ratio);
-    Aeq.block(2 * i, 2 * (nbReferences +  i), 2 , 2) = X_0_rc.inv().rotation().block(0,0,2,2) * ratio;
-    beq.segment(2 * i,2) = zmp_ref[i] - X_0_lc.translation().segment(0,2) * (1-ratio) - X_0_rc.translation().segment(0,2) * (ratio);
-
-    
-    //Convert the CoP reference into the modeled CoP
-    Eigen::MatrixXd Acop  = Eigen::MatrixXd::Zero( 2, nbVariables);
-    double t_k = 0;
-    for (Eigen::Index k = 0 ; k <= i ; k++)
+    if(i == 0)
     {
-      
-      Acop(0, 2 * k) = (1 - exp(-c_.lambdaCoP.x() * delta)) * exp(-c_.lambdaCoP.x() * t_k) ;
-      Acop(1, 2 * k + 1) = (1 - exp(-c_.lambdaCoP.y() * delta)) * exp(-c_.lambdaCoP.y() * t_k) ;
+      first_ratio = ratio;
+    }
+
+    Aeq.block(2 * i, 2 * i, 2, 2) = X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio);
+    Aeq.block(2 * i, 2 * (nbReferences + i), 2, 2) = X_0_rc.inv().rotation().block(0, 0, 2, 2) * ratio;
+    beq.segment(2 * i, 2) =
+        zmp_ref[i] - X_0_lc.translation().segment(0, 2) * (1 - ratio) - X_0_rc.translation().segment(0, 2) * (ratio);
+
+    // Convert the CoP reference into the modeled CoP
+    Eigen::MatrixXd Acop = Eigen::MatrixXd::Zero(2, nbVariables);
+    double t_k = 0;
+    for(Eigen::Index k = 0; k <= i; k++)
+    {
+
+      Acop(0, 2 * k) = (1 - exp(-c_.lambdaCoP.x() * delta)) * exp(-c_.lambdaCoP.x() * t_k);
+      Acop(1, 2 * k + 1) = (1 - exp(-c_.lambdaCoP.y() * delta)) * exp(-c_.lambdaCoP.y() * t_k);
       t_k += delta;
     }
     Eigen::Matrix2d exp_mat;
-    exp_mat << exp(-c_.lambdaCoP.x() * t_k ) , 0, 0,exp(-c_.lambdaCoP.y() * t_k ) ;
-    bineq.segment( 4 * i , 4) = offsetLeft - normals * exp_mat * footTasks[ContactState::Left]->measuredCoP();
-    Aineq.block(4 * i , 0 , 4 , nbVariables) = normals * Acop; 
-    Aineq.block(4 * ( i + nbReferences), 0 , 4 , nbVariables) = normals * Acop; 
-    bineq.segment( 4 * (nbReferences +  i ) , 4) = offsetRight - normals * exp_mat *footTasks[ContactState::Right]->measuredCoP();
-
-
+    exp_mat << exp(-c_.lambdaCoP.x() * t_k), 0, 0, exp(-c_.lambdaCoP.y() * t_k);
+    bineq.segment(4 * i, 4) = offsetLeft - normals * exp_mat * footTasks[ContactState::Left]->measuredCoP();
+    Aineq.block(4 * i, 0, 4, nbVariables) = normals * Acop;
+    Aineq.block(4 * (i + nbReferences), 0, 4, nbVariables) = normals * Acop;
+    bineq.segment(4 * (nbReferences + i), 4) =
+        offsetRight - normals * exp_mat * footTasks[ContactState::Right]->measuredCoP();
   }
 
-  Aineq.block(8*nbReferences,4 * nbReferences,4,4) = Eigen::Matrix4d::Identity();
-  bineq.segment(8*nbReferences,2) = Eigen::Vector2d::Ones() * leftContact.friction() * fz_tot * (1 - first_ratio);
-  bineq.segment(8*nbReferences + 2,2) = Eigen::Vector2d::Ones() * rightContact.friction() * fz_tot * (first_ratio);
+  Aineq.block(8 * nbReferences, 4 * nbReferences, 4, 4) = Eigen::Matrix4d::Identity();
+  bineq.segment(8 * nbReferences, 2) = Eigen::Vector2d::Ones() * leftContact.friction() * fz_tot * (1 - first_ratio);
+  bineq.segment(8 * nbReferences + 2, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * fz_tot * (first_ratio);
 
-  Aineq.block(8*nbReferences + 4,4 * nbReferences,4,4) = -Eigen::Matrix4d::Identity();
-  bineq.segment(8*nbReferences + 4,2) = Eigen::Vector2d::Ones() * leftContact.friction() * fz_tot * (1 - first_ratio);
-  bineq.segment(8*nbReferences + 6,2) = Eigen::Vector2d::Ones() * rightContact.friction() * fz_tot * (first_ratio);
+  Aineq.block(8 * nbReferences + 4, 4 * nbReferences, 4, 4) = -Eigen::Matrix4d::Identity();
+  bineq.segment(8 * nbReferences + 4, 2) =
+      Eigen::Vector2d::Ones() * leftContact.friction() * fz_tot * (1 - first_ratio);
+  bineq.segment(8 * nbReferences + 6, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * fz_tot * (first_ratio);
 
-  Eigen::MatrixXd M_force = Eigen::MatrixXd::Zero(2 , nbVariables);
-  M_force.block(0,4*nbReferences,2,2) = Eigen::Matrix2d::Identity();
-  M_force.block(0,4*nbReferences + 2,2,2) = Eigen::Matrix2d::Identity();
-  Eigen::MatrixXd b_force = desiredWrench.force().segment(3,2);
+  Eigen::MatrixXd M_force = Eigen::MatrixXd::Zero(2, nbVariables);
+  M_force.block(0, 4 * nbReferences, 2, 2) = Eigen::Matrix2d::Identity();
+  M_force.block(0, 4 * nbReferences + 2, 2, 2) = Eigen::Matrix2d::Identity();
+  Eigen::MatrixXd b_force = desiredWrench.force().segment(3, 2);
 
-  Eigen::MatrixXd M_cop = Eigen::MatrixXd::Zero(4 * nbReferences , nbVariables);
-  M_cop.block(0,0,4 * nbReferences,4 * nbReferences) = Eigen::MatrixXd::Identity(4*nbReferences,4*nbReferences);
+  Eigen::MatrixXd M_cop = Eigen::MatrixXd::Zero(4 * nbReferences, nbVariables);
+  M_cop.block(0, 0, 4 * nbReferences, 4 * nbReferences) = Eigen::MatrixXd::Identity(4 * nbReferences, 4 * nbReferences);
 
-  Eigen::MatrixXd Q = M_cop.transpose() * M_cop + M_force.transpose() * M_force + 1e-12 * Eigen::MatrixXd::Identity(nbVariables , nbVariables);
-  Eigen::VectorXd c = (- M_force.transpose() * b_force);
+  Eigen::MatrixXd Q = M_cop.transpose() * M_cop + M_force.transpose() * M_force
+                      + 1e-12 * Eigen::MatrixXd::Identity(nbVariables, nbVariables);
+  Eigen::VectorXd c = (-M_force.transpose() * b_force);
 
   // Eigen::MatrixXd Q = Eigen::MatrixXd::Identity(nbVariables , nbVariables);
   // Eigen::VectorXd c = Eigen::VectorXd::Zero(nbVariables);
 
-
-  qpSolver_.problem( nbVariables, nbEqCstr, nbIneqCstr);
+  qpSolver_.problem(nbVariables, nbEqCstr, nbIneqCstr);
 
   bool solutionFound = qpSolver_.solve(Q, c, Aeq, beq, Aineq, bineq, /* isDecomp = */ false);
   if(!solutionFound)
   {
-    mc_rtc::log::error("[{}] DS force/CoP distribution QP: solver found no solution",name());
+    mc_rtc::log::error("[{}] DS force/CoP distribution QP: solver found no solution", name());
     return;
   }
 
   Eigen::VectorXd x = qpSolver_.result();
-  Eigen::Vector2d leftCoP(x.segment(0,2));
-  Eigen::Vector2d rightCoP(x.segment(2 * nbReferences,2));
-  Eigen::Vector2d leftForce_xy = x.segment(4 * nbReferences,2);
-  Eigen::Vector2d rightForce_xy = x.segment(4 * nbReferences + 2,2);
+  Eigen::Vector2d leftCoP(x.segment(0, 2));
+  Eigen::Vector2d rightCoP(x.segment(2 * nbReferences, 2));
+  Eigen::Vector2d leftForce_xy = x.segment(4 * nbReferences, 2);
+  Eigen::Vector2d rightForce_xy = x.segment(4 * nbReferences + 2, 2);
   modeledCoPLeft_ = leftCoP + (footTasks[ContactState::Left]->measuredCoP() - leftCoP) * exp(-c_.lambdaCoP.x() * dt_);
-  modeledCoPRight_ = rightCoP + (footTasks[ContactState::Right]->measuredCoP() - rightCoP) * exp(-c_.lambdaCoP.y() * dt_);
+  modeledCoPRight_ =
+      rightCoP + (footTasks[ContactState::Right]->measuredCoP() - rightCoP) * exp(-c_.lambdaCoP.y() * dt_);
 
   const double fz_left = (1 - first_ratio) * fz_tot;
-  const double fz_right = (first_ratio) * fz_tot;
+  const double fz_right = (first_ratio)*fz_tot;
 
-  sva::ForceVecd w_l_lc = sva::ForceVecd{Eigen::Vector3d{leftCoP.y()  * fz_left  , -leftCoP.x()  * fz_left  , 0},
-                                         Eigen::Vector3d{leftForce_xy.x(),leftForce_xy.y() , fz_left}};
-  sva::ForceVecd w_r_rc = sva::ForceVecd{Eigen::Vector3d{rightCoP.y() * fz_right , -rightCoP.x() * fz_right , 0},
-                                         Eigen::Vector3d{rightForce_xy.x(),rightForce_xy.y() , fz_right}};
-
+  sva::ForceVecd w_l_lc = sva::ForceVecd{Eigen::Vector3d{leftCoP.y() * fz_left, -leftCoP.x() * fz_left, 0},
+                                         Eigen::Vector3d{leftForce_xy.x(), leftForce_xy.y(), fz_left}};
+  sva::ForceVecd w_r_rc = sva::ForceVecd{Eigen::Vector3d{rightCoP.y() * fz_right, -rightCoP.x() * fz_right, 0},
+                                         Eigen::Vector3d{rightForce_xy.x(), rightForce_xy.y(), fz_right}};
 
   footTasks[ContactState::Left]->targetCoP(leftCoP);
   footTasks[ContactState::Left]->targetForce(w_l_lc.force());
   footTasks[ContactState::Right]->targetCoP(rightCoP);
   footTasks[ContactState::Right]->targetForce(w_r_rc.force());
 
-
   distribWrench_ = X_0_lc.inv().dualMul(w_l_lc) + X_0_rc.inv().dualMul(w_r_rc);
-
 }
 
 void StabilizerTask::saturateWrench(const sva::ForceVecd & desiredWrench,

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1306,9 +1306,9 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
   offsetRight << rightContact.halfLength(), rightContact.halfLength(), rightContact.halfWidth(),
       rightContact.halfWidth();
 
-  Eigen::Vector2d t_lankle_zmp = (zmp_ref[0].segment(0, 2) - lankle);
+  Eigen::Vector2d t_lankle_zmp = zmp_ref[0] - lankle.segment(0, 2);
   const double lankle_rankle = t_lankle_rankle.norm();
-  double d_proj = t_lankle_zmp.dot(t_lankle_rankle.segment(0, 2).normalized());
+  double d_proj = t_lankle_zmp.dot(t_lankle_rankle.normalized());
   // The vertical forces are splitted using the ratio obtained between the reference zmp pose and the contact pose;
   double ratio_desired = clamp(d_proj / lankle_rankle, c_.safetyThresholds.MIN_DS_PRESSURE / fz_tot,
                                1 - (c_.safetyThresholds.MIN_DS_PRESSURE / fz_tot));
@@ -1341,7 +1341,7 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
     {
 
       t_lankle_zmp = zmp_ref[i] - lankle.segment(0, 2);
-      d_proj = t_lankle_zmp.dot(t_lankle_rankle.segment(0, 2).normalized());
+      d_proj = t_lankle_zmp.dot(t_lankle_rankle.normalized());
       // ratio = 1 : fz on rightfoot, 0 on leftFoot
       ratio_desired = clamp(d_proj / lankle_rankle, c_.safetyThresholds.MIN_DS_PRESSURE / fz_tot,
                             1 - (c_.safetyThresholds.MIN_DS_PRESSURE / fz_tot));
@@ -1417,6 +1417,10 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
   Eigen::Vector2d leftCoP(x.segment(0, 2));
   Eigen::Vector2d rightCoP(x.segment(2 * nbReferences, 2));
 
+  //distribZMP_.segment(0,2) = (Mcop * x - bcop).segment(0,2) + zmp_ref[0] ;
+
+  errQPzmp = (Mcop * x - bcop).segment(0,2);
+  
   sva::ForceVecd w_l_lc = sva::ForceVecd{
       Eigen::Vector3d{leftCoP.y() * targetForceLeft.z(), -leftCoP.x() * targetForceLeft.z(), 0}, targetForceLeft};
   sva::ForceVecd w_r_rc = sva::ForceVecd{

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -683,8 +683,8 @@ void StabilizerTask::computeWrenchOffsetAndCoefficient(const mc_rbdyn::Robot & r
   {
     computeExternalContact(robot, extWrench.surfaceName, extWrench.*TargetOrMeasured, pos, force, moment);
 
-    offset_gamma.x() += (pos.z() - zmpTarget_.z()) * force.x() - pos.x() * force.z() + moment.y();
-    offset_gamma.y() += (pos.z() - zmpTarget_.z()) * force.y() - pos.y() * force.z() - moment.x();
+    offset_gamma.x() += (pos.z() - zmpTarget_.z()) * force.x() + (zmpTarget_.x() - pos.x()) * force.z() + moment.y();
+    offset_gamma.y() += (pos.z() - zmpTarget_.z()) * force.y() + (zmpTarget_.y() - pos.y()) * force.z() - moment.x();
 
     coef_kappa -= force.z();
   }

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1156,7 +1156,8 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
   // Constraints
   // -----------
   // (fr_i_z * ur_i_x + fl_i_z * ul_i_x)/(fl_i_z + fr_i_z) == zmp_ref_i  -- CoP reference must match zmp reference (same
-  // for y) CoP within the contact polygone
+  // for y) 
+  //  CoP within the contact polygone
   //  -- left foot wrench within contact wrench cone
   //  -- right foot wrench within contact wrench cone
 
@@ -1172,6 +1173,12 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
   const Eigen::Vector3d & lankle = contacts_.at(ContactState::Left).anklePose().translation();
   const Eigen::Vector3d & rankle = contacts_.at(ContactState::Right).anklePose().translation();
   const Eigen::Vector3d t_lankle_rankle = rankle - lankle;
+  Eigen::Vector2d measuredLeftCoP  = clamp(footTasks[ContactState::Left]->measuredCoP(),
+                                        Eigen::Vector2d{-leftContact.halfLength()*1,-leftContact.halfWidth()*1},
+                                        Eigen::Vector2d{leftContact.halfLength()*1,leftContact.halfWidth()*1});
+  Eigen::Vector2d measuredRightCoP = clamp(footTasks[ContactState::Right]->measuredCoP(),
+                                        Eigen::Vector2d{-rightContact.halfLength()*1,-rightContact.halfWidth()*1},
+                                        Eigen::Vector2d{rightContact.halfLength()*1,rightContact.halfWidth()*1});
 
   const int nbReferences = static_cast<int>(zmp_ref.size());
   const int nbVariables = 2 * 2 * nbReferences + 4;

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1169,191 +1169,257 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
   const auto & leftContact = contacts_.at(ContactState::Left);
   const auto & rightContact = contacts_.at(ContactState::Right);
   const double fz_tot = robot().mass() * constants::GRAVITY;
-  const double safety_ratio = c_.safetyThresholds.MIN_DS_PRESSURE / fz_tot;
   
   const sva::PTransformd & X_0_lc = leftContact.surfacePose();
   const sva::PTransformd & X_0_rc = rightContact.surfacePose();
   const Eigen::Vector3d & lankle = contacts_.at(ContactState::Left).anklePose().translation();
   const Eigen::Vector3d & rankle = contacts_.at(ContactState::Right).anklePose().translation();
   const Eigen::Vector2d t_lankle_rankle = (rankle - lankle).segment(0,2);
-  Eigen::Vector2d measuredLeftCoP = clamp(footTasks[ContactState::Left]->measuredCoP(),
-                                          Eigen::Vector2d{-leftContact.halfLength() * 1, -leftContact.halfWidth() * 1},
-                                          Eigen::Vector2d{leftContact.halfLength() * 1, leftContact.halfWidth() * 1});
-  Eigen::Vector2d measuredRightCoP =
-      clamp(footTasks[ContactState::Right]->measuredCoP(),
-            Eigen::Vector2d{-rightContact.halfLength() * 1, -rightContact.halfWidth() * 1},
-            Eigen::Vector2d{rightContact.halfLength() * 1, rightContact.halfWidth() * 1});
-
-  const Eigen::Vector2d currentCoPTargetLeft = footTasks[ContactState::Left]->targetCoP();
-  const Eigen::Vector2d currentCoPTargetRight = footTasks[ContactState::Right]->targetCoP();
-  Eigen::Vector2d measuredLeftCoP_delayed;
-  measuredLeftCoP_delayed.x() = measuredLeftCoP.x() * exp(-c_.lambdaCoP.x() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.x() * c_.delayCoP)) * currentCoPTargetLeft.x();
-  measuredLeftCoP_delayed.y() = measuredLeftCoP.y() * exp(-c_.lambdaCoP.y() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.y() * c_.delayCoP)) * currentCoPTargetLeft.y();
-
-  Eigen::Vector2d measuredRightCoP_delayed;
-  measuredRightCoP_delayed.x() = measuredRightCoP.x() * exp(-c_.lambdaCoP.x() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.x() * c_.delayCoP)) * currentCoPTargetRight.x();
-  measuredRightCoP_delayed.y() = measuredRightCoP.y() * exp(-c_.lambdaCoP.y() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.y() * c_.delayCoP)) * currentCoPTargetRight.y();
-
-  const int nbReferences = static_cast<int>(zmp_ref.size());
-  const int nbVariables = 2 * 2 * nbReferences + 0;
-  const int nbIneqCstr = 8 * nbReferences + 2 * 2 + 2 * 2;
-  const int nbEqCstr = 2 * nbReferences;
-  Eigen::MatrixXd Aeq = Eigen::MatrixXd::Zero(nbEqCstr, nbVariables);
-  Eigen::VectorXd beq = Eigen::VectorXd::Zero(Aeq.rows());
-
-  Eigen::MatrixXd Aineq = Eigen::MatrixXd::Zero(nbIneqCstr, nbVariables);
-  Eigen::VectorXd bineq = Eigen::VectorXd::Zero(Aineq.rows());
-  Eigen::MatrixXd normals = Eigen::MatrixXd::Zero(4, 2); // normals matrix for CoP constraints
-  Eigen::VectorXd offsetLeft = Eigen::VectorXd::Zero(normals.rows());
-  Eigen::VectorXd offsetRight = Eigen::VectorXd::Zero(normals.rows());
-  normals << 1, 0, -1, 0, 0, 1, 0, -1;
-  offsetLeft << leftContact.halfLength(), leftContact.halfLength(), leftContact.halfWidth(), leftContact.halfWidth();
-
-  offsetRight << rightContact.halfLength(), rightContact.halfLength(), rightContact.halfWidth(),
-      rightContact.halfWidth();
 
 
-  Eigen::Vector2d t_lankle_zmp = (u_ref[0].segment(0,2) - lankle);
-  const double lankle_rankle = t_lankle_rankle.norm();
-  double d_proj = t_lankle_zmp.dot(t_lankle_rankle.segment(0, 2).normalized());
-  // The vertical forces are splitted using the ratio obtained between the reference zmp pose and the contact pose;
-  double first_ratio = clamp(d_proj / lankle_rankle, 0.025, .975);
-  for(Eigen::Index i = 0; i < nbReferences; i++)
+
+
+  if(t_ - tComputation_ > delta)
   {
+    tComputation_ = t_;
+    const Eigen::Vector2d measuredRightCoP =
+        clamp(footTasks[ContactState::Right]->measuredCoP(),
+              Eigen::Vector2d{-rightContact.halfLength() * 1, -rightContact.halfWidth() * 1},
+              Eigen::Vector2d{rightContact.halfLength() * 1, rightContact.halfWidth() * 1});
+    const double measuredFzLeft = footTasks[ContactState::Left]->measuredWrench().force().z();
+    const Eigen::Vector2d measuredLeftCoP = clamp(footTasks[ContactState::Left]->measuredCoP(),
+                                            Eigen::Vector2d{-leftContact.halfLength() * 1, -leftContact.halfWidth() * 1},
+                                            Eigen::Vector2d{leftContact.halfLength() * 1, leftContact.halfWidth() * 1});
+    const double measuredFzRight = footTasks[ContactState::Right]->measuredWrench().force().z();
+    modeledCoPLeft_ = measuredLeftCoP;
+    modeledCoPRight_ = measuredRightCoP;
+    modeledFzLeft_ = measuredFzLeft;
+    modeledFzRight_ = measuredFzRight;
 
-    t_lankle_zmp = u_ref[i] - lankle.segment(0, 2);
-    d_proj = t_lankle_zmp.dot(t_lankle_rankle.segment(0, 2).normalized());
-    // 1 : rightfoot 0 : leftFoot
-    double ratio = clamp(d_proj / lankle_rankle, 0.025, .975);
+    delayedTargetCoPLeft_ = footTasks[ContactState::Left]->targetCoP();
+    delayedTargetCoPRight_ = footTasks[ContactState::Right]->targetCoP();
+    delayedTargetFzLeft_ = footTasks[ContactState::Left]->targetWrench().force().z();
+    delayedTargetFzRight_ = footTasks[ContactState::Right]->targetWrench().force().z();
+  
+    Eigen::Vector3d targetForceLeft = Eigen::Vector3d::Zero();
+    Eigen::Vector3d targetForceRight = Eigen::Vector3d::Zero();
 
-    if(i == 0)
+    Eigen::Vector3d measuredLeftCoP_delayed;
+    measuredLeftCoP_delayed.x() = measuredLeftCoP.x() * exp(-c_.lambdaCoP.x() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.x() * c_.delayCoP)) * delayedTargetCoPLeft_.x();
+    measuredLeftCoP_delayed.y() = measuredLeftCoP.y() * exp(-c_.lambdaCoP.y() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.y() * c_.delayCoP)) * delayedTargetCoPLeft_.y();
+    measuredLeftCoP_delayed.z() = measuredFzLeft * exp(-c_.lambdaCoP.z() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.z() * c_.delayCoP)) * delayedTargetFzLeft_;
+
+    Eigen::Vector3d measuredRightCoP_delayed;
+    measuredRightCoP_delayed.x() = measuredRightCoP.x() * exp(-c_.lambdaCoP.x() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.x() * c_.delayCoP)) * delayedTargetCoPRight_.x();
+    measuredRightCoP_delayed.y() = measuredRightCoP.y() * exp(-c_.lambdaCoP.y() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.y() * c_.delayCoP)) * delayedTargetCoPRight_.y();
+    measuredRightCoP_delayed.z() = measuredFzRight * exp(-c_.lambdaCoP.z() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.z() * c_.delayCoP)) * delayedTargetFzRight_;
+
+
+    const int nbReferences = static_cast<int>(zmp_ref.size());
+    const int nbVariables = 2 * 2 * nbReferences + 0;
+    const int nbIneqCstr = 8 * nbReferences + 2 * 2 + 2 * 2;
+    const int nbEqCstr = 2 * nbReferences;
+    Eigen::MatrixXd Aeq = Eigen::MatrixXd::Zero(nbEqCstr, nbVariables);
+    Eigen::VectorXd beq = Eigen::VectorXd::Zero(Aeq.rows());
+
+    Eigen::MatrixXd Aineq = Eigen::MatrixXd::Zero(nbIneqCstr, nbVariables);
+    Eigen::VectorXd bineq = Eigen::VectorXd::Zero(Aineq.rows());
+    
+    // Eigen::MatrixXd M_force = Eigen::MatrixXd::Zero(2, nbVariables);
+    // Eigen::VectorXd b_force = desiredWrench.force().segment(3, 2);
+
+    Eigen::MatrixXd normals = Eigen::MatrixXd::Zero(4, 2); // normals matrix for CoP constraints
+    Eigen::VectorXd offsetLeft = Eigen::VectorXd::Zero(normals.rows());
+    Eigen::VectorXd offsetRight = Eigen::VectorXd::Zero(normals.rows());
+    normals << 1, 0, -1, 0, 0, 1, 0, -1;
+    offsetLeft << leftContact.halfLength(), leftContact.halfLength(), leftContact.halfWidth(), leftContact.halfWidth();
+
+    offsetRight << rightContact.halfLength(), rightContact.halfLength(), rightContact.halfWidth(),
+        rightContact.halfWidth();
+
+
+    Eigen::Vector2d t_lankle_zmp = (zmp_ref[0].segment(0,2) - lankle);
+    const double lankle_rankle = t_lankle_rankle.norm();
+    double d_proj = t_lankle_zmp.dot(t_lankle_rankle.segment(0, 2).normalized());
+    // The vertical forces are splitted using the ratio obtained between the reference zmp pose and the contact pose;
+    double ratio_desired = clamp(d_proj / lankle_rankle, 0.025, .975);
+    
+    double f_z_desired_left = (1 - ratio_desired) * fz_tot;
+    double f_z_desired_right = ratio_desired * fz_tot;
+    desiredFzLeft_ = f_z_desired_left;
+    desiredFzRight_ = f_z_desired_right; 
+    
+    double f_z_ref_left = (f_z_desired_left -  measuredLeftCoP_delayed.z() * exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP)));
+    f_z_ref_left/= (1 - exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP) ));
+    
+    double f_z_ref_right = (f_z_desired_right -  measuredRightCoP_delayed.z() * exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP)));
+    f_z_ref_right/= (1 - exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP) ));
+
+    double ratio = (f_z_ref_right / (f_z_ref_left + f_z_ref_right));
+
+    targetForceLeft.z() = f_z_ref_left;
+    targetForceRight.z() = f_z_ref_right;
+
+    double f_z_left_i = f_z_desired_left;
+    double f_z_right_i = f_z_desired_right;
+
+    for(Eigen::Index i = 0; i < nbReferences; i++)
     {
-      ratio = first_ratio;
-      // if(first_ratio == 1)
-      // {
-      //   mc_rtc::log::warning("[{}] DS force/CoP distribution QP: puting wrench on right Foot", name());
-      //   saturateWrench(desiredWrench, footTasks[ContactState::Right], rightContact);
-      //   footTasks[ContactState::Left]->setZeroTargetWrench();
-      //   footTasks[ContactState::Left]->targetForce(Eigen::Vector3d{0, 0, c_.safetyThresholds.MIN_DS_PRESSURE});
 
-      //   return;
-      // }
-      // else if(first_ratio == 0)
-      // {
-      //   mc_rtc::log::warning("[{}] DS force/CoP distribution QP: puting wrench on left Foot", name());
-      //   saturateWrench(desiredWrench, footTasks[ContactState::Left], leftContact);
-      //   footTasks[ContactState::Right]->setZeroTargetWrench();
-      //   footTasks[ContactState::Right]->targetForce(Eigen::Vector3d{0, 0, c_.safetyThresholds.MIN_DS_PRESSURE});
-      //   return;
-      // }
-    }
-    // Convert the CoP reference into the modeled CoP
-    Eigen::MatrixXd Acop = Eigen::MatrixXd::Zero(2, 2 * nbReferences);
-    double t = static_cast<double>(i) * delta;
-    Eigen::Matrix2d exp_mat;
-    exp_mat << exp(-c_.lambdaCoP.x() * (t + delta - c_.delayCoP)), 0, 0, exp(-c_.lambdaCoP.y() * (t + delta - c_.delayCoP));
-    for(Eigen::Index k = 0; k <= i; k++)
-    {
-      if(k == 0)
+      t_lankle_zmp = zmp_ref[i] - lankle.segment(0, 2);
+      d_proj = t_lankle_zmp.dot(t_lankle_rankle.segment(0, 2).normalized());
+      // 1 : rightfoot 0 : leftFoot
+      ratio_desired = clamp(d_proj / lankle_rankle, 0.025, 0.975);
+      
+      if( i != 0)
       {
-        Acop(0, 2 * k) = (1 - exp(-c_.lambdaCoP.x() * (delta - c_.delayCoP))) * exp(-c_.lambdaCoP.x() * t);
-        Acop(1, 2 * k + 1) = (1 - exp(-c_.lambdaCoP.y() *  (delta - c_.delayCoP))) * exp(-c_.lambdaCoP.y() * t);
+        f_z_desired_left = (1 - ratio_desired) * fz_tot;
+        f_z_desired_right = ratio_desired * fz_tot;
+
+        f_z_ref_left = (f_z_desired_left -  f_z_left_i * exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP)));
+        f_z_ref_left/= (1 - exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP) ));
+
+        f_z_ref_right = (f_z_desired_right -  f_z_right_i * exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP)));
+        f_z_ref_right/= (1 - exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP) ));
+
+        f_z_left_i = f_z_desired_left;
+        f_z_right_i = f_z_desired_right;
+        ratio = (f_z_ref_right / (f_z_ref_left + f_z_ref_right));
       }
+
       else
       {
-        Acop(0, 2 * k) = (1 - exp(-c_.lambdaCoP.x() * delta)) * exp(-c_.lambdaCoP.x() * t);
-        Acop(1, 2 * k + 1) = (1 - exp(-c_.lambdaCoP.y() * delta)) * exp(-c_.lambdaCoP.y() * t);
+        //Force coulomb constraint
+        //{
+        // Aineq.block(8 * nbReferences, 4 * nbReferences, 4, 4) = Eigen::Matrix4d::Identity();
+        // bineq.segment(8 * nbReferences, 2)     = Eigen::Vector2d::Ones() * leftContact.friction()  * (f_z_ref_left + f_z_ref_right) * (1 - ratio);
+        // bineq.segment(8 * nbReferences + 2, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * (f_z_ref_left + f_z_ref_right) * (ratio);
+
+        // Aineq.block(8 * nbReferences + 4, 4 * nbReferences, 4, 4) = -Eigen::Matrix4d::Identity();
+        // bineq.segment(8 * nbReferences + 4, 2) = Eigen::Vector2d::Ones() *  leftContact.friction() * (f_z_ref_left + f_z_ref_right) * (1 - ratio);
+        // bineq.segment(8 * nbReferences + 6, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * (f_z_ref_left + f_z_ref_right) * (ratio);
+
+        // M_force.block(0, 4 * nbReferences, 2, 2) = Eigen::Matrix2d::Identity();
+        // M_force.block(0, 4 * nbReferences + 2, 2, 2) = Eigen::Matrix2d::Identity();
+        
+        //}
+
+        // if(ratio == 1)
+        // {
+        //   mc_rtc::log::warning("[{}] DS force/CoP distribution QP: puting wrench on right Foot", name());
+        //   saturateWrench(desiredWrench, footTasks[ContactState::Right], rightContact);
+        //   footTasks[ContactState::Left]->setZeroTargetWrench();
+        //   footTasks[ContactState::Left]->targetForce(Eigen::Vector3d{0, 0, c_.safetyThresholds.MIN_DS_PRESSURE});
+        //   return;
+        // }
+        // else if(ratio == 0)
+        // {
+        //   mc_rtc::log::warning("[{}] DS force/CoP distribution QP: puting wrench on left Foot", name());
+        //   saturateWrench(desiredWrench, footTasks[ContactState::Left], leftContact);
+        //   footTasks[ContactState::Right]->setZeroTargetWrench();
+        //   footTasks[ContactState::Right]->targetForce(Eigen::Vector3d{0, 0, c_.safetyThresholds.MIN_DS_PRESSURE});
+        //   return;
+        // }
+      
       }
-      t -= delta;
+      // Convert the CoP reference into the modeled CoP
+      Eigen::MatrixXd Acop = Eigen::MatrixXd::Zero(2, 2 * nbReferences);
+      double t = static_cast<double>(i) * delta;
+      Eigen::Matrix2d exp_mat;
+      exp_mat << exp(-c_.lambdaCoP.x() * (t + delta - c_.delayCoP)), 0, 0, exp(-c_.lambdaCoP.y() * (t + delta - c_.delayCoP));
+      for(Eigen::Index k = 0; k <= i; k++)
+      {
+        if(k == 0)
+        {
+          Acop(0, 2 * k) = (1 - exp(-c_.lambdaCoP.x() * (delta - c_.delayCoP))) * exp(-c_.lambdaCoP.x() * t);
+          Acop(1, 2 * k + 1) = (1 - exp(-c_.lambdaCoP.y() *  (delta - c_.delayCoP))) * exp(-c_.lambdaCoP.y() * t);
+        }
+        else
+        {
+          Acop(0, 2 * k) = (1 - exp(-c_.lambdaCoP.x() * delta)) * exp(-c_.lambdaCoP.x() * t);
+          Acop(1, 2 * k + 1) = (1 - exp(-c_.lambdaCoP.y() * delta)) * exp(-c_.lambdaCoP.y() * t);
+        }
+        t -= delta;
+      }
+
+      // Acop * x = cop in foot frame
+      Aeq.block(2 * i, 0, 2, 2 * nbReferences)                = X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * Acop;
+      Aeq.block(2 * i, 2 * nbReferences, 2, 2 * nbReferences) = X_0_rc.inv().rotation().block(0, 0, 2, 2) * ratio * Acop;
+      beq.segment(2 * i, 2) = zmp_ref[i] 
+                              - X_0_lc.translation().segment(0, 2) * (1 - ratio)
+                              - X_0_rc.translation().segment(0, 2) * (ratio)
+                              -X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * exp_mat * measuredLeftCoP_delayed.segment(0,2)
+                              - X_0_rc.inv().rotation().block(0, 0, 2, 2) * (ratio) *exp_mat * measuredRightCoP_delayed.segment(0,2);
+
+      Aineq.block(4 * i, 0, 4, 2 * nbReferences) = normals * Acop;
+
+      bineq.segment(4 * i, 4) = offsetLeft - normals * exp_mat * (1 - ratio) * measuredLeftCoP_delayed.segment(0,2);
+      bineq.segment(4 * (nbReferences + i), 4) = offsetRight - normals * exp_mat * ratio * measuredRightCoP_delayed.segment(0,2);
+    }
+    Aineq.block(4 * nbReferences, 2 * nbReferences, 4 * nbReferences, 2 * nbReferences) =
+        Aineq.block(0, 0, 4 * nbReferences, 2 * nbReferences);
+
+  
+    Eigen::MatrixXd Q = Aeq.transpose() * Aeq
+                        //+ M_force.transpose() * M_force
+                        + 1e-12 * Eigen::MatrixXd::Identity(nbVariables, nbVariables);
+    Eigen::VectorXd c = (-Aeq.transpose() * beq)
+                        //+ (-M_force.transpose() * b_force)
+                        ;
+
+    // Eigen::MatrixXd Q = Eigen::MatrixXd::Identity(nbVariables , nbVariables);
+    // Eigen::VectorXd c = Eigen::VectorXd::Zero(nbVariables);
+
+    qpSolver_.problem(nbVariables, 0, nbIneqCstr);
+    Eigen::MatrixXd A_eq(0, 0);
+    Eigen::VectorXd b_eq;
+    b_eq.resize(0);
+
+    bool solutionFound = qpSolver_.solve(Q, c, A_eq, b_eq, Aineq, bineq, /* isDecomp = */ false);
+    if(!solutionFound)
+    {
+      mc_rtc::log::error("[{}] DS force/CoP distribution QP: solver found no solution", name());
+      return;
     }
 
-    // Acop * x = cop in foot frame
-    Aeq.block(2 * i, 0, 2, 2 * nbReferences)                = X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * Acop;
-    Aeq.block(2 * i, 2 * nbReferences, 2, 2 * nbReferences) = X_0_rc.inv().rotation().block(0, 0, 2, 2) * ratio * Acop;
-    beq.segment(2 * i, 2) = zmp_ref[i] 
-                            - X_0_lc.translation().segment(0, 2) * (1 - ratio)
-                            - X_0_rc.translation().segment(0, 2) * (ratio)
-                             -X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * exp_mat * measuredLeftCoP_delayed
-                            - X_0_rc.inv().rotation().block(0, 0, 2, 2) * (ratio) *exp_mat * measuredRightCoP_delayed;
-
-    Aineq.block(4 * i, 0, 4, 2 * nbReferences) = normals * Acop;
-
-    bineq.segment(4 * i, 4) = offsetLeft - normals * exp_mat * (1 - ratio) * measuredLeftCoP_delayed;
-    bineq.segment(4 * (nbReferences + i), 4) = offsetRight - normals * exp_mat * ratio * measuredRightCoP_delayed;
+    Eigen::VectorXd x = qpSolver_.result();
+    Eigen::Vector2d leftCoP(x.segment(0, 2));
+    Eigen::Vector2d rightCoP(x.segment(2 * nbReferences, 2));
+    // targetForceLeft.segment(0,2) = x.segment(4 * nbReferences, 2);
+    // targetForceRight.segment(0,2) = x.segment(4 * nbReferences + 2, 2);
+    sva::ForceVecd w_l_lc = sva::ForceVecd{Eigen::Vector3d{leftCoP.y() * targetForceLeft.z(), -leftCoP.x() * targetForceLeft.z(), 0},
+                                          targetForceLeft};
+    sva::ForceVecd w_r_rc = sva::ForceVecd{Eigen::Vector3d{rightCoP.y() * targetForceRight.z(), -rightCoP.x() * targetForceRight.z(), 0},
+                                          targetForceRight};
+    footTasks[ContactState::Left]->targetCoP(leftCoP);
+    footTasks[ContactState::Left]->targetForce(w_l_lc.force());
+    footTasks[ContactState::Right]->targetCoP(rightCoP);
+    footTasks[ContactState::Right]->targetForce(w_r_rc.force());
+    distribWrench_ = X_0_lc.inv().dualMul(w_l_lc) + X_0_rc.inv().dualMul(w_r_rc);
+  
   }
-  Aineq.block(4 * nbReferences, 2 * nbReferences, 4 * nbReferences, 2 * nbReferences) =
-      Aineq.block(0, 0, 4 * nbReferences, 2 * nbReferences);
 
-  // Force coulomb constraint
-  //{
-  // Aineq.block(8 * nbReferences, 4 * nbReferences, 4, 4) = Eigen::Matrix4d::Identity();
-  // bineq.segment(8 * nbReferences, 2) = Eigen::Vector2d::Ones() * leftContact.friction() * fz_tot * (1 - first_ratio);
-  // bineq.segment(8 * nbReferences + 2, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * fz_tot * (first_ratio);
-
-  // Aineq.block(8 * nbReferences + 4, 4 * nbReferences, 4, 4) = -Eigen::Matrix4d::Identity();
-  // bineq.segment(8 * nbReferences + 4, 2) =
-  //     Eigen::Vector2d::Ones() * leftContact.friction() * fz_tot * (1 - first_ratio);
-  // bineq.segment(8 * nbReferences + 6, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * fz_tot * (first_ratio);
-
-  // Eigen::MatrixXd M_force = Eigen::MatrixXd::Zero(2, nbVariables);
-  // M_force.block(0, 4 * nbReferences, 2, 2) = Eigen::Matrix2d::Identity();
-  // M_force.block(0, 4 * nbReferences + 2, 2, 2) = Eigen::Matrix2d::Identity();
-  // Eigen::MatrixXd b_force = desiredWrench.force().segment(3, 2);
-  //}
-
-  Eigen::MatrixXd M_cop = Eigen::MatrixXd::Zero(2 * nbReferences, nbVariables);
-  Eigen::VectorXd b_cop = Eigen::VectorXd::Zero(2 * nbReferences);
-  // M_cop.block(0, 0, 4 * nbReferences, 4 * nbReferences) = Eigen::MatrixXd::Identity(4 * nbReferences,4 *
-  // nbReferences);
-
-  Eigen::MatrixXd Q = Aeq.transpose() * Aeq
-                      //+ M_force.transpose() * M_force
-                      + 1e-12 * Eigen::MatrixXd::Identity(nbVariables, nbVariables);
-  Eigen::VectorXd c = (-Aeq.transpose() * beq)
-      //+ (-M_force.transpose() * b_force)
-      ;
-
-  // Eigen::MatrixXd Q = Eigen::MatrixXd::Identity(nbVariables , nbVariables);
-  // Eigen::VectorXd c = Eigen::VectorXd::Zero(nbVariables);
-
-  qpSolver_.problem(nbVariables, 0, nbIneqCstr);
-  Eigen::MatrixXd A_eq(0, 0);
-  Eigen::VectorXd b_eq;
-  b_eq.resize(0);
-
-  bool solutionFound = qpSolver_.solve(Q, c, A_eq, b_eq, Aineq, bineq, /* isDecomp = */ false);
-  if(!solutionFound)
+  if(c_.delayCoP !=0 && t_ - (c_.delayCoP + tComputation_) <= 0 )
   {
-    mc_rtc::log::error("[{}] DS force/CoP distribution QP: solver found no solution, ratio {}", name(), first_ratio);
-    return;
+    modeledCoPLeft_.x()  = (delayedTargetCoPLeft_ + (modeledCoPLeft_ - delayedTargetCoPLeft_) * exp(-c_.lambdaCoP.x() * dt_)).x();
+    modeledCoPLeft_.y()  = (delayedTargetCoPLeft_ + (modeledCoPLeft_ - delayedTargetCoPLeft_) * exp(-c_.lambdaCoP.y() * dt_)).y();
+    modeledCoPRight_.x() = (delayedTargetCoPRight_ + (modeledCoPRight_ - delayedTargetCoPRight_) * exp(-c_.lambdaCoP.x() * dt_)).x();
+    modeledCoPRight_.y() = (delayedTargetCoPRight_ + (modeledCoPRight_ - delayedTargetCoPRight_) * exp(-c_.lambdaCoP.y() * dt_)).y();
+    modeledFzLeft_       = (delayedTargetFzLeft_ + (modeledFzLeft_ - delayedTargetFzLeft_) * exp(-c_.lambdaCoP.z() * dt_));
+    modeledFzRight_      = (delayedTargetFzRight_ + (modeledFzRight_ - delayedTargetFzRight_) * exp(-c_.lambdaCoP.z() * dt_));
+  }
+  else
+  {
+    modeledCoPLeft_.x() = (footTasks[ContactState::Left]->targetCoP() + (modeledCoPLeft_ - footTasks[ContactState::Left]->targetCoP()) * exp(-c_.lambdaCoP.x() * dt_)).x();
+    modeledCoPLeft_.y() = (footTasks[ContactState::Left]->targetCoP() + (modeledCoPLeft_ - footTasks[ContactState::Left]->targetCoP()) * exp(-c_.lambdaCoP.y() * dt_)).y();
+    modeledCoPRight_.x() = (footTasks[ContactState::Right]->targetCoP() + (modeledCoPRight_ - footTasks[ContactState::Right]->targetCoP()) * exp(-c_.lambdaCoP.x() * dt_)).x();
+    modeledCoPRight_.y() = (footTasks[ContactState::Right]->targetCoP() + (modeledCoPRight_ - footTasks[ContactState::Right]->targetCoP()) * exp(-c_.lambdaCoP.y() * dt_)).y(); 
+    modeledFzLeft_    = (footTasks[ContactState::Left]->targetWrench().force().z()  + (modeledFzLeft_  -  footTasks[ContactState::Left]->targetWrench().force().z()) * exp(-c_.lambdaCoP.z() * dt_));
+    modeledFzRight_   = (footTasks[ContactState::Right]->targetWrench().force().z() + (modeledFzRight_ - footTasks[ContactState::Right]->targetWrench().force().z()) * exp(-c_.lambdaCoP.z() * dt_));
   }
 
-  Eigen::VectorXd x = qpSolver_.result();
-  Eigen::Vector2d leftCoP(x.segment(0, 2));
-  Eigen::Vector2d rightCoP(x.segment(2 * nbReferences, 2));
-  // Eigen::Vector2d leftForce_xy = x.segment(4 * nbReferences, 2);
-  // Eigen::Vector2d rightForce_xy = x.segment(4 * nbReferences + 2, 2);
-  Eigen::Vector2d leftForce_xy = Eigen::Vector2d::Zero();
-  Eigen::Vector2d rightForce_xy = Eigen::Vector2d::Zero();
-  modeledCoPLeft_.x() = (currentCoPTargetLeft + (measuredLeftCoP - currentCoPTargetLeft) * exp(-c_.lambdaCoP.x() * dt_)).x();
-  modeledCoPLeft_.y() = (currentCoPTargetLeft + (measuredLeftCoP - currentCoPTargetLeft) * exp(-c_.lambdaCoP.y() * dt_)).y();
-  modeledCoPRight_.x() = (currentCoPTargetRight + (measuredRightCoP - currentCoPTargetRight) * exp(-c_.lambdaCoP.x() * dt_)).x();
-  modeledCoPRight_.y() = (currentCoPTargetRight + (measuredRightCoP - currentCoPTargetRight) * exp(-c_.lambdaCoP.y() * dt_)).y();
 
-  const double fz_left = (1 - first_ratio) * fz_tot;
-  const double fz_right = (first_ratio)*fz_tot;
-
-  sva::ForceVecd w_l_lc = sva::ForceVecd{Eigen::Vector3d{leftCoP.y() * fz_left, -leftCoP.x() * fz_left, 0},
-                                         Eigen::Vector3d{leftForce_xy.x(), leftForce_xy.y(), fz_left}};
-  sva::ForceVecd w_r_rc = sva::ForceVecd{Eigen::Vector3d{rightCoP.y() * fz_right, -rightCoP.x() * fz_right, 0},
-                                         Eigen::Vector3d{rightForce_xy.x(), rightForce_xy.y(), fz_right}};
-
-  footTasks[ContactState::Left]->targetCoP(leftCoP);
-  footTasks[ContactState::Left]->targetForce(w_l_lc.force());
-  footTasks[ContactState::Right]->targetCoP(rightCoP);
-  footTasks[ContactState::Right]->targetForce(w_r_rc.force());
-
-  distribWrench_ = X_0_lc.inv().dualMul(w_l_lc) + X_0_rc.inv().dualMul(w_r_rc);
+  
 }
 
 void StabilizerTask::saturateWrench(const sva::ForceVecd & desiredWrench,

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -683,8 +683,8 @@ void StabilizerTask::computeWrenchOffsetAndCoefficient(const mc_rbdyn::Robot & r
   {
     computeExternalContact(robot, extWrench.surfaceName, extWrench.*TargetOrMeasured, pos, force, moment);
 
-    offset_gamma.x() += (pos.z() - zmpTarget_.z()) * force.x() + (zmpTarget_.x() - pos.x()) * force.z() + moment.y();
-    offset_gamma.y() += (pos.z() - zmpTarget_.z()) * force.y() + (zmpTarget_.y() - pos.y()) * force.z() - moment.x();
+    offset_gamma.x() += (pos.z() - zmpTarget_.z()) * force.x() - pos.x() * force.z() + moment.y();
+    offset_gamma.y() += (pos.z() - zmpTarget_.z()) * force.y() - pos.y() * force.z() - moment.x();
 
     coef_kappa -= force.z();
   }

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1404,7 +1404,7 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
         offsetRight - normals * exp_mat * measuredRightCoP_delayed.segment(0, 2);
     
     McopDiff(2 * i , 2 * i) = 1;
-    McopDiff(2 * ( nbReferences + i),2 * ( nbReferences + i) ) = -1;
+    McopDiff(2 * i , 2 * ( nbReferences + i) ) = -1;
   }
 
   Aineq.block(4 * nbReferences, 2 * nbReferences, 4 * nbReferences, 2 * nbReferences) =

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1517,8 +1517,7 @@ void StabilizerTask::updateFootForceDifferenceControl()
 {
   auto leftFootTask = footTasks[ContactState::Left];
   auto rightFootTask = footTasks[ContactState::Right];
-  if(!inDoubleSupport() || inTheAir_ || leftFootTask->targetForce().norm() <= c_.safetyThresholds.MIN_DS_PRESSURE
-     || rightFootTask->targetForce().norm() <= c_.safetyThresholds.MIN_DS_PRESSURE)
+  if(!inDoubleSupport() || inTheAir_)
   {
     dfForceError_ = Eigen::Vector3d::Zero();
     dfError_ = Eigen::Vector3d::Zero();

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1254,6 +1254,15 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
   measuredRightCoP_delayed.z() = measuredFzRight * exp(-c_.lambdaCoP.z() * t_delay)
                                  + (1 - exp(-c_.lambdaCoP.z() * t_delay)) * delayedTargetFzRight_;
   
+  if(supportFoot_ == ContactState::Left)
+  {
+    measuredLeftCoP_delayed.z() = fz_tot - measuredRightCoP_delayed.z();
+  }
+  else
+  {
+    measuredRightCoP_delayed.z() = fz_tot - measuredLeftCoP_delayed.z();
+  }
+  
   clampInPlace(measuredLeftCoP_delayed.z() ,0,fz_tot);
   clampInPlace(measuredRightCoP_delayed.z(),0,fz_tot);
 

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1232,6 +1232,9 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
                                  + (1 - exp(-c_.lambdaCoP.y() * t_delay)) * delayedTargetCoPRight_.y();
   measuredRightCoP_delayed.z() = measuredFzRight * exp(-c_.lambdaCoP.z() * t_delay)
                                  + (1 - exp(-c_.lambdaCoP.z() * t_delay)) * delayedTargetFzRight_;
+  
+  clampInPlace(measuredLeftCoP_delayed.z() ,0,fz_tot);
+  clampInPlace(measuredRightCoP_delayed.z(),0,fz_tot);
 
   const int nbReferences = static_cast<int>(zmp_ref.size());
   const int nbVariables = 2 * 2 * nbReferences; // Each reference induce 2 CoP which has 2 coordinates x y

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1155,7 +1155,7 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
   //
   // Constraints
   // -----------
-  // (fr_i_z * ur_i_x + fl_i_z * ul_i_x)/(fl_i_z + fr_i_z) == zmp_ref_i  -- CoP reference must match zmp reference (same
+  // (fr_i_z * ur_i_x + fl_i_z * ul_i_x)/(fl_i_z + fr_i_z) == zmp_ref_i  -- modeled CoP must match zmp reference (same
   // for y)
   //  CoP within the contact polygone
   //  -- left foot wrench within contact wrench cone
@@ -1182,7 +1182,7 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
             Eigen::Vector2d{rightContact.halfLength() * 1, rightContact.halfWidth() * 1});
 
   const int nbReferences = static_cast<int>(zmp_ref.size());
-  const int nbVariables = 2 * 2 * nbReferences + 4;
+  const int nbVariables = 2 * 2 * nbReferences + 0;
   const int nbIneqCstr = 8 * nbReferences + 2 * 2 + 2 * 2;
   const int nbEqCstr = 2 * nbReferences;
   Eigen::MatrixXd Aeq = Eigen::MatrixXd::Zero(nbEqCstr, nbVariables);
@@ -1214,23 +1214,23 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
     if(i == 0)
     {
       first_ratio = ratio;
-      if(first_ratio == 1)
-      {
-        mc_rtc::log::warning("[{}] DS force/CoP distribution QP: puting wrench on right Foot", name());
-        saturateWrench(desiredWrench, footTasks[ContactState::Right], rightContact);
-        footTasks[ContactState::Left]->setZeroTargetWrench();
-        footTasks[ContactState::Left]->targetForce(Eigen::Vector3d{0, 0, c_.safetyThresholds.MIN_DS_PRESSURE});
+      // if(first_ratio == 1)
+      // {
+      //   mc_rtc::log::warning("[{}] DS force/CoP distribution QP: puting wrench on right Foot", name());
+      //   saturateWrench(desiredWrench, footTasks[ContactState::Right], rightContact);
+      //   footTasks[ContactState::Left]->setZeroTargetWrench();
+      //   footTasks[ContactState::Left]->targetForce(Eigen::Vector3d{0, 0, c_.safetyThresholds.MIN_DS_PRESSURE});
 
-        return;
-      }
-      else if(first_ratio == 0)
-      {
-        mc_rtc::log::warning("[{}] DS force/CoP distribution QP: puting wrench on left Foot", name());
-        saturateWrench(desiredWrench, footTasks[ContactState::Left], leftContact);
-        footTasks[ContactState::Right]->setZeroTargetWrench();
-        footTasks[ContactState::Right]->targetForce(Eigen::Vector3d{0, 0, c_.safetyThresholds.MIN_DS_PRESSURE});
-        return;
-      }
+      //   return;
+      // }
+      // else if(first_ratio == 0)
+      // {
+      //   mc_rtc::log::warning("[{}] DS force/CoP distribution QP: puting wrench on left Foot", name());
+      //   saturateWrench(desiredWrench, footTasks[ContactState::Left], leftContact);
+      //   footTasks[ContactState::Right]->setZeroTargetWrench();
+      //   footTasks[ContactState::Right]->targetForce(Eigen::Vector3d{0, 0, c_.safetyThresholds.MIN_DS_PRESSURE});
+      //   return;
+      // }
     }
     // Convert the CoP reference into the modeled CoP
     Eigen::MatrixXd Acop = Eigen::MatrixXd::Zero(2, 2 * nbReferences);
@@ -1262,19 +1262,19 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
 
   // Force coulomb constraint
   //{
-  Aineq.block(8 * nbReferences, 4 * nbReferences, 4, 4) = Eigen::Matrix4d::Identity();
-  bineq.segment(8 * nbReferences, 2) = Eigen::Vector2d::Ones() * leftContact.friction() * fz_tot * (1 - first_ratio);
-  bineq.segment(8 * nbReferences + 2, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * fz_tot * (first_ratio);
+  // Aineq.block(8 * nbReferences, 4 * nbReferences, 4, 4) = Eigen::Matrix4d::Identity();
+  // bineq.segment(8 * nbReferences, 2) = Eigen::Vector2d::Ones() * leftContact.friction() * fz_tot * (1 - first_ratio);
+  // bineq.segment(8 * nbReferences + 2, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * fz_tot * (first_ratio);
 
-  Aineq.block(8 * nbReferences + 4, 4 * nbReferences, 4, 4) = -Eigen::Matrix4d::Identity();
-  bineq.segment(8 * nbReferences + 4, 2) =
-      Eigen::Vector2d::Ones() * leftContact.friction() * fz_tot * (1 - first_ratio);
-  bineq.segment(8 * nbReferences + 6, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * fz_tot * (first_ratio);
+  // Aineq.block(8 * nbReferences + 4, 4 * nbReferences, 4, 4) = -Eigen::Matrix4d::Identity();
+  // bineq.segment(8 * nbReferences + 4, 2) =
+  //     Eigen::Vector2d::Ones() * leftContact.friction() * fz_tot * (1 - first_ratio);
+  // bineq.segment(8 * nbReferences + 6, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * fz_tot * (first_ratio);
 
-  Eigen::MatrixXd M_force = Eigen::MatrixXd::Zero(2, nbVariables);
-  M_force.block(0, 4 * nbReferences, 2, 2) = Eigen::Matrix2d::Identity();
-  M_force.block(0, 4 * nbReferences + 2, 2, 2) = Eigen::Matrix2d::Identity();
-  Eigen::MatrixXd b_force = desiredWrench.force().segment(3, 2);
+  // Eigen::MatrixXd M_force = Eigen::MatrixXd::Zero(2, nbVariables);
+  // M_force.block(0, 4 * nbReferences, 2, 2) = Eigen::Matrix2d::Identity();
+  // M_force.block(0, 4 * nbReferences + 2, 2, 2) = Eigen::Matrix2d::Identity();
+  // Eigen::MatrixXd b_force = desiredWrench.force().segment(3, 2);
   //}
 
   Eigen::MatrixXd M_cop = Eigen::MatrixXd::Zero(2 * nbReferences, nbVariables);
@@ -1282,9 +1282,12 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
   // M_cop.block(0, 0, 4 * nbReferences, 4 * nbReferences) = Eigen::MatrixXd::Identity(4 * nbReferences,4 *
   // nbReferences);
 
-  Eigen::MatrixXd Q = Aeq.transpose() * Aeq + M_force.transpose() * M_force
+  Eigen::MatrixXd Q = Aeq.transpose() * Aeq
+                      //+ M_force.transpose() * M_force
                       + 1e-12 * Eigen::MatrixXd::Identity(nbVariables, nbVariables);
-  Eigen::VectorXd c = (-Aeq.transpose() * beq) + (-M_force.transpose() * b_force);
+  Eigen::VectorXd c = (-Aeq.transpose() * beq)
+      //+ (-M_force.transpose() * b_force)
+      ;
 
   // Eigen::MatrixXd Q = Eigen::MatrixXd::Identity(nbVariables , nbVariables);
   // Eigen::VectorXd c = Eigen::VectorXd::Zero(nbVariables);
@@ -1304,8 +1307,10 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
   Eigen::VectorXd x = qpSolver_.result();
   Eigen::Vector2d leftCoP(x.segment(0, 2));
   Eigen::Vector2d rightCoP(x.segment(2 * nbReferences, 2));
-  Eigen::Vector2d leftForce_xy = x.segment(4 * nbReferences, 2);
-  Eigen::Vector2d rightForce_xy = x.segment(4 * nbReferences + 2, 2);
+  // Eigen::Vector2d leftForce_xy = x.segment(4 * nbReferences, 2);
+  // Eigen::Vector2d rightForce_xy = x.segment(4 * nbReferences + 2, 2);
+  Eigen::Vector2d leftForce_xy = Eigen::Vector2d::Zero();
+  Eigen::Vector2d rightForce_xy = Eigen::Vector2d::Zero();
   modeledCoPLeft_.x() = (leftCoP + (measuredLeftCoP - leftCoP) * exp(-c_.lambdaCoP.x() * dt_)).x();
   modeledCoPLeft_.y() = (leftCoP + (measuredLeftCoP - leftCoP) * exp(-c_.lambdaCoP.y() * dt_)).y();
   modeledCoPRight_.x() = (rightCoP + (measuredRightCoP - rightCoP) * exp(-c_.lambdaCoP.x() * dt_)).x();

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -243,7 +243,10 @@ void StabilizerTask::updateContacts(mc_solver::QPSolver & solver)
     for(const auto contactState : addContacts_)
     {
       auto footTask = footTasks[contactState];
-      footTask->selectActiveJoints(contactState == ContactState::Left ? c_.leftCopActiveJoints : c_.rightCopActiveJoints);
+      footTask->selectActiveJoints(
+          contactState == ContactState::Left
+              ? (c_.leftCopActiveJoints.size() ? c_.leftCopActiveJoints : c_.comActiveJoints)
+              : (c_.rightCopActiveJoints.size() ? c_.rightCopActiveJoints : c_.comActiveJoints));
       if(c_.verbose)
       {
         mc_rtc::log::info("{}: Adding contact {}", name(), footTask->surface());

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1404,7 +1404,9 @@ void StabilizerTask::updateFootForceDifferenceControl()
 {
   auto leftFootTask = footTasks[ContactState::Left];
   auto rightFootTask = footTasks[ContactState::Right];
-  if(!inDoubleSupport() || inTheAir_)
+  if(!inDoubleSupport() || inTheAir_ 
+    || leftFootTask->targetForce().norm() <= c_.safetyThresholds.MIN_DS_PRESSURE ||
+       rightFootTask->targetForce().norm() <= c_.safetyThresholds.MIN_DS_PRESSURE)
   {
     dfForceError_ = Eigen::Vector3d::Zero();
     dfError_ = Eigen::Vector3d::Zero();

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1289,7 +1289,7 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
 
   // Task to regulate de CoP velocity
   Eigen::MatrixXd McopVel = Eigen::MatrixXd::Zero(nbVariables, nbVariables);
-  Eigen::VectorXd bcopVel = Eigen::VectorXd::Zero(McopReg.rows());
+  Eigen::VectorXd bcopVel = Eigen::VectorXd::Zero(McopVel.rows());
 
   // Task to regulate the CoPs difference
   Eigen::MatrixXd McopDiff = Eigen::MatrixXd::Zero(2 * nbReferences, nbVariables);

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -352,6 +352,8 @@ void StabilizerTask::configure_(mc_solver::QPSolver & solver)
   dcmDerivator_.cutoffPeriod(c_.dcmDerivatorTimeConstant);
   dcmIntegrator_.timeConstant(c_.dcmIntegratorTimeConstant);
   dcmIntegrator_.saturation(c_.safetyThresholds.MAX_AVERAGE_DCM_ERROR);
+  
+  fSumFilter_.cutoffPeriod(c_.fSumFilter_T);
 
   extWrenchSumLowPass_.cutoffPeriod(c_.extWrench.extWrenchSumLowPassCutoffPeriod);
   comOffsetLowPass_.cutoffPeriod(c_.extWrench.comOffsetLowPassCutoffPeriod);
@@ -768,7 +770,8 @@ void StabilizerTask::run()
     sva::ForceVecd wrench = sva::ForceVecd::Zero();
     for(const auto & footT : footTasks)
     {
-      wrench += footT.second->measuredWrench();
+      sva::PTransformd X_0_foot = footT.second->surfacePose();
+      wrench += X_0_foot.inv().dualMul(footT.second->measuredWrench());
     }
     fSumFilter_.update(wrench.force());
   }

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -792,7 +792,7 @@ void StabilizerTask::run()
       distributeWrench(desiredWrench_);
     }
   }
-  else if(inContact(ContactState::Left))
+  else
   {
     tComputation_ = 0.;
     if(inContact(ContactState::Left))

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1181,7 +1181,7 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
   const Eigen::Vector2d t_lankle_rankle = (rankle - lankle).segment(0,2);
 
 
-  if(t_ - tComputation_ > c_.delayCoP)
+  if(t_ - tComputation_ > delta)
   {
     tComputation_ = t_;
     delayedTargetCoPLeft_ = footTasks[ContactState::Left]->targetCoP();
@@ -1189,7 +1189,7 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
     delayedTargetFzLeft_ = footTasks[ContactState::Left]->targetWrench().force().z();
     delayedTargetFzRight_ = footTasks[ContactState::Right]->targetWrench().force().z();
   }
-  double t_delay = (c_.delayCoP - (t_ - tComputation_ ));
+  double t_delay = clamp((c_.delayCoP - (t_ - tComputation_ )),0,c_.delayCoP);
 
 
   const Eigen::Vector2d measuredRightCoP =

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -773,7 +773,7 @@ void StabilizerTask::run()
   {
     if(horizonCoPDistribution_)
     {
-      distributeCoPonHorizon(desiredWrench_, horizonZmpRef_,horizonURef_, horizonDelta_);
+      distributeCoPonHorizon(horizonZmpRef_, horizonDelta_);
       horizonCoPDistribution_ = false;
     }
     else
@@ -1140,30 +1140,28 @@ void StabilizerTask::distributeWrench(const sva::ForceVecd & desiredWrench)
   footTasks[ContactState::Right]->targetForce(w_r_rc.force());
 }
 
-void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench,
-                                            const std::vector<Eigen::Vector2d> & zmp_ref,const std::vector<Eigen::Vector2d> & u_ref,
+void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref,
                                             const double delta)
 {
   // Variables
   // ---------
-  // sequence [ul_1_x,ul_1_y, ..., ul_n_x,ul_n_y,ur_1_x,ur_1_y, ..., ur_n_x,ur_n_y,f_l_x,f_l_y,f_r_x,f_r_y]
+  // sequence [ul_1_x,ul_1_y, ..., ul_n_x,ul_n_y,ur_1_x,ur_1_y, ..., ur_n_x,ur_n_y]
   // [ur_i_x,ur_i_y]: Right CoP reference in the foot frame at the ith iteration
   // [ul_i_x,ul_i_y]: Left  CoP reference in the foot frame at the ith iteration
   // Objective
   // ---------
   // Weighted minimization of the following tasks:
   //
-  // [ur_i_x,ur_i_y] == [0,0] -- minimize the CoP position for each foot
-  // f_l_x + f_r_x = desiredWrench_fx
-  // f_l_y + f_r_y = desiredWrench_fy
+  // [ur_i_x,ur_i_y] == [x_ankle,y_ankle] -- minimize the CoP reference to be under the ankle for each foot
+  //
+  // (fr_i_z * ur_i_x + fl_i_z * ul_i_x)/(fl_i_z + fr_i_z) == zmp_ref_i  -- modeled CoP must match zmp reference (same
+  // for y)
   //
   // Constraints
   // -----------
-  // (fr_i_z * ur_i_x + fl_i_z * ul_i_x)/(fl_i_z + fr_i_z) == zmp_ref_i  -- modeled CoP must match zmp reference (same
-  // for y)
+  //
   //  CoP within the contact polygone
-  //  -- left foot wrench within contact wrench cone
-  //  -- right foot wrench within contact wrench cone
+
 
   if(zmp_ref.size() == 0)
   {
@@ -1176,21 +1174,16 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
   
   const sva::PTransformd & X_0_lc = leftContact.surfacePose();
   const sva::PTransformd & X_0_rc = rightContact.surfacePose();
+
+  //translation vector from contact center to contact ankle in contact frame
+  //{
+  const Eigen::Vector3d t_rc_rankle = (contacts_.at(ContactState::Right).anklePose() * X_0_rc.inv()).translation();
+  const Eigen::Vector3d t_lc_lankle = (contacts_.at(ContactState::Left).anklePose() * X_0_lc.inv()).translation();
+  //}
+
   const Eigen::Vector3d & lankle = contacts_.at(ContactState::Left).anklePose().translation();
   const Eigen::Vector3d & rankle = contacts_.at(ContactState::Right).anklePose().translation();
   const Eigen::Vector2d t_lankle_rankle = (rankle - lankle).segment(0,2);
-
-
-  if(t_ - tComputation_ > delta)
-  {
-    tComputation_ = t_;
-    delayedTargetCoPLeft_ = footTasks[ContactState::Left]->targetCoP();
-    delayedTargetCoPRight_ = footTasks[ContactState::Right]->targetCoP();
-    delayedTargetFzLeft_ = footTasks[ContactState::Left]->targetWrench().force().z();
-    delayedTargetFzRight_ = footTasks[ContactState::Right]->targetWrench().force().z();
-  }
-  double t_delay = clamp((c_.delayCoP - (t_ - tComputation_ )),0,c_.delayCoP);
-
 
   const Eigen::Vector2d measuredRightCoP =
       clamp(footTasks[ContactState::Right]->measuredCoP(),
@@ -1201,10 +1194,22 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
                                           Eigen::Vector2d{-leftContact.halfLength() * 1, -leftContact.halfWidth() * 1},
                                           Eigen::Vector2d{leftContact.halfLength() * 1, leftContact.halfWidth() * 1});
   const double measuredFzRight = footTasks[ContactState::Right]->measuredWrench().force().z();
+
   modeledCoPLeft_ = measuredLeftCoP;
   modeledCoPRight_ = measuredRightCoP;
   modeledFzLeft_ = measuredFzLeft;
   modeledFzRight_ = measuredFzRight;
+
+  if(t_ - tComputation_ > delta)
+  {
+    tComputation_ = t_;
+    delayedTargetCoPLeft_ = footTasks[ContactState::Left]->targetCoP();
+    delayedTargetCoPRight_ = footTasks[ContactState::Right]->targetCoP();
+    delayedTargetFzLeft_ = footTasks[ContactState::Left]->targetWrench().force().z();
+    delayedTargetFzRight_ = footTasks[ContactState::Right]->targetWrench().force().z();
+    
+  }
+  double t_delay = clamp((c_.delayCoP - (t_ - tComputation_ )),0,c_.delayCoP);
 
   Eigen::Vector3d targetForceLeft = Eigen::Vector3d::Zero();
   Eigen::Vector3d targetForceRight = Eigen::Vector3d::Zero();
@@ -1221,22 +1226,24 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
 
 
   const int nbReferences = static_cast<int>(zmp_ref.size());
-  const int nbVariables = 2 * 2 * nbReferences + 0;
+  const int nbVariables = 2 * 2 * nbReferences;
   const int nbIneqCstr = 8 * nbReferences + 2 * 2 + 2 * 2;
   const int nbEqCstr = 2 * nbReferences;
-  Eigen::MatrixXd Aeq = Eigen::MatrixXd::Zero(nbEqCstr, nbVariables);
-  Eigen::VectorXd beq = Eigen::VectorXd::Zero(Aeq.rows());
+  Eigen::MatrixXd Mcop = Eigen::MatrixXd::Zero(nbEqCstr, nbVariables);
+  Eigen::VectorXd bcop = Eigen::VectorXd::Zero(Mcop.rows());
+
+  const Eigen::MatrixXd McopReg = Eigen::MatrixXd::Identity(nbVariables, nbVariables);
+  Eigen::VectorXd bcopReg = Eigen::VectorXd::Zero(McopReg.rows());
+
 
   Eigen::MatrixXd Aineq = Eigen::MatrixXd::Zero(nbIneqCstr, nbVariables);
   Eigen::VectorXd bineq = Eigen::VectorXd::Zero(Aineq.rows());
-  
-  // Eigen::MatrixXd M_force = Eigen::MatrixXd::Zero(2, nbVariables);
-  // Eigen::VectorXd b_force = desiredWrench.force().segment(3, 2);
 
   Eigen::MatrixXd normals = Eigen::MatrixXd::Zero(4, 2); // normals matrix for CoP constraints
   Eigen::VectorXd offsetLeft = Eigen::VectorXd::Zero(normals.rows());
   Eigen::VectorXd offsetRight = Eigen::VectorXd::Zero(normals.rows());
   normals << 1, 0, -1, 0, 0, 1, 0, -1;
+
   offsetLeft << leftContact.halfLength(), leftContact.halfLength(), leftContact.halfWidth(), leftContact.halfWidth();
 
   offsetRight << rightContact.halfLength(), rightContact.halfLength(), rightContact.halfWidth(),
@@ -1247,97 +1254,70 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
   const double lankle_rankle = t_lankle_rankle.norm();
   double d_proj = t_lankle_zmp.dot(t_lankle_rankle.segment(0, 2).normalized());
   // The vertical forces are splitted using the ratio obtained between the reference zmp pose and the contact pose;
-  double ratio_desired = clamp(d_proj / lankle_rankle, 0.025, .975);
-  
+  double ratio_desired = clamp(d_proj / lankle_rankle,c_.safetyThresholds.MIN_DS_PRESSURE/fz_tot, 1 - (c_.safetyThresholds.MIN_DS_PRESSURE/fz_tot));
+
+ 
   double f_z_desired_left = (1 - ratio_desired) * fz_tot;
   double f_z_desired_right = ratio_desired * fz_tot;
   desiredFzLeft_ = f_z_desired_left;
   desiredFzRight_ = f_z_desired_right; 
+
+  double f_z_ref_left = f_z_desired_left -  measuredLeftCoP_delayed.z() * exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP)) ;
+  f_z_ref_left/= (1 - exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP) ));
   
-  double f_z_ref_left = (f_z_desired_left -  measuredLeftCoP_delayed.z() * exp(-c_.lambdaCoP.z() * (delta)));
-  f_z_ref_left/= (1 - exp(-c_.lambdaCoP.z() * (delta) ));
-  
-  double f_z_ref_right = (f_z_desired_right -  measuredRightCoP_delayed.z() * exp(-c_.lambdaCoP.z() * (delta)));
-  f_z_ref_right/= (1 - exp(-c_.lambdaCoP.z() * (delta) ));
+  double f_z_ref_right = f_z_desired_right -  measuredRightCoP_delayed.z() * exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP)) ;
+  f_z_ref_right/= (1 - exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP) ));
+
 
   double ratio = (f_z_ref_right / (f_z_ref_left + f_z_ref_right));
 
   targetForceLeft.z() = f_z_ref_left;
   targetForceRight.z() = f_z_ref_right;
 
-  double f_z_left_i = f_z_desired_left;
-  double f_z_right_i = f_z_desired_right;
+  double f_z_left_i = f_z_desired_left * exp(-c_.lambdaCoP.z() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.z() * c_.delayCoP)) * f_z_ref_left;
+  double f_z_right_i = f_z_desired_right * exp(-c_.lambdaCoP.z() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.z() * c_.delayCoP)) * f_z_ref_right;
 
   for(Eigen::Index i = 0; i < nbReferences; i++)
   {
 
+    bcopReg.segment(2 *i,2) =  t_lc_lankle.segment(0,2);
+    bcopReg.segment(2 * (i +  nbReferences) ,2) =  t_rc_rankle.segment(0,2);
+
     t_lankle_zmp = zmp_ref[i] - lankle.segment(0, 2);
     d_proj = t_lankle_zmp.dot(t_lankle_rankle.segment(0, 2).normalized());
     // 1 : rightfoot 0 : leftFoot
-    ratio_desired = clamp(d_proj / lankle_rankle, 0.025, 0.975);
+    ratio_desired = clamp(d_proj / lankle_rankle,c_.safetyThresholds.MIN_DS_PRESSURE/fz_tot, 1 - (c_.safetyThresholds.MIN_DS_PRESSURE/fz_tot));
     
     if( i != 0)
     {
+ 
       f_z_desired_left = (1 - ratio_desired) * fz_tot;
       f_z_desired_right = ratio_desired * fz_tot;
 
-      f_z_ref_left = (f_z_desired_left -  f_z_left_i * exp(-c_.lambdaCoP.z() * (delta)));
-      f_z_ref_left/= (1 - exp(-c_.lambdaCoP.z() * (delta) ));
+      f_z_ref_left = f_z_desired_left -  f_z_left_i * exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP)) ;
+      f_z_ref_left/= (1 - exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP) ));
 
-      f_z_ref_right = (f_z_desired_right -  f_z_right_i * exp(-c_.lambdaCoP.z() * (delta)));
-      f_z_ref_right/= (1 - exp(-c_.lambdaCoP.z() * (delta) ));
+      f_z_ref_right = f_z_desired_right -  f_z_right_i * exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP)) ;
+      f_z_ref_right/= (1 - exp(-c_.lambdaCoP.z() * (delta - c_.delayCoP) ));
 
-      f_z_left_i = f_z_desired_left;
-      f_z_right_i = f_z_desired_right;
+
+      f_z_left_i = f_z_desired_left * exp(-c_.lambdaCoP.z() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.z() * c_.delayCoP)) * f_z_ref_left;
+      f_z_right_i = f_z_desired_right * exp(-c_.lambdaCoP.z() * c_.delayCoP) + (1 - exp(-c_.lambdaCoP.z() * c_.delayCoP)) * f_z_ref_right;
       ratio = (f_z_ref_right / (f_z_ref_left + f_z_ref_right));
     }
-
-    else
-    {
-      //Force coulomb constraint
-      //{
-      // Aineq.block(8 * nbReferences, 4 * nbReferences, 4, 4) = Eigen::Matrix4d::Identity();
-      // bineq.segment(8 * nbReferences, 2)     = Eigen::Vector2d::Ones() * leftContact.friction()  * (f_z_ref_left + f_z_ref_right) * (1 - ratio);
-      // bineq.segment(8 * nbReferences + 2, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * (f_z_ref_left + f_z_ref_right) * (ratio);
-
-      // Aineq.block(8 * nbReferences + 4, 4 * nbReferences, 4, 4) = -Eigen::Matrix4d::Identity();
-      // bineq.segment(8 * nbReferences + 4, 2) = Eigen::Vector2d::Ones() *  leftContact.friction() * (f_z_ref_left + f_z_ref_right) * (1 - ratio);
-      // bineq.segment(8 * nbReferences + 6, 2) = Eigen::Vector2d::Ones() * rightContact.friction() * (f_z_ref_left + f_z_ref_right) * (ratio);
-
-      // M_force.block(0, 4 * nbReferences, 2, 2) = Eigen::Matrix2d::Identity();
-      // M_force.block(0, 4 * nbReferences + 2, 2, 2) = Eigen::Matrix2d::Identity();
-      
-      //}
-
-      // if(ratio == 1)
-      // {
-      //   mc_rtc::log::warning("[{}] DS force/CoP distribution QP: puting wrench on right Foot", name());
-      //   saturateWrench(desiredWrench, footTasks[ContactState::Right], rightContact);
-      //   footTasks[ContactState::Left]->setZeroTargetWrench();
-      //   footTasks[ContactState::Left]->targetForce(Eigen::Vector3d{0, 0, c_.safetyThresholds.MIN_DS_PRESSURE});
-      //   return;
-      // }
-      // else if(ratio == 0)
-      // {
-      //   mc_rtc::log::warning("[{}] DS force/CoP distribution QP: puting wrench on left Foot", name());
-      //   saturateWrench(desiredWrench, footTasks[ContactState::Left], leftContact);
-      //   footTasks[ContactState::Right]->setZeroTargetWrench();
-      //   footTasks[ContactState::Right]->targetForce(Eigen::Vector3d{0, 0, c_.safetyThresholds.MIN_DS_PRESSURE});
-      //   return;
-      // }
+   
     
-    }
     // Convert the CoP reference into the modeled CoP
     Eigen::MatrixXd Acop = Eigen::MatrixXd::Zero(2, 2 * nbReferences);
     double t = static_cast<double>(i) * delta;
     Eigen::Matrix2d exp_mat;
-    exp_mat << exp(-c_.lambdaCoP.x() * (t + delta)), 0, 0, exp(-c_.lambdaCoP.y() * (t + delta));
+    exp_mat << exp(-c_.lambdaCoP.x() * (t + delta - c_.delayCoP)), 0, 0, exp(-c_.lambdaCoP.y() * (t + delta - c_.delayCoP));
     for(Eigen::Index k = 0; k <= i; k++)
     {
-      if(k == 0)
+      if(k == i)
       {
-        Acop(0, 2 * k) = (1 - exp(-c_.lambdaCoP.x() * (delta))) * exp(-c_.lambdaCoP.x() * t);
-        Acop(1, 2 * k + 1) = (1 - exp(-c_.lambdaCoP.y() *  (delta))) * exp(-c_.lambdaCoP.y() * t);
+        Acop(0, 2 * k) = (1 - exp(-c_.lambdaCoP.x() * (delta - c_.delayCoP))) * exp(-c_.lambdaCoP.x() * t);
+        Acop(1, 2 * k + 1) = (1 - exp(-c_.lambdaCoP.y() *  (delta - c_.delayCoP))) * exp(-c_.lambdaCoP.y() * t);
       }
       else
       {
@@ -1348,12 +1328,12 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
     }
 
     // Acop * x = cop in foot frame
-    Aeq.block(2 * i, 0, 2, 2 * nbReferences)                = X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * Acop;
-    Aeq.block(2 * i, 2 * nbReferences, 2, 2 * nbReferences) = X_0_rc.inv().rotation().block(0, 0, 2, 2) * ratio * Acop;
-    beq.segment(2 * i, 2) = zmp_ref[i] 
+    Mcop.block(2 * i, 0, 2, 2 * nbReferences)                = X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * Acop;
+    Mcop.block(2 * i, 2 * nbReferences, 2, 2 * nbReferences) = X_0_rc.inv().rotation().block(0, 0, 2, 2) * ratio * Acop;
+    bcop.segment(2 * i, 2) = zmp_ref[i] 
                             - X_0_lc.translation().segment(0, 2) * (1 - ratio)
                             - X_0_rc.translation().segment(0, 2) * (ratio)
-                            -X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * exp_mat * measuredLeftCoP_delayed.segment(0,2)
+                            - X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * exp_mat * measuredLeftCoP_delayed.segment(0,2)
                             - X_0_rc.inv().rotation().block(0, 0, 2, 2) * (ratio) *exp_mat * measuredRightCoP_delayed.segment(0,2);
 
     Aineq.block(4 * i, 0, 4, 2 * nbReferences) = normals * Acop;
@@ -1366,22 +1346,15 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
       Aineq.block(0, 0, 4 * nbReferences, 2 * nbReferences);
 
 
-  Eigen::MatrixXd Q = Aeq.transpose() * Aeq
-                      //+ M_force.transpose() * M_force
-                      + 1e-12 * Eigen::MatrixXd::Identity(nbVariables, nbVariables);
-  Eigen::VectorXd c = (-Aeq.transpose() * beq)
-                      //+ (-M_force.transpose() * b_force)
-                      ;
-
-  // Eigen::MatrixXd Q = Eigen::MatrixXd::Identity(nbVariables , nbVariables);
-  // Eigen::VectorXd c = Eigen::VectorXd::Zero(nbVariables);
+  Eigen::MatrixXd Q = Mcop.transpose() * Mcop + 1e-12 * McopReg;
+  Eigen::VectorXd c = (-Mcop.transpose() * bcop) + 1e-12 * (-McopReg.transpose() * bcopReg);
 
   qpSolver_.problem(nbVariables, 0, nbIneqCstr);
-  Eigen::MatrixXd A_eq(0, 0);
-  Eigen::VectorXd b_eq;
-  b_eq.resize(0);
+  Eigen::MatrixXd Aeq(0, 0);
+  Eigen::VectorXd beq;
+  beq.resize(0);
 
-  bool solutionFound = qpSolver_.solve(Q, c, A_eq, b_eq, Aineq, bineq, /* isDecomp = */ false);
+  bool solutionFound = qpSolver_.solve(Q, c, Aeq, beq, Aineq, bineq, /* isDecomp = */ false);
   if(!solutionFound)
   {
     mc_rtc::log::error("[{}] DS force/CoP distribution QP: solver found no solution", name());
@@ -1406,7 +1379,7 @@ void StabilizerTask::distributeCoPonHorizon(const sva::ForceVecd & desiredWrench
 
 
 
-  if(c_.delayCoP !=0 && t_ - (c_.delayCoP + tComputation_) < 0 )
+  if(c_.delayCoP !=0 && t_delay > 0 )
   {
     modeledCoPLeft_.x()  = (delayedTargetCoPLeft_ + (modeledCoPLeft_ - delayedTargetCoPLeft_) * exp(-c_.lambdaCoP.x() * dt_)).x();
     modeledCoPLeft_.y()  = (delayedTargetCoPLeft_ + (modeledCoPLeft_ - delayedTargetCoPLeft_) * exp(-c_.lambdaCoP.y() * dt_)).y();

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -48,6 +48,7 @@ StabilizerTask::StabilizerTask(const mc_rbdyn::Robots & robots,
                                                                 leftSurface, robots, robotIndex_);
   auto rightCoP = std::allocate_shared<mc_tasks::force::CoPTask>(Eigen::aligned_allocator<mc_tasks::force::CoPTask>{},
                                                                  rightSurface, robots, robotIndex_);
+  
   footTasks[ContactState::Left] = leftCoP;
   footTasks[ContactState::Right] = rightCoP;
 
@@ -242,6 +243,7 @@ void StabilizerTask::updateContacts(mc_solver::QPSolver & solver)
     for(const auto contactState : addContacts_)
     {
       auto footTask = footTasks[contactState];
+      footTask->selectActiveJoints(contactState == ContactState::Left ? c_.leftCopActiveJoints : c_.rightCopActiveJoints);
       if(c_.verbose)
       {
         mc_rtc::log::info("{}: Adding contact {}", name(), footTask->surface());
@@ -1210,11 +1212,11 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
   const Eigen::Vector2d measuredRightCoP = clamp(footTasks[ContactState::Right]->measuredCoP(),
                                                  Eigen::Vector2d{-rightContact.halfLength(), -rightContact.halfWidth()},
                                                  Eigen::Vector2d{rightContact.halfLength(), rightContact.halfWidth()});
-  const double measuredFzLeft = clamp(footTasks[ContactState::Left]->measuredWrench().force().z(),0,fz_tot);
+  const double measuredFzLeft = clamp(X_0_rc.inv().dualMul(footTasks[ContactState::Left]->measuredWrench()).force().z(),0,fz_tot);
   const Eigen::Vector2d measuredLeftCoP = clamp(footTasks[ContactState::Left]->measuredCoP(),
                                                 Eigen::Vector2d{-leftContact.halfLength(), -leftContact.halfWidth()},
                                                 Eigen::Vector2d{leftContact.halfLength(), leftContact.halfWidth()});
-  const double measuredFzRight = clamp(footTasks[ContactState::Right]->measuredWrench().force().z(),0,fz_tot);
+  const double measuredFzRight = clamp(X_0_lc.inv().dualMul(footTasks[ContactState::Right]->measuredWrench()).force().z(),0,fz_tot);
 
 
   // double fz_tot = clamp( measuredFzRight + measuredFzLeft,0. ,robot().mass() * constants::GRAVITY );
@@ -1238,30 +1240,33 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
   Eigen::Vector3d targetForceLeft = Eigen::Vector3d::Zero();
   Eigen::Vector3d targetForceRight = Eigen::Vector3d::Zero();
 
+  Eigen::Vector2d lambdaCoPLeft = supportFoot_ == ContactState::Right ? c_.lambdaCoP.segment(0,2) : c_.lambdaCoPSupportFoot;
+  Eigen::Vector2d lambdaCoPRight = supportFoot_ == ContactState::Left ? c_.lambdaCoP.segment(0,2) : c_.lambdaCoPSupportFoot;
+
   Eigen::Vector3d measuredLeftCoP_delayed;
-  measuredLeftCoP_delayed.x() = measuredLeftCoP.x() * exp(-c_.lambdaCoP.x() * t_delay)
-                                + (1 - exp(-c_.lambdaCoP.x() * t_delay)) * delayedTargetCoPLeft_.x();
-  measuredLeftCoP_delayed.y() = measuredLeftCoP.y() * exp(-c_.lambdaCoP.y() * t_delay)
-                                + (1 - exp(-c_.lambdaCoP.y() * t_delay)) * delayedTargetCoPLeft_.y();
+  measuredLeftCoP_delayed.x() = measuredLeftCoP.x() * exp(-lambdaCoPLeft.x() * t_delay)
+                                + (1 - exp(-lambdaCoPLeft.x() * t_delay)) * delayedTargetCoPLeft_.x();
+  measuredLeftCoP_delayed.y() = measuredLeftCoP.y() * exp(-lambdaCoPLeft.y() * t_delay)
+                                + (1 - exp(-lambdaCoPLeft.y() * t_delay)) * delayedTargetCoPLeft_.y();
   measuredLeftCoP_delayed.z() =
       measuredFzLeft * exp(-c_.lambdaCoP.z() * t_delay) + (1 - exp(-c_.lambdaCoP.z() * t_delay)) * delayedTargetFzLeft_;
 
   Eigen::Vector3d measuredRightCoP_delayed;
-  measuredRightCoP_delayed.x() = measuredRightCoP.x() * exp(-c_.lambdaCoP.x() * t_delay)
-                                 + (1 - exp(-c_.lambdaCoP.x() * t_delay)) * delayedTargetCoPRight_.x();
-  measuredRightCoP_delayed.y() = measuredRightCoP.y() * exp(-c_.lambdaCoP.y() * t_delay)
-                                 + (1 - exp(-c_.lambdaCoP.y() * t_delay)) * delayedTargetCoPRight_.y();
+  measuredRightCoP_delayed.x() = measuredRightCoP.x() * exp(-lambdaCoPRight.x() * t_delay)
+                                 + (1 - exp(-lambdaCoPRight.x() * t_delay)) * delayedTargetCoPRight_.x();
+  measuredRightCoP_delayed.y() = measuredRightCoP.y() * exp(-lambdaCoPRight.y() * t_delay)
+                                 + (1 - exp(-lambdaCoPRight.y() * t_delay)) * delayedTargetCoPRight_.y();
   measuredRightCoP_delayed.z() = measuredFzRight * exp(-c_.lambdaCoP.z() * t_delay)
                                  + (1 - exp(-c_.lambdaCoP.z() * t_delay)) * delayedTargetFzRight_;
   
-  if(supportFoot_ == ContactState::Left)
-  {
-    measuredLeftCoP_delayed.z() = fz_tot - measuredRightCoP_delayed.z();
-  }
-  else
-  {
-    measuredRightCoP_delayed.z() = fz_tot - measuredLeftCoP_delayed.z();
-  }
+  // if(supportFoot_ == ContactState::Left)
+  // {
+  //   measuredLeftCoP_delayed.z() = fz_tot - measuredRightCoP_delayed.z();
+  // }
+  // else
+  // {
+  //   measuredRightCoP_delayed.z() = fz_tot - measuredLeftCoP_delayed.z();
+  // }
   
   clampInPlace(measuredLeftCoP_delayed.z() ,0,fz_tot);
   clampInPlace(measuredRightCoP_delayed.z(),0,fz_tot);
@@ -1344,39 +1349,50 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
 
     }
 
+
     // Acop convert the CoP reference into the modeled CoP
     // Acop * x + cop_0 * e^(-lambda t_i) = cop i in foot frame (left/right)
-    Eigen::MatrixXd Acop = Eigen::MatrixXd::Zero(2, 2 * nbReferences);
+    Eigen::MatrixXd AcopLeft = Eigen::MatrixXd::Zero(2, 2 * nbReferences);
+    Eigen::MatrixXd AcopRight = Eigen::MatrixXd::Zero(2, 2 * nbReferences);
     double t = static_cast<double>(i) * delta;
-    Eigen::Matrix2d exp_mat;
-    exp_mat << exp(-c_.lambdaCoP.x() * (t + delta - (i == 0 ? t_delay : c_.delayCoP))), 0, 0,
-        exp(-c_.lambdaCoP.y() * (t + delta - (i == 0 ? t_delay : c_.delayCoP)));
+    Eigen::Matrix2d exp_mat_left;
+    exp_mat_left << exp(-lambdaCoPLeft.x() * (t + delta - (i == 0 ? t_delay : c_.delayCoP))), 0, 0,
+        exp(-lambdaCoPLeft.y() * (t + delta - (i == 0 ? t_delay : c_.delayCoP)));
+    Eigen::Matrix2d exp_mat_right;
+    exp_mat_right << exp(-lambdaCoPRight.x() * (t + delta - (i == 0 ? t_delay : c_.delayCoP))), 0, 0,
+        exp(-lambdaCoPRight.y() * (t + delta - (i == 0 ? t_delay : c_.delayCoP)));
     for(Eigen::Index k = 0; k <= i; k++)
     {
       if(k == i)
       {
-        Acop(0, 2 * k) =
-            (1 - exp(-c_.lambdaCoP.x() * (delta - (i == 0 ? t_delay : c_.delayCoP)))) * exp(-c_.lambdaCoP.x() * t);
-        Acop(1, 2 * k + 1) =
-            (1 - exp(-c_.lambdaCoP.y() * (delta - (i == 0 ? t_delay : c_.delayCoP)))) * exp(-c_.lambdaCoP.y() * t);
+        AcopLeft(0, 2 * k) =
+            (1 - exp(-lambdaCoPLeft.x() * (delta - (i == 0 ? t_delay : c_.delayCoP)))) * exp(-lambdaCoPLeft.x() * t);
+        AcopLeft(1, 2 * k + 1) =
+            (1 - exp(-lambdaCoPLeft.y() * (delta - (i == 0 ? t_delay : c_.delayCoP)))) * exp(-lambdaCoPLeft.y() * t);
+        AcopRight(0, 2 * k) =
+            (1 - exp(-lambdaCoPRight.x() * (delta - (i == 0 ? t_delay : c_.delayCoP)))) * exp(-lambdaCoPRight.x() * t);
+        AcopRight(1, 2 * k + 1) =
+            (1 - exp(-lambdaCoPRight.y() * (delta - (i == 0 ? t_delay : c_.delayCoP)))) * exp(-lambdaCoPRight.y() * t);
       }
       else
       {
-        Acop(0, 2 * k) = (1 - exp(-c_.lambdaCoP.x() * delta)) * exp(-c_.lambdaCoP.x() * t);
-        Acop(1, 2 * k + 1) = (1 - exp(-c_.lambdaCoP.y() * delta)) * exp(-c_.lambdaCoP.y() * t);
+        AcopLeft(0, 2 * k) = (1 - exp(-lambdaCoPLeft.x() * delta)) * exp(-lambdaCoPLeft.x() * t);
+        AcopLeft(1, 2 * k + 1) = (1 - exp(-lambdaCoPLeft.y() * delta)) * exp(-lambdaCoPLeft.y() * t);
+        AcopRight(0, 2 * k) = (1 - exp(-lambdaCoPRight.x() * delta)) * exp(-lambdaCoPRight.x() * t);
+        AcopRight(1, 2 * k + 1) = (1 - exp(-lambdaCoPRight.y() * delta)) * exp(-lambdaCoPRight.y() * t);
       }
       t -= delta;
     }
 
     // zmp_i = (cop_l * f_z_l + cop_r * f_z_r)/f_z
-    Mcop.block(2 * i, 0, 2, 2 * nbReferences) = X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * Acop;
-    Mcop.block(2 * i, 2 * nbReferences, 2, 2 * nbReferences) = X_0_rc.inv().rotation().block(0, 0, 2, 2) * ratio * Acop;
+    Mcop.block(2 * i, 0, 2, 2 * nbReferences) = X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * AcopLeft;
+    Mcop.block(2 * i, 2 * nbReferences, 2, 2 * nbReferences) = X_0_rc.inv().rotation().block(0, 0, 2, 2) * ratio * AcopRight;
     bcop.segment(2 * i, 2) =
         zmp_ref[i] 
         - X_0_lc.translation().segment(0, 2) * (1 - ratio)
         - X_0_rc.translation().segment(0, 2) * (ratio)
-        - X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * exp_mat * measuredLeftCoP_delayed.segment(0, 2)
-        - X_0_rc.inv().rotation().block(0, 0, 2, 2) * (ratio) * exp_mat * measuredRightCoP_delayed.segment(0, 2);
+        - X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * exp_mat_left * measuredLeftCoP_delayed.segment(0, 2)
+        - X_0_rc.inv().rotation().block(0, 0, 2, 2) * (ratio) * exp_mat_right * measuredRightCoP_delayed.segment(0, 2);
 
     // McopReg.block(2 * i, 0, 2, 2 * nbReferences) = Acop;
     // McopReg.block(2 * (nbReferences + i), 2 * nbReferences, 2, 2 * nbReferences) = Acop;
@@ -1384,44 +1400,43 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
     // bcopReg.segment(2 * (i + nbReferences), 2) = -t_rankle_rc.segment(0, 2) - exp_mat *
     // measuredRightCoP_delayed.segment(0, 2);
 
-    McopReg.block(2 * i, 0, 2, 2 * nbReferences) = Acop;
-    McopReg.block(2 * nbReferences + 2 * i, 2 * nbReferences, 2, 2 * nbReferences) = Acop;
-    bcopReg.segment(2 * i, 2) = -t_lankle_lc.segment(0, 2) - exp_mat * measuredLeftCoP_delayed.segment(0, 2);
+    McopReg.block(2 * i, 0, 2, 2 * nbReferences) = AcopLeft;
+    McopReg.block(2 * nbReferences + 2 * i, 2 * nbReferences, 2, 2 * nbReferences) = AcopRight;
+    bcopReg.segment(2 * i, 2) = -t_lankle_lc.segment(0, 2) - exp_mat_left * measuredLeftCoP_delayed.segment(0, 2);
     bcopReg.segment(2 * (i + nbReferences), 2) =
-        -t_rankle_rc.segment(0, 2) - exp_mat * measuredRightCoP_delayed.segment(0, 2);
+        -t_rankle_rc.segment(0, 2) - exp_mat_left * measuredRightCoP_delayed.segment(0, 2);
 
     // CoP must remain bounded in polygon cstr
-    Aineq.block(4 * i, 0, 4, 2 * nbReferences) = normals * Acop;
+    Aineq.block(4 * i, 0, 4, 2 * nbReferences) = normals * AcopLeft;
+    Aineq.block(4 * ( i + nbReferences ), 2 * nbReferences, 4, 2 * nbReferences) = normals * AcopRight;
 
-    bineq.segment(4 * i, 4) = offsetLeft - normals * exp_mat * measuredLeftCoP_delayed.segment(0, 2);
-    bineq.segment(4 * (nbReferences + i), 4) = offsetRight - normals * exp_mat * measuredRightCoP_delayed.segment(0, 2);
+    bineq.segment(4 * i, 4) = offsetLeft - normals * exp_mat_left * measuredLeftCoP_delayed.segment(0, 2);
+    bineq.segment(4 * (nbReferences + i), 4) = offsetRight - normals * exp_mat_right * measuredRightCoP_delayed.segment(0, 2);
 
-    McopDiff.block(2 * i,0, 2, 2 * nbReferences ) = Acop;
-    McopDiff.block(2 * i, 2 * nbReferences, 2, 2 * nbReferences ) = -Acop;
-    bcopDiff.segment(2 * i , 2 ) = exp_mat * (measuredLeftCoP_delayed - measuredRightCoP_delayed).segment(0, 2);
+    McopDiff.block(2 * i,0, 2, 2 * nbReferences ) = AcopLeft;
+    McopDiff.block(2 * i, 2 * nbReferences, 2, 2 * nbReferences ) = -AcopRight;
+    bcopDiff.segment(2 * i , 2 ) = exp_mat_left * measuredLeftCoP_delayed.segment(0,2) - exp_mat_right * measuredRightCoP_delayed.segment(0, 2);
 
-    Eigen::Matrix2d lambda_mat = Eigen::Matrix2d::Identity();
-    lambda_mat.diagonal() *= c_.lambdaCoP.segment(0, 2);
-    McopVel.block(2 * i, 2 * i, 2, 2) = lambda_mat;
-    McopVel.block(2 * i, 0, 2, 2 * nbReferences) += -lambda_mat * Acop;
-    bcopVel.segment(2 * i, 2) = -lambda_mat * exp_mat * measuredLeftCoP_delayed.segment(0, 2);
-    bcopVel.segment(2 * (nbReferences + i), 2) = -lambda_mat * exp_mat * measuredRightCoP_delayed.segment(0, 2);
+
+    // Eigen::Matrix2d lambda_mat = Eigen::Matrix2d::Identity();
+    // lambda_mat.diagonal() *= c_.lambdaCoP.segment(0, 2);
+    // McopVel.block(2 * i, 2 * i, 2, 2) = lambda_mat;
+    // McopVel.block(2 * i, 0, 2, 2 * nbReferences) += -lambda_mat * Acop;
+    // bcopVel.segment(2 * i, 2) = -lambda_mat * exp_mat * measuredLeftCoP_delayed.segment(0, 2);
+    // bcopVel.segment(2 * (nbReferences + i), 2) = -lambda_mat * exp_mat * measuredRightCoP_delayed.segment(0, 2);
   }
 
-  Aineq.block(4 * nbReferences, 2 * nbReferences, 4 * nbReferences, 2 * nbReferences) =
-      Aineq.block(0, 0, 4 * nbReferences, 2 * nbReferences);
-
-  McopVel.block(2 * nbReferences, 2 * nbReferences, 2 * nbReferences, 2 * nbReferences) =
-      McopVel.block(0, 0, 2 * nbReferences, 2 * nbReferences);
+  // McopVel.block(2 * nbReferences, 2 * nbReferences, 2 * nbReferences, 2 * nbReferences) =
+  //     McopVel.block(0, 0, 2 * nbReferences, 2 * nbReferences);
 
   Eigen::MatrixXd Q = 1e2 * Mcop.transpose() * Mcop;
-  Q += 0e-8 * McopDiff.transpose() * McopDiff;
+  Q += 1e-8 * McopDiff.transpose() * McopDiff;
   Q += 1e-8 * McopReg.transpose() * McopReg;
-  Q += 0e-2 * McopVel.transpose() * McopVel;
+  // Q += 1e-2 * McopVel.transpose() * McopVel;
   Eigen::VectorXd c = 1e2 * (-Mcop.transpose() * bcop);
-  c += 0e-8 * (McopDiff.transpose() * bcopDiff);
-  c += 1e-8* (-McopReg.transpose() * bcopReg);
-  c += 0e-2 * McopVel.transpose() * bcopVel;
+  c += 1e-8 * (McopDiff.transpose() * bcopDiff);
+  c += 1e-8 * (-McopReg.transpose() * bcopReg);
+  // c += 1e-2 * McopVel.transpose() * bcopVel;
 
   qpSolver_.problem(nbVariables, 0, nbIneqCstr);
   Eigen::MatrixXd Aeq(0, 0);
@@ -1442,15 +1457,19 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
   //distribZMP_.segment(0,2) = (Mcop * x - bcop).segment(0,2) + zmp_ref[0] ;
 
   errQPzmp = (Mcop * x - bcop).segment(0,2);
-  Eigen::Matrix2d exp_mat;
-  exp_mat << exp(-c_.lambdaCoP.x() * (delta -  t_delay)), 0, 0,
-      exp(-c_.lambdaCoP.y() * (delta - t_delay));
+  Eigen::Matrix2d exp_mat_left;
+  exp_mat_left << exp(-lambdaCoPLeft.x() * (delta -  t_delay)), 0, 0,
+      exp(-lambdaCoPLeft.y() * (delta - t_delay));
+
+  Eigen::Matrix2d exp_mat_right;
+  exp_mat_right << exp(-lambdaCoPRight.x() * (delta -  t_delay)), 0, 0,
+      exp(-lambdaCoPRight.y() * (delta - t_delay));
 
   // leftCoP.y() = (0. - exp_mat(1,1) * measuredLeftCoP_delayed.y())/(1 - exp_mat(1,1)) ;
   // rightCoP.y() = (0. - exp_mat(1,1) * measuredRightCoP_delayed.y())/(1 - exp_mat(1,1)) ;
 
-  QPCoPLeft_ = exp_mat * measuredLeftCoP_delayed.segment(0, 2)  + (Eigen::Matrix2d::Identity() - exp_mat ) * leftCoP;
-  QPCoPRight_ = exp_mat * measuredRightCoP_delayed.segment(0, 2) + (Eigen::Matrix2d::Identity() - exp_mat ) * rightCoP;
+  QPCoPLeft_ = exp_mat_left * measuredLeftCoP_delayed.segment(0, 2)  + (Eigen::Matrix2d::Identity() - exp_mat_left ) * leftCoP;
+  QPCoPRight_ = exp_mat_right * measuredRightCoP_delayed.segment(0, 2) + (Eigen::Matrix2d::Identity() - exp_mat_right ) * rightCoP;
 
   distribCheck_ = (1-ratio0) * ( X_0_lc.translation().segment(0,2) + QPCoPLeft_) 
                   + ratio0 * ( X_0_rc.translation().segment(0,2) + QPCoPRight_) 
@@ -1468,20 +1487,30 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
 
   footTasks[ContactState::Left]->targetCoP(leftCoP);
   footTasks[ContactState::Left]->targetForce(w_l_lc.force());
+  sva::ForceVecd admittance = sva::ForceVecd::Zero();
+  double alpha = clamp(1 - (2*measuredFzLeft/fz_tot),0,1);
+  admittance.couple().segment(0,2) = c_.copAdmittance + alpha * c_.copSlope;
+  footTasks[ContactState::Left]->admittance(admittance);
+  
   footTasks[ContactState::Right]->targetCoP(rightCoP);
   footTasks[ContactState::Right]->targetForce(w_r_rc.force());
+  admittance = sva::ForceVecd::Zero();
+  alpha = clamp(1 - (2*measuredFzRight/fz_tot),0,1);
+  admittance.couple().segment(0,2) = c_.copAdmittance + alpha * c_.copSlope;
+  footTasks[ContactState::Right]->admittance(admittance);
+
   distribWrench_ = X_0_lc.inv().dualMul(w_l_lc) + X_0_rc.inv().dualMul(w_r_rc);
 
   if(c_.delayCoP != 0 && t_delay > 0)
   {
     modeledCoPLeft_.x() =
-        (delayedTargetCoPLeft_ + (modeledCoPLeft_ - delayedTargetCoPLeft_) * exp(-c_.lambdaCoP.x() * dt_)).x();
+        (delayedTargetCoPLeft_ + (modeledCoPLeft_ - delayedTargetCoPLeft_) * exp(-lambdaCoPLeft.x() * dt_)).x();
     modeledCoPLeft_.y() =
-        (delayedTargetCoPLeft_ + (modeledCoPLeft_ - delayedTargetCoPLeft_) * exp(-c_.lambdaCoP.y() * dt_)).y();
+        (delayedTargetCoPLeft_ + (modeledCoPLeft_ - delayedTargetCoPLeft_) * exp(-lambdaCoPLeft.y() * dt_)).y();
     modeledCoPRight_.x() =
-        (delayedTargetCoPRight_ + (modeledCoPRight_ - delayedTargetCoPRight_) * exp(-c_.lambdaCoP.x() * dt_)).x();
+        (delayedTargetCoPRight_ + (modeledCoPRight_ - delayedTargetCoPRight_) * exp(-lambdaCoPRight.x() * dt_)).x();
     modeledCoPRight_.y() =
-        (delayedTargetCoPRight_ + (modeledCoPRight_ - delayedTargetCoPRight_) * exp(-c_.lambdaCoP.y() * dt_)).y();
+        (delayedTargetCoPRight_ + (modeledCoPRight_ - delayedTargetCoPRight_) * exp(-lambdaCoPRight.y() * dt_)).y();
     modeledFzLeft_ = (delayedTargetFzLeft_ + (modeledFzLeft_ - delayedTargetFzLeft_) * exp(-c_.lambdaCoP.z() * dt_));
     modeledFzRight_ =
         (delayedTargetFzRight_ + (modeledFzRight_ - delayedTargetFzRight_) * exp(-c_.lambdaCoP.z() * dt_));
@@ -1490,19 +1519,19 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
   {
     modeledCoPLeft_.x() =
         (footTasks[ContactState::Left]->targetCoP()
-         + (modeledCoPLeft_ - footTasks[ContactState::Left]->targetCoP()) * exp(-c_.lambdaCoP.x() * dt_))
+         + (modeledCoPLeft_ - footTasks[ContactState::Left]->targetCoP()) * exp(-lambdaCoPLeft.x() * dt_))
             .x();
     modeledCoPLeft_.y() =
         (footTasks[ContactState::Left]->targetCoP()
-         + (modeledCoPLeft_ - footTasks[ContactState::Left]->targetCoP()) * exp(-c_.lambdaCoP.y() * dt_))
+         + (modeledCoPLeft_ - footTasks[ContactState::Left]->targetCoP()) * exp(-lambdaCoPLeft.y() * dt_))
             .y();
     modeledCoPRight_.x() =
         (footTasks[ContactState::Right]->targetCoP()
-         + (modeledCoPRight_ - footTasks[ContactState::Right]->targetCoP()) * exp(-c_.lambdaCoP.x() * dt_))
+         + (modeledCoPRight_ - footTasks[ContactState::Right]->targetCoP()) * exp(-lambdaCoPRight.x() * dt_))
             .x();
     modeledCoPRight_.y() =
         (footTasks[ContactState::Right]->targetCoP()
-         + (modeledCoPRight_ - footTasks[ContactState::Right]->targetCoP()) * exp(-c_.lambdaCoP.y() * dt_))
+         + (modeledCoPRight_ - footTasks[ContactState::Right]->targetCoP()) * exp(-lambdaCoPRight.y() * dt_))
             .y();
     modeledFzLeft_ =
         (footTasks[ContactState::Left]->targetWrench().force().z()

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -449,6 +449,7 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
     return Eigen::Vector2d::Zero();
   });
   logger.addLogEntry(name_ + "_admittance_cop", this, [this]() -> const Eigen::Vector2d & { return c_.copAdmittance; });
+  logger.addLogEntry(name_ + "_admittance_cop_QPerr", this, [this]() -> const Eigen::Vector2d & { return errQPzmp; });
   logger.addLogEntry(name_ + "_admittance_df", this, [this]() { return c_.dfAdmittance; });
   logger.addLogEntry(name_ + "_admittance_df_support_foot", this, [this]() { return c_.dfAdmittanceSupportFoot; });
   logger.addLogEntry(name_ + "_dcmDerivator_filtered", this, [this]() { return dcmDerivator_.eval(); });

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -100,14 +100,13 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
           "CoP constraints", [this]() { return c_.constrainCoP; }, [this]() { c_.constrainCoP = !c_.constrainCoP; }),
 
       ArrayInput(
-          "Foot CoP lambda", {"CoPx", "CoPy","f"},
+          "Foot CoP lambda", {"CoPx", "CoPy", "f"},
           [this]() -> Eigen::Vector3d {
-            return {c_.lambdaCoP.x(), c_.lambdaCoP.y(),c_.lambdaCoP.z()};
+            return {c_.lambdaCoP.x(), c_.lambdaCoP.y(), c_.lambdaCoP.z()};
           },
           [this](const Eigen::Vector3d & a) { c_.lambdaCoP = a; }),
       NumberInput(
-          "Admittance Delay", [this]() { return c_.delayCoP; },
-          [this](double d) { c_.delayCoP = d; }),
+          "Admittance Delay", [this]() { return c_.delayCoP; }, [this](double d) { c_.delayCoP = d; }),
       ArrayInput(
           "Max cop linear velocity [m/s]",
           [this]() -> const Eigen::Vector3d & { return footTasks.at(ContactState::Left)->maxLinearVel(); },

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -105,6 +105,9 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
             return {c_.lambdaCoP.x(), c_.lambdaCoP.y()};
           },
           [this](const Eigen::Vector2d & a) { c_.lambdaCoP = a; }),
+      NumberInput(
+          "Admittance Delay", [this]() { return c_.delayCoP; },
+          [this](double d) { c_.delayCoP = d; }),
       ArrayInput(
           "Max cop linear velocity [m/s]",
           [this]() -> const Eigen::Vector3d & { return footTasks.at(ContactState::Left)->maxLinearVel(); },

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -109,6 +109,18 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
             return {c_.lambdaCoP.x(), c_.lambdaCoP.y(), c_.lambdaCoP.z()};
           },
           [this](const Eigen::Vector3d & a) { c_.lambdaCoP = a; }),
+      ArrayInput(
+          "Foot CoP lambda support foot", {"CoPx", "CoPy"},
+          [this]() -> Eigen::Vector2d {
+            return {c_.lambdaCoPSupportFoot.x(), c_.lambdaCoPSupportFoot.y()};
+          },
+          [this](const Eigen::Vector2d & a) { c_.lambdaCoPSupportFoot = a; }),
+      ArrayInput(
+          "Foot CoP slope", {"CoPx", "CoPy"},
+          [this]() -> Eigen::Vector2d {
+            return {c_.copSlope.x(), c_.copSlope.y()};
+          },
+          [this](const Eigen::Vector2d & a) { c_.copSlope = a; }),
       NumberInput(
           "Admittance Delay", [this]() { return c_.delayCoP; }, [this](double d) { c_.delayCoP = d; }),
       ArrayInput(
@@ -500,7 +512,9 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
                      [this]() { return std::pow(c_.fdqpWeights.pressureSqrt, 2); });
   logger.addLogEntry(name_ + "_vdc_frequency", this, [this]() { return c_.vdcFrequency; });
   logger.addLogEntry(name_ + "_vdc_stiffness", this, [this]() { return c_.vdcStiffness; });
-  logger.addLogEntry(name_ + "_admittance_model_cop_lambda", this, [this]() { return c_.lambdaCoP; });
+  logger.addLogEntry(name_ + "_admittance_model_cop_lambda", this, [this]() -> const Eigen::Vector3d & { return c_.lambdaCoP; });
+  logger.addLogEntry(name_ + "_admittance_model_cop_lambda_supportFoot", this, [this]() -> const Eigen::Vector2d & { return c_.lambdaCoPSupportFoot; });
+  logger.addLogEntry(name_ + "_admittance_model_cop_slope", this, [this]() { return c_.copSlope; });
   logger.addLogEntry(name_ + "_admittance_model_cop_left", this, [this]() { return modeledCoPLeft_; });
   logger.addLogEntry(name_ + "_admittance_model_cop_right", this, [this]() { return modeledCoPRight_; });
   logger.addLogEntry(name_ + "_admittance_model_fz_left", this, [this]() { return modeledFzLeft_; });

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -449,6 +449,7 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
     return Eigen::Vector2d::Zero();
   });
   logger.addLogEntry(name_ + "_admittance_cop", this, [this]() -> const Eigen::Vector2d & { return c_.copAdmittance; });
+  logger.addLogEntry(name_ + "_admittance_cop_DistribError", this, [this]() -> const Eigen::Vector2d & { return distribCheck_; });
   logger.addLogEntry(name_ + "_admittance_cop_QPerr", this, [this]() -> const Eigen::Vector2d & { return errQPzmp; });
   logger.addLogEntry(name_ + "_admittance_cop_left_QP", this, [this]() -> const Eigen::Vector2d & { return QPCoPLeft_; });
   logger.addLogEntry(name_ + "_admittance_cop_right_QP", this, [this]() -> const Eigen::Vector2d & { return QPCoPRight_; });

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -450,6 +450,8 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   });
   logger.addLogEntry(name_ + "_admittance_cop", this, [this]() -> const Eigen::Vector2d & { return c_.copAdmittance; });
   logger.addLogEntry(name_ + "_admittance_cop_QPerr", this, [this]() -> const Eigen::Vector2d & { return errQPzmp; });
+  logger.addLogEntry(name_ + "_admittance_cop_left_QP", this, [this]() -> const Eigen::Vector2d & { return QPCoPLeft_; });
+  logger.addLogEntry(name_ + "_admittance_cop_right_QP", this, [this]() -> const Eigen::Vector2d & { return QPCoPRight_; });
   logger.addLogEntry(name_ + "_admittance_df", this, [this]() { return c_.dfAdmittance; });
   logger.addLogEntry(name_ + "_admittance_df_support_foot", this, [this]() { return c_.dfAdmittanceSupportFoot; });
   logger.addLogEntry(name_ + "_dcmDerivator_filtered", this, [this]() { return dcmDerivator_.eval(); });

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -486,6 +486,8 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   logger.addLogEntry(name_ + "_df_damping", this, [this]() { return c_.dfDamping; });
   logger.addLogEntry(name_ + "_forcesSum", this,
                      [this]() -> const Eigen::Vector3d & { return fSumFilter_.eval(); });
+  logger.addLogEntry(name_ + "_forcesSum_cutOffPeriod", this,
+                     [this]() -> const double { return c_.fSumFilter_T; });
   logger.addLogEntry(name_ + "_fdqp_weights_ankleTorque", this,
                      [this]() { return std::pow(c_.fdqpWeights.ankleTorqueSqrt, 2); });
   logger.addLogEntry(name_ + "_fdqp_weights_netWrench", this,

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -109,18 +109,6 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
             return {c_.lambdaCoP.x(), c_.lambdaCoP.y(), c_.lambdaCoP.z()};
           },
           [this](const Eigen::Vector3d & a) { c_.lambdaCoP = a; }),
-      ArrayInput(
-          "Foot CoP lambda support foot", {"CoPx", "CoPy"},
-          [this]() -> Eigen::Vector2d {
-            return {c_.lambdaCoPSupportFoot.x(), c_.lambdaCoPSupportFoot.y()};
-          },
-          [this](const Eigen::Vector2d & a) { c_.lambdaCoPSupportFoot = a; }),
-      ArrayInput(
-          "Foot CoP slope", {"CoPx", "CoPy"},
-          [this]() -> Eigen::Vector2d {
-            return {c_.copSlope.x(), c_.copSlope.y()};
-          },
-          [this](const Eigen::Vector2d & a) { c_.copSlope = a; }),
       NumberInput(
           "Admittance Delay", [this]() { return c_.delayCoP; }, [this](double d) { c_.delayCoP = d; }),
       ArrayInput(
@@ -512,9 +500,7 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
                      [this]() { return std::pow(c_.fdqpWeights.pressureSqrt, 2); });
   logger.addLogEntry(name_ + "_vdc_frequency", this, [this]() { return c_.vdcFrequency; });
   logger.addLogEntry(name_ + "_vdc_stiffness", this, [this]() { return c_.vdcStiffness; });
-  logger.addLogEntry(name_ + "_admittance_model_cop_lambda", this, [this]() -> const Eigen::Vector3d & { return c_.lambdaCoP; });
-  logger.addLogEntry(name_ + "_admittance_model_cop_lambda_supportFoot", this, [this]() -> const Eigen::Vector2d & { return c_.lambdaCoPSupportFoot; });
-  logger.addLogEntry(name_ + "_admittance_model_cop_slope", this, [this]() { return c_.copSlope; });
+  logger.addLogEntry(name_ + "_admittance_model_cop_lambda", this, [this]() { return c_.lambdaCoP; });
   logger.addLogEntry(name_ + "_admittance_model_cop_left", this, [this]() { return modeledCoPLeft_; });
   logger.addLogEntry(name_ + "_admittance_model_cop_right", this, [this]() { return modeledCoPRight_; });
   logger.addLogEntry(name_ + "_admittance_model_fz_left", this, [this]() { return modeledFzLeft_; });

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -98,6 +98,13 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
           }),
       Checkbox(
           "CoP constraints", [this]() { return c_.constrainCoP; }, [this]() { c_.constrainCoP = !c_.constrainCoP; }),
+          
+      ArrayInput(
+          "Foot CoP lambda", {"CoPx", "CoPy"},
+          [this]() -> Eigen::Vector2d {
+            return {c_.lambdaCoP.x(), c_.lambdaCoP.y()};
+          },
+          [this](const Eigen::Vector2d & a) { c_.lambdaCoP = a; }),
       ArrayInput(
           "Max cop linear velocity [m/s]",
           [this]() -> const Eigen::Vector3d & { return footTasks.at(ContactState::Left)->maxLinearVel(); },
@@ -442,6 +449,9 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
                      [this]() { return std::pow(c_.fdqpWeights.pressureSqrt, 2); });
   logger.addLogEntry(name_ + "_vdc_frequency", this, [this]() { return c_.vdcFrequency; });
   logger.addLogEntry(name_ + "_vdc_stiffness", this, [this]() { return c_.vdcStiffness; });
+  logger.addLogEntry(name_ + "_model_cop_lambda", this, [this]() { return c_.lambdaCoP; });
+  logger.addLogEntry(name_ + "_model_cop_left", this, [this]() { return modeledCoPLeft_; });
+  logger.addLogEntry(name_ + "_model_cop_right", this, [this]() { return modeledCoPRight_; });
   MC_RTC_LOG_HELPER(name_ + "_desired_wrench", desiredWrench_);
   MC_RTC_LOG_HELPER(name_ + "_wrench", distribWrench_);
   MC_RTC_LOG_HELPER(name_ + "_support_min", supportMin_);
@@ -457,6 +467,8 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   MC_RTC_LOG_HELPER(name_ + "_target_pendulum_zmp", zmpTarget_);
   MC_RTC_LOG_HELPER(name_ + "_target_pendulum_zmpd", zmpdTarget_);
   MC_RTC_LOG_HELPER(name_ + "_target_stabilizer_zmp", distribZMP_);
+
+
 
   logger.addLogEntry(name_ + "_contactState", this, [this]() -> int {
     if(inDoubleSupport())

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -98,7 +98,7 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
           }),
       Checkbox(
           "CoP constraints", [this]() { return c_.constrainCoP; }, [this]() { c_.constrainCoP = !c_.constrainCoP; }),
-          
+
       ArrayInput(
           "Foot CoP lambda", {"CoPx", "CoPy"},
           [this]() -> Eigen::Vector2d {
@@ -467,8 +467,6 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   MC_RTC_LOG_HELPER(name_ + "_target_pendulum_zmp", zmpTarget_);
   MC_RTC_LOG_HELPER(name_ + "_target_pendulum_zmpd", zmpdTarget_);
   MC_RTC_LOG_HELPER(name_ + "_target_stabilizer_zmp", distribZMP_);
-
-
 
   logger.addLogEntry(name_ + "_contactState", this, [this]() -> int {
     if(inDoubleSupport())

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -102,9 +102,9 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
       ArrayInput(
           "Foot CoP lambda", {"CoPx", "CoPy", "f"},
           [this]() -> Eigen::Vector3d {
-            return {c_.lambda_CoP_Fz.x(), c_.lambda_CoP_Fz.y(), c_.lambda_CoP_Fz.z()};
+            return {c_.copFzLambda.x(), c_.copFzLambda.y(), c_.copFzLambda.z()};
           },
-          [this](const Eigen::Vector3d & a) { c_.lambda_CoP_Fz = a; }),
+          [this](const Eigen::Vector3d & a) { c_.copFzLambda = a; }),
       NumberInput(
           "Admittance Delay", [this]() { return c_.delayCoP; }, [this](double d) { c_.delayCoP = d; }),
       ArrayInput(
@@ -482,7 +482,8 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
                      [this]() -> const double & { return zmpCoefMeasured_; });
   logger.addLogEntry(name_ + "_df_damping", this, [this]() { return c_.dfDamping; });
   logger.addLogEntry(name_ + "_forcesSum", this, [this]() -> const Eigen::Vector3d & { return fSumFilter_.eval(); });
-  logger.addLogEntry(name_ + "_forcesSum_cutOffPeriod", this, [this]() -> const double { return c_.fSumFilter_T; });
+  logger.addLogEntry(name_ + "_forcesSum_cutOffPeriod", this,
+                     [this]() -> const double { return c_.fSumFilterTimeConstant; });
   logger.addLogEntry(name_ + "_fdqp_weights_ankleTorque", this,
                      [this]() { return std::pow(c_.fdqpWeights.ankleTorqueSqrt, 2); });
   logger.addLogEntry(name_ + "_fdqp_weights_netWrench", this,
@@ -492,15 +493,18 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   logger.addLogEntry(name_ + "_vdc_frequency", this, [this]() { return c_.vdcFrequency; });
   logger.addLogEntry(name_ + "_vdc_stiffness", this, [this]() { return c_.vdcStiffness; });
   logger.addLogEntry(name_ + "_fdmpc_model_cop_lambda", this,
-                     [this]() -> Eigen::Vector2d { return c_.lambda_CoP_Fz.segment(0, 2); });
+                     [this]() -> Eigen::Vector2d { return c_.copFzLambda.segment(0, 2); });
   logger.addLogEntry(name_ + "_fdmpc_model_cop_left", this, [this]() { return modeledCoPLeft_; });
   logger.addLogEntry(name_ + "_fdmpc_model_cop_right", this, [this]() { return modeledCoPRight_; });
-  logger.addLogEntry(name_ + "_fdmpc_model_fz_lambda", this, [this]() -> double { return c_.lambda_CoP_Fz.z(); });
+  logger.addLogEntry(name_ + "_fdmpc_model_fz_lambda", this, [this]() -> double { return c_.copFzLambda.z(); });
   logger.addLogEntry(name_ + "_fdmpc_model_fz_left", this, [this]() { return modeledFzLeft_; });
   logger.addLogEntry(name_ + "_fdmpc_model_fz_right", this, [this]() { return modeledFzRight_; });
   logger.addLogEntry(name_ + "_fdmpc_desired_fz_left", this, [this]() { return desiredFzLeft_; });
   logger.addLogEntry(name_ + "_fdmpc_desired_fz_right", this, [this]() { return desiredFzRight_; });
   logger.addLogEntry(name_ + "_fdmpc_model_delay", this, [this]() { return c_.delayCoP; });
+  logger.addLogEntry(name_ + "_fdmpc_weights_cop", this, [this]() { return c_.fdmpcWeights.cop_; });
+  logger.addLogEntry(name_ + "_fdmpc_weights_copDiff", this, [this]() { return c_.fdmpcWeights.copDiff_; });
+  logger.addLogEntry(name_ + "_fdmpc_weights_copReg", this, [this]() { return c_.fdmpcWeights.copRegulation_; });
   MC_RTC_LOG_HELPER(name_ + "_desired_wrench", desiredWrench_);
   MC_RTC_LOG_HELPER(name_ + "_wrench", distribWrench_);
   MC_RTC_LOG_HELPER(name_ + "_support_min", supportMin_);

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -56,6 +56,10 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
           [this]() -> Eigen::Vector3d { return c_.dfAdmittance; },
           [this](const Eigen::Vector3d & a) { dfAdmittance(a); }),
       ArrayInput(
+          "Foot force difference Admittance Support Foot", {"Fx", "Fy", "Fz"},
+          [this]() -> Eigen::Vector3d { return c_.dfAdmittanceSupportFoot; },
+          [this](const Eigen::Vector3d & a) { dfAdmittanceSupportFoot(a); }),
+      ArrayInput(
           "DCM P gains", {"x", "y"}, [this]() -> const Eigen::Vector2d & { return c_.dcmPropGain; },
           [this](const Eigen::Vector2d & gains) { dcmGains(gains, c_.dcmIntegralGain, c_.dcmDerivGain); }),
       ArrayInput(
@@ -446,6 +450,7 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   });
   logger.addLogEntry(name_ + "_admittance_cop", this, [this]() -> const Eigen::Vector2d & { return c_.copAdmittance; });
   logger.addLogEntry(name_ + "_admittance_df", this, [this]() { return c_.dfAdmittance; });
+  logger.addLogEntry(name_ + "_admittance_df_support_foot", this, [this]() { return c_.dfAdmittanceSupportFoot; });
   logger.addLogEntry(name_ + "_dcmDerivator_filtered", this, [this]() { return dcmDerivator_.eval(); });
   logger.addLogEntry(name_ + "_dcmDerivator_input_lp", this, [this]() { return dcmDerivator_.input_lp(); });
   logger.addLogEntry(name_ + "_dcmDerivator_input_hp", this, [this]() { return dcmDerivator_.input_hp(); });
@@ -479,6 +484,8 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   logger.addLogEntry(name_ + "_extWrench_ZMPCoefMeasured", this,
                      [this]() -> const double & { return zmpCoefMeasured_; });
   logger.addLogEntry(name_ + "_df_damping", this, [this]() { return c_.dfDamping; });
+  logger.addLogEntry(name_ + "_forcesSum", this,
+                     [this]() -> const Eigen::Vector3d & { return fSumFilter_.eval(); });
   logger.addLogEntry(name_ + "_fdqp_weights_ankleTorque", this,
                      [this]() { return std::pow(c_.fdqpWeights.ankleTorqueSqrt, 2); });
   logger.addLogEntry(name_ + "_fdqp_weights_netWrench", this,

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -56,10 +56,6 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
           [this]() -> Eigen::Vector3d { return c_.dfAdmittance; },
           [this](const Eigen::Vector3d & a) { dfAdmittance(a); }),
       ArrayInput(
-          "Foot force difference Admittance Support Foot", {"Fx", "Fy", "Fz"},
-          [this]() -> Eigen::Vector3d { return c_.dfAdmittanceSupportFoot; },
-          [this](const Eigen::Vector3d & a) { dfAdmittanceSupportFoot(a); }),
-      ArrayInput(
           "DCM P gains", {"x", "y"}, [this]() -> const Eigen::Vector2d & { return c_.dcmPropGain; },
           [this](const Eigen::Vector2d & gains) { dcmGains(gains, c_.dcmIntegralGain, c_.dcmDerivGain); }),
       ArrayInput(
@@ -454,7 +450,6 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   logger.addLogEntry(name_ + "_admittance_cop_left_QP", this, [this]() -> const Eigen::Vector2d & { return QPCoPLeft_; });
   logger.addLogEntry(name_ + "_admittance_cop_right_QP", this, [this]() -> const Eigen::Vector2d & { return QPCoPRight_; });
   logger.addLogEntry(name_ + "_admittance_df", this, [this]() { return c_.dfAdmittance; });
-  logger.addLogEntry(name_ + "_admittance_df_support_foot", this, [this]() { return c_.dfAdmittanceSupportFoot; });
   logger.addLogEntry(name_ + "_dcmDerivator_filtered", this, [this]() { return dcmDerivator_.eval(); });
   logger.addLogEntry(name_ + "_dcmDerivator_input_lp", this, [this]() { return dcmDerivator_.input_lp(); });
   logger.addLogEntry(name_ + "_dcmDerivator_input_hp", this, [this]() { return dcmDerivator_.input_hp(); });

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -100,11 +100,11 @@ void StabilizerTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
           "CoP constraints", [this]() { return c_.constrainCoP; }, [this]() { c_.constrainCoP = !c_.constrainCoP; }),
 
       ArrayInput(
-          "Foot CoP lambda", {"CoPx", "CoPy"},
-          [this]() -> Eigen::Vector2d {
-            return {c_.lambdaCoP.x(), c_.lambdaCoP.y()};
+          "Foot CoP lambda", {"CoPx", "CoPy","f"},
+          [this]() -> Eigen::Vector3d {
+            return {c_.lambdaCoP.x(), c_.lambdaCoP.y(),c_.lambdaCoP.z()};
           },
-          [this](const Eigen::Vector2d & a) { c_.lambdaCoP = a; }),
+          [this](const Eigen::Vector3d & a) { c_.lambdaCoP = a; }),
       NumberInput(
           "Admittance Delay", [this]() { return c_.delayCoP; },
           [this](double d) { c_.delayCoP = d; }),
@@ -452,9 +452,14 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
                      [this]() { return std::pow(c_.fdqpWeights.pressureSqrt, 2); });
   logger.addLogEntry(name_ + "_vdc_frequency", this, [this]() { return c_.vdcFrequency; });
   logger.addLogEntry(name_ + "_vdc_stiffness", this, [this]() { return c_.vdcStiffness; });
-  logger.addLogEntry(name_ + "_model_cop_lambda", this, [this]() { return c_.lambdaCoP; });
-  logger.addLogEntry(name_ + "_model_cop_left", this, [this]() { return modeledCoPLeft_; });
-  logger.addLogEntry(name_ + "_model_cop_right", this, [this]() { return modeledCoPRight_; });
+  logger.addLogEntry(name_ + "_admittance_model_cop_lambda", this, [this]() { return c_.lambdaCoP; });
+  logger.addLogEntry(name_ + "_admittance_model_cop_left", this, [this]() { return modeledCoPLeft_; });
+  logger.addLogEntry(name_ + "_admittance_model_cop_right", this, [this]() { return modeledCoPRight_; });
+  logger.addLogEntry(name_ + "_admittance_model_fz_left", this, [this]() { return modeledFzLeft_; });
+  logger.addLogEntry(name_ + "_admittance_model_fz_right", this, [this]() { return modeledFzRight_; });
+  logger.addLogEntry(name_ + "_admittance_desired_fz_left", this, [this]() { return desiredFzLeft_; });
+  logger.addLogEntry(name_ + "_admittance_desired_fz_right", this, [this]() { return desiredFzRight_; });
+  logger.addLogEntry(name_ + "_admittance_model_delay", this, [this]() { return c_.delayCoP; });
   MC_RTC_LOG_HELPER(name_ + "_desired_wrench", desiredWrench_);
   MC_RTC_LOG_HELPER(name_ + "_wrench", distribWrench_);
   MC_RTC_LOG_HELPER(name_ + "_support_min", supportMin_);

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
@@ -408,6 +408,42 @@ void StabilizerTask::addToLogger(mc_rtc::Logger & logger)
   MC_RTC_LOG_HELPER(name_ + "_error_df_force", dfForceError_);
   MC_RTC_LOG_HELPER(name_ + "_error_df_eval", dfError_);
   MC_RTC_LOG_HELPER(name_ + "_error_vdc", vdcHeightError_);
+  logger.addLogEntry(name_ + "_support_left_max", this, [this]() -> Eigen::Vector2d
+  {   
+    if(inContact(ContactState::Left))
+    {
+        const auto & contact = contacts_.at(ContactState::Left);
+        return Eigen::Vector2d{contact.halfLength(),contact.halfWidth()}; 
+    }
+    return Eigen::Vector2d::Zero();
+  });
+  logger.addLogEntry(name_ + "_support_left_min", this, [this]() -> Eigen::Vector2d
+  { 
+    if(inContact(ContactState::Left))
+    {
+        const auto & contact = contacts_.at(ContactState::Left);
+        return Eigen::Vector2d{-contact.halfLength(),-contact.halfWidth()}; 
+    }
+    return Eigen::Vector2d::Zero();
+  });
+  logger.addLogEntry(name_ + "_support_right_max", this, [this]() -> Eigen::Vector2d  
+  {   
+    if(inContact(ContactState::Right))
+    {
+        const auto & contact = contacts_.at(ContactState::Right);
+        return Eigen::Vector2d{contact.halfLength(),contact.halfWidth()}; 
+    }
+    return Eigen::Vector2d::Zero();
+  });
+  logger.addLogEntry(name_ + "_support_right_min", this, [this]() -> Eigen::Vector2d 
+  {   
+    if(inContact(ContactState::Right))
+    {
+        const auto & contact = contacts_.at(ContactState::Right);
+        return Eigen::Vector2d{-contact.halfLength(),-contact.halfWidth()}; 
+    }
+    return Eigen::Vector2d::Zero();
+  });
   logger.addLogEntry(name_ + "_admittance_cop", this, [this]() -> const Eigen::Vector2d & { return c_.copAdmittance; });
   logger.addLogEntry(name_ + "_admittance_df", this, [this]() { return c_.dfAdmittance; });
   logger.addLogEntry(name_ + "_dcmDerivator_filtered", this, [this]() { return dcmDerivator_.eval(); });


### PR DESCRIPTION
This PR adds a new method to distribute the force during a double support phase.

It uses a set of reference ZMP in a defined horizon.

The CoP are then modelled as a 1st order w.r.t the generated reference with parameters lambda and delay w.r.t the previous reference.
The distribution computes the reference CoP to send to the admittances tasks in order to obtain the desired ZMP.

This method does not rely on the classic DCM feedback scheme and is supposed to be used in a case where the centroidal dynamic is already computed.
The previous use of the lipm_stabilizer remains.

This has been tested using the ismpc controller with HRP-2KAI and HRP-4CR real robots.

It also added other accessor on the stabilizer state.