### PR TITLE
Fix issue with using multiple PythonState instances in a row

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,8 @@ repos:
           src/mc_control/samples/Door/etc/DoorSample.in.yaml|
           src/mc_control/samples/ExternalForces/etc/ExternalForces.in.yaml|
           src/mc_control/samples/LIPMStabilizer/etc/LIPMStabilizer.in.yaml|
-          src/mc_control/fsm/states/data/StabilizerStanding.yaml
+          src/mc_control/fsm/states/data/StabilizerStanding.yaml|
+          tests/controllers/TestPythonState.in.yaml
       )$
   - id: debug-statements
   - id: destroyed-symlinks

--- a/src/mc_control/fsm/states/CMakeLists.txt
+++ b/src/mc_control/fsm/states/CMakeLists.txt
@@ -73,7 +73,18 @@ if(${PYTHON_BINDING})
     add_library(${PYTHON_NAME}State SHARED "${SRC}")
     set_target_properties(${PYTHON_NAME}State PROPERTIES PREFIX "")
     set_target_properties(${PYTHON_NAME}State PROPERTIES FOLDER controllers/fsm/states)
-    target_link_libraries(${PYTHON_NAME}State PUBLIC mc_control_fsm_${PYTHON_NAME})
+    target_link_libraries(${PYTHON_NAME}State PRIVATE ${PYTHON_NAME}::Python)
+    target_include_directories(${PYTHON_NAME}State PRIVATE "${PROJECT_SOURCE_DIR}/src")
+    target_include_directories(
+      ${PYTHON_NAME}State
+      PRIVATE
+        $<TARGET_PROPERTY:mc_control_fsm_${PYTHON_NAME},INTERFACE_INCLUDE_DIRECTORIES>
+    )
+    target_compile_definitions(
+      ${PYTHON_NAME}State
+      PRIVATE
+        $<TARGET_PROPERTY:mc_control_fsm_${PYTHON_NAME},INTERFACE_COMPILE_DEFINITIONS>
+    )
     install(
       TARGETS ${PYTHON_NAME}State
       ARCHIVE

--- a/src/mc_control/fsm/states/CMakeLists.txt
+++ b/src/mc_control/fsm/states/CMakeLists.txt
@@ -73,8 +73,13 @@ if(${PYTHON_BINDING})
     add_library(${PYTHON_NAME}State SHARED "${SRC}")
     set_target_properties(${PYTHON_NAME}State PROPERTIES PREFIX "")
     set_target_properties(${PYTHON_NAME}State PROPERTIES FOLDER controllers/fsm/states)
-    target_link_libraries(${PYTHON_NAME}State PRIVATE ${PYTHON_NAME}::Python)
+    target_link_libraries(
+      ${PYTHON_NAME}State PRIVATE ${PYTHON_NAME}::Python mc_control_fsm
+    )
     target_include_directories(${PYTHON_NAME}State PRIVATE "${PROJECT_SOURCE_DIR}/src")
+    add_dependencies(
+      ${PYTHON_NAME}State mc_control_${PYTHON_NAME} mc_rbdyn_${PYTHON_NAME}
+    )
     target_include_directories(
       ${PYTHON_NAME}State
       PRIVATE

--- a/src/mc_control/fsm/states/PythonState.cpp
+++ b/src/mc_control/fsm/states/PythonState.cpp
@@ -4,13 +4,7 @@
 
 #include <mc_control/fsm/PythonState.h>
 
-#pragma GCC diagnostic push
-#ifdef __clang__
-#  pragma GCC diagnostic ignored "-Wdeprecated-register"
-#endif
-#pragma GCC diagnostic ignored "-Wregister"
-#include "Python.h"
-#pragma GCC diagnostic pop
+#include <mc_rtc/python.h>
 
 #include "mc_control/fsm/fsm.h"
 
@@ -27,11 +21,7 @@ extern "C"
   FSM_STATE_API void destroy(mc_control::fsm::State * ptr)
   {
     delete ptr;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-    auto gstate = PyGILState_Ensure();
-#pragma GCC diagnostic pop
-    Py_Finalize();
+    mc_rtc::python::Finalize();
   }
 
   FSM_STATE_API void LOAD_GLOBAL() {}
@@ -40,11 +30,7 @@ extern "C"
   {
     mc_rtc::log::info("[PythonState] Running with Python {}.{}.{}", PY_MAJOR_VERSION, PY_MINOR_VERSION,
                       PY_MICRO_VERSION);
-    if(!Py_IsInitialized())
-    {
-      Py_Initialize();
-      PyEval_SaveThread();
-    }
+    mc_rtc::python::Initialize();
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
     auto gstate = PyGILState_Ensure();

--- a/src/mc_control/python/CMakeLists.txt
+++ b/src/mc_control/python/CMakeLists.txt
@@ -25,6 +25,7 @@ foreach(PYTHON_NAME ${PYTHON_BINDING_VERSIONS})
   )
   target_include_directories(
     ${PYTHON_NAME_LOWER}_controller PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}"
+                                            "${PROJECT_SOURCE_DIR}/src/"
   )
   target_link_libraries(${PYTHON_NAME_LOWER}_controller PRIVATE ${PYTHON_NAME}::Python)
 endforeach()

--- a/src/mc_control/python/python_controller.cpp
+++ b/src/mc_control/python/python_controller.cpp
@@ -4,13 +4,7 @@
 
 #include "python_controller.h"
 
-#pragma GCC diagnostic push
-#ifdef __clang__
-#  pragma GCC diagnostic ignored "-Wdeprecated-register"
-#endif
-#pragma GCC diagnostic ignored "-Wregister"
-#include <Python.h>
-#pragma GCC diagnostic pop
+#include <mc_rtc/python.h>
 
 #include <mc_control/mc_python_controller.h>
 
@@ -28,11 +22,7 @@ extern "C"
     // The Python object should be garbage collected, so we only take care of
     // the C++ memory we allocated
     delete ptr;
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-variable"
-    auto gstate = PyGILState_Ensure();
-#pragma GCC diagnostic pop
-    Py_Finalize();
+    mc_rtc::python::Finalize();
   }
   mc_control::MCController * create(const std::string &,
                                     const std::string & controller_name,
@@ -42,11 +32,7 @@ extern "C"
   {
     mc_rtc::log::info("[PythonController] Running with Python {}.{}.{}", PY_MAJOR_VERSION, PY_MINOR_VERSION,
                       PY_MICRO_VERSION);
-    if(!Py_IsInitialized())
-    {
-      Py_Initialize();
-      PyEval_SaveThread();
-    }
+    mc_rtc::python::Initialize();
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
     auto gstate = PyGILState_Ensure();

--- a/src/mc_rtc/python.h
+++ b/src/mc_rtc/python.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2023 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+/** Safely initialize and finalize the Python interpreter multiple times */
+
+#pragma GCC diagnostic push
+#ifdef __clang__
+#  pragma GCC diagnostic ignored "-Wdeprecated-register"
+#endif
+#pragma GCC diagnostic ignored "-Wregister"
+#include "Python.h"
+#pragma GCC diagnostic pop
+
+namespace mc_rtc::python
+{
+
+inline static int PYTHON_INIT_COUNT = 0;
+
+inline static void Initialize()
+{
+  if(!Py_IsInitialized())
+  {
+    PYTHON_INIT_COUNT = 1;
+    Py_Initialize();
+    PyEval_SaveThread();
+  }
+  else { PYTHON_INIT_COUNT += 1; }
+}
+
+inline static void Finalize()
+{
+  PYTHON_INIT_COUNT -= 1;
+  if(PYTHON_INIT_COUNT <= 0)
+  {
+    PYTHON_INIT_COUNT = 0;
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-variable"
+    auto gstate = PyGILState_Ensure();
+#pragma GCC diagnostic pop
+    Py_Finalize();
+  }
+}
+
+} // namespace mc_rtc::python

--- a/tests/controllers/CMakeLists.txt
+++ b/tests/controllers/CMakeLists.txt
@@ -602,12 +602,29 @@ endif()
 add_global_controller_test_run(
   TestPluginController ${CONFIG_OUT} 5 TestPluginController_2_3
 )
+set(TEST_PLUGINS "")
+set(PLUGINS_MODULE_PATH "")
 
 # Test Python bindings
 if(PYTHON_BINDING AND NOT APPLE)
   file(READ "ObserverPipelinesPython.json" OBSERVER_PIPELINES)
   set(LOG_ENABLED "true")
   get_python_names(python_names)
+  add_library(TestPythonState SHARED TestPythonState.cpp)
+  target_link_libraries(
+    TestPythonState PUBLIC mc_control_fsm Boost::unit_test_framework
+  )
+  if(NOT Boost_USE_STATIC_LIBS)
+    target_link_libraries(TestPythonState PUBLIC Boost::dynamic_linking)
+  endif()
+  set_target_properties(
+    TestPythonState
+    PROPERTIES COMPILE_FLAGS "-DMC_CONTROL_EXPORTS"
+               PREFIX ""
+               ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/TestPythonState
+               LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/TestPythonState
+               RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/TestPythonState
+  )
   foreach(PYTHON ${python_names})
     set(TEST_CONTROLLER_NAME "${PYTHON}#test_python.TestPythonController")
     set(PYTHON_CONTROLLER_PATH "${CMAKE_BINARY_DIR}/src/mc_control/python")
@@ -674,6 +691,59 @@ if(PYTHON_BINDING AND NOT APPLE)
       )
       setup_test_log_fixture(Test${PYTHON}Controller Test${PYTHON}Log)
     endif()
+    macro(setup_test_python_state VARIANT)
+      set(TEST_CONTROLLER_NAME TestPythonState${VARIANT})
+      # This is not a path with library but we use this to output the controller
+      # configuration
+      set(PYTHON_CONTROLLER_PATH
+          "${CMAKE_CURRENT_BINARY_DIR}/${TEST_CONTROLLER_NAME}/${PYTHON}/$<CONFIG>"
+      )
+      set(TEST_CONTROLLER_PATH "$<TARGET_FILE_DIR:TestPythonState>")
+      set(CTL_CFG_OUT
+          "${CMAKE_CURRENT_BINARY_DIR}/${TEST_CONTROLLER_NAME}/${PYTHON}/${TEST_CONTROLLER_NAME}.cmake.yaml"
+      )
+      set(CONFIG_OUT
+          "${CMAKE_CURRENT_BINARY_DIR}/${TEST_CONTROLLER_NAME}/${PYTHON}/mc_rtc.cmake.conf"
+      )
+      set(NRITER 5)
+      configure_file(TestPythonState.in.yaml "${CTL_CFG_OUT}")
+      configure_file(mc_rtc.conf.in "${CONFIG_OUT}")
+      set(CTL_CFG_IN "${CTL_CFG_OUT}")
+      string(REPLACE "${TEST_CONTROLLER_NAME}.cmake.yaml"
+                     "$<CONFIG>/etc/${TEST_CONTROLLER_NAME}.yaml" CTL_CFG_OUT
+                     "${CTL_CFG_OUT}"
+      )
+      file(
+        GENERATE
+        OUTPUT "${CTL_CFG_OUT}"
+        INPUT "${CTL_CFG_IN}"
+      )
+      set(CONFIG_IN "${CONFIG_OUT}")
+      string(REPLACE "mc_rtc.cmake.conf" "$<CONFIG>/mc_rtc.conf" CONFIG_OUT
+                     "${CONFIG_OUT}"
+      )
+      file(
+        GENERATE
+        OUTPUT "${CONFIG_OUT}"
+        INPUT "${CONFIG_IN}"
+      )
+      add_global_controller_test_run(
+        Test${PYTHON}State${VARIANT}
+        ${CONFIG_OUT}
+        ${NRITER}
+        ""
+        ${CMAKE_COMMAND}
+        -E
+        env
+        "PYTHONPATH=${PYTHONPATH}${PATH_SEP}$ENV{PYTHONPATH}"
+        ${CMAKE_COMMAND}
+        -E
+        env
+        "${LDPATH_VAR}=${LDPATH}${PATH_SEP}${LDPATH_CONTROL}${PATH_SEP}$ENV{${LDPATH_VAR}}"
+      )
+    endmacro()
+    setup_test_python_state("")
+    setup_test_python_state("_TVM")
   endforeach()
   unset(OBSERVER_PIPELINES)
 endif()

--- a/tests/controllers/TestPythonState.cpp
+++ b/tests/controllers/TestPythonState.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2015-2023 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#ifdef BOOST_TEST_MAIN
+#  undef BOOST_TEST_MAIN
+#endif
+
+#include <mc_control/fsm/Controller.h>
+
+#include <mc_control/mc_controller.h>
+
+#include <mc_rtc/logging.h>
+
+#include <boost/test/unit_test.hpp>
+
+namespace mc_control
+{
+
+struct MC_CONTROL_DLLAPI TestPythonStateController : public fsm::Controller
+{
+public:
+  TestPythonStateController(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & conf, Backend backend)
+  : fsm::Controller(rm, dt, conf, backend)
+  {
+    // Check that the default constructor loads the robot + ground environment
+    BOOST_CHECK_EQUAL(robots().size(), 2);
+    // Check that JVRC-1 was loaded
+    BOOST_CHECK_EQUAL(robot().name(), "jvrc1");
+    BOOST_REQUIRE(hasRobot("ground"));
+    mc_rtc::log::success("Created TestPythonStateController");
+  }
+
+  bool run() override
+  {
+    bool ret = fsm::Controller::run();
+    BOOST_REQUIRE(ret);
+    if(iter_ == 0) { BOOST_REQUIRE(executor_.state() == "TestInitial"); }
+    else if(iter_ == 1)
+    {
+      BOOST_REQUIRE(executor_.next_state() == "TestFinal");
+      BOOST_REQUIRE(executor_.output() == "Value=42");
+      executor_.next();
+    }
+    else
+    {
+      BOOST_REQUIRE(executor_.state() == "TestFinal");
+      if(iter_ > 2)
+      {
+        BOOST_REQUIRE(executor_.complete());
+        BOOST_REQUIRE(executor_.output() == "Value=100");
+      }
+    }
+    iter_++;
+    return ret;
+  }
+
+  void reset(const ControllerResetData & reset_data) override
+  {
+    fsm::Controller::reset(reset_data);
+    BOOST_REQUIRE(hasContact("LeftFoot"));
+    BOOST_REQUIRE(hasContact("RightFoot"));
+  }
+
+  using fsm::Controller::hasContact;
+
+  const fsm::Contact & contact(const fsm::Contact & c)
+  {
+    assert(hasContact(c));
+    return *contacts().find(c);
+  }
+
+  bool hasContact(const std::string & s,
+                  double friction = mc_rbdyn::Contact::defaultFriction,
+                  const Eigen::Vector6d & dof = Eigen::Vector6d::Ones())
+  {
+    fsm::Contact c("jvrc1", "ground", s, "AllGround", friction, dof);
+    if(!hasContact(c)) { return false; }
+    const auto & ref = contact(c);
+    return ref.friction == c.friction && ref.dof == c.dof;
+  }
+
+private:
+  unsigned int iter_ = 0;
+};
+
+} // namespace mc_control
+
+using Controller = mc_control::TestPythonStateController;
+using Backend = mc_control::MCController::Backend;
+MULTI_CONTROLLERS_CONSTRUCTOR("TestPythonState",
+                              Controller(rm, dt, config, Backend::Tasks),
+                              "TestPythonState_TVM",
+                              Controller(rm, dt, config, Backend::TVM))

--- a/tests/controllers/TestPythonState.in.yaml
+++ b/tests/controllers/TestPythonState.in.yaml
@@ -1,0 +1,31 @@
+StatesLibraries: ["@FSM_STATES_INSTALL_PREFIX@"]
+StepByStep: false
+Managed: false
+IdleKeepState: true
+robots:
+  ground:
+    module: env/ground
+constraints:
+  - type: kinematics
+    damper: [0.1, 0.01, 0.5]
+  - type: contact
+contacts:
+  - r1: jvrc1
+    r2: ground
+    r1Surface: LeftFoot
+    r2Surface: AllGround
+  - r1: jvrc1
+    r2: ground
+    r1Surface: RightFoot
+    r2Surface: AllGround
+collisions:
+  - useMinimal: true
+states:
+  TestInitial:
+    base: @PYTHON@#test_python.TestPythonState
+    value: 42
+  TestFinal:
+    base: TestInitial
+    value: 100
+transitions:
+  - [TestInitial, Value=42, TestFinal, Strict]

--- a/tests/controllers/test_python/__init__.py
+++ b/tests/controllers/test_python/__init__.py
@@ -1,3 +1,4 @@
 from .test_python import TestPythonController
+from .test_python_state import TestPythonState
 
-__all__ = ["TestPythonController"]
+__all__ = ["TestPythonController", "TestPythonState"]

--- a/tests/controllers/test_python/test_python_state.py
+++ b/tests/controllers/test_python/test_python_state.py
@@ -1,0 +1,25 @@
+#
+# Copyright 2015-2023 CNRS-UM LIRMM, CNRS-AIST JRL
+#
+
+import mc_control
+import mc_rtc
+
+
+class TestPythonState(mc_control.fsm.PythonState):
+    def __init__(self):
+        self.iter = 0
+        self.config = mc_rtc.Configuration()
+
+    def configure(self, config):
+        self.config.load(config)
+
+    def start(self, ctl):
+        self.value = self.config("value", 0)
+        self.output("Value={}".format(self.value))
+
+    def run(self, ctl):
+        return True
+
+    def teardown(self, ctl):
+        pass


### PR DESCRIPTION
This PR:
- fixes an initialize/finalize issue with PythonState (and potentially PythonController) when they are used in a row (e.g. a Python state instance transiting to another Python state instance)
- adds a test for Python states