### PR TITLE
[mc_observers] Add observers' configuration

### DIFF
--- a/debian/libmc-rtc-dev.install
+++ b/debian/libmc-rtc-dev.install
@@ -18,7 +18,6 @@ usr/lib/*/libmc_rtc_gui.so
 usr/lib/*/libmc_solver.so
 usr/lib/*/libmc_trajectory.so
 usr/lib/*/libmc_tasks.so
-usr/lib/*/libmc_observers.so
 usr/lib/*/libmc_control.so
 usr/lib/*/libmc_control_client.so
 usr/lib/*/libmc_control_fsm.so

--- a/debian/libmc-rtc.install
+++ b/debian/libmc-rtc.install
@@ -9,7 +9,6 @@ usr/lib/*/libmc_rtc_gui.so.*
 usr/lib/*/libmc_solver.so.*
 usr/lib/*/libmc_trajectory.so.*
 usr/lib/*/libmc_tasks.so.*
-usr/lib/*/libmc_observers.so.*
 usr/lib/*/libmc_control.so.*
 usr/lib/*/libmc_control_client.so.*
 usr/lib/*/libmc_control_fsm.so.*

--- a/doc/_i18n/en/tutorials/recipes/observers.md
+++ b/doc/_i18n/en/tutorials/recipes/observers.md
@@ -91,6 +91,19 @@ The end-result for this example pipeline looks like this *(left: choreonoid simu
   <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/ssoNkV940yc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
+## Observers' configuration
+
+In addition to the configuration of the pipeline, observers can load configurations from the following locations:
+
+- Global configuration: {% ihighlight bash %}${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX}/etc/${ObserverType}.yaml{% endihighlight %}
+- User configuration: {% ihighlight bash %}${HOME}/.config/mc_rtc/observers/${ObserverType}.yaml{% endihighlight %}
+- Global robot-specific configuration: {% ihighlight bash %}${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX}/${ObserverType}/${Robot}.yaml{% endihighlight %}
+- User robot-specific configuration: {% ihighlight bash %}${HOME}/.config/mc_rtc/observers/${ObserverType}/${Robot}.yaml{% endihighlight %}
+
+The configuration at these locations are loaded in the order displayed above and the configuration in the pipeline is loaded last.
+
+For the robot specific configuration, the `${Robot}` value is the name provided by the `RobotModule`. mc_rtc uses the `robot` entry in the controller's configuration of the observer to decide which robot to look for.
+
 # Default observers
 
 This section provides a brief description of the default observers provided with the framework. Please refer to each observer's API documentation and JSON Schema for further details.

--- a/doc/_i18n/jp/tutorials/recipes/observers.md
+++ b/doc/_i18n/jp/tutorials/recipes/observers.md
@@ -91,7 +91,20 @@ ObserverPipelines:
   <iframe class="embed-responsive-item" src="https://www.youtube.com/embed/ssoNkV940yc" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 </div>
 
-## デフォルト観測器
+## 観測者の設定
+
+パイプラインの設定に加えて、観測者は以下の場所から設定を読み込むことができます:
+
+- グローバル設定: {% ihighlight bash %}${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX}/etc/${ObserverType}.yaml{% endihighlight %}
+- ユーザー設定: {% ihighlight bash %}${HOME}/.config/mc_rtc/observers/${ObserverType}.yaml{% endihighlight %}
+- グローバルロボット固有の設定: {% ihighlight bash %}${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX}/${ObserverType}/${Robot}.yaml{% endihighlight %}
+- ユーザーロボット固有の設定: {% ihighlight bash %}${HOME}/.config/mc_rtc/observers/${ObserverType}/${Robot}.yaml{% endihighlight %}
+
+これらの場所にある設定は、上記に表示されている順序で読み込まれ、パイプラインの設定は最後に読み込まれます。
+
+ロボット固有の設定では、`${Robot}`の値は`RobotModule`によって提供される名前です。mc_rtcは、観測者のコントローラーの設定の`robot`エントリを使用して、どのロボットを探すかを決定します。
+
+# デフォルト観測器
 
 このセクションでは、このフレームワークで用意されているデフォルト観測器について簡単に説明します。詳細については、各観測器のAPIドキュメントとJSONスキーマを参照してください。
 

--- a/include/mc_observers/ObserverLoader.h
+++ b/include/mc_observers/ObserverLoader.h
@@ -38,6 +38,20 @@ public:
     return observer_loader->create_object(name, args...);
   }
 
+  /** Returns an Observer runtime directory
+   *
+   * Empty when the module does not exist or when it's registered statically
+   *
+   * \param name Module name
+   *
+   */
+  inline static std::string get_observer_runtime_directory(const std::string & name) noexcept
+  {
+    std::lock_guard<std::mutex> guard{mtx};
+    init();
+    return observer_loader->get_object_runtime_directory(name);
+  }
+
   template<typename RetT, typename... Args>
   static void register_object(const std::string & name, std::function<RetT *(const Args &...)> callback)
   {

--- a/include/mc_observers/ObserverPipeline.h
+++ b/include/mc_observers/ObserverPipeline.h
@@ -115,7 +115,7 @@ struct MC_OBSERVERS_DLLAPI ObserverPipeline
   ~ObserverPipeline() = default;
 
   /* Load the observers */
-  void create(const mc_rtc::Configuration & config, const std::string & default_robot, double dt);
+  void create(const mc_rtc::Configuration & config, double dt);
 
   /* Initialize based on the current robot state */
   void reset();

--- a/include/mc_observers/ObserverPipeline.h
+++ b/include/mc_observers/ObserverPipeline.h
@@ -115,7 +115,7 @@ struct MC_OBSERVERS_DLLAPI ObserverPipeline
   ~ObserverPipeline() = default;
 
   /* Load the observers */
-  void create(const mc_rtc::Configuration & config, double dt);
+  void create(const mc_rtc::Configuration & config, const std::string & default_robot, double dt);
 
   /* Initialize based on the current robot state */
   void reset();

--- a/include/mc_observers/api.h
+++ b/include/mc_observers/api.h
@@ -41,11 +41,11 @@
 #else
 // Depending on whether one is building or using the
 // library define DLLAPI to import or export.
-#  ifdef MC_OBSERVERS_EXPORTS
+#  ifdef MC_CONTROL_EXPORTS
 #    define MC_OBSERVERS_DLLAPI MC_OBSERVERS_DLLEXPORT
 #  else
 #    define MC_OBSERVERS_DLLAPI MC_OBSERVERS_DLLIMPORT
-#  endif // MC_OBSERVERS_EXPORTS
+#  endif // MC_CONTROL_EXPORTS
 #  define MC_OBSERVERS_LOCAL MC_OBSERVERS_DLLLOCAL
 #endif // MC_OBSERVERS_STATIC
 
@@ -86,10 +86,10 @@
 #else
 // Depending on whether one is building or using the
 // library define DLLAPI to import or export.
-#  ifdef MC_OBSERVER_EXPORTS
+#  ifdef MC_CONTROL_EXPORTS
 #    define MC_OBSERVER_DLLAPI MC_OBSERVER_DLLEXPORT
 #  else
 #    define MC_OBSERVER_DLLAPI MC_OBSERVER_DLLIMPORT
-#  endif // MC_OBSERVER_EXPORTS
+#  endif // MC_CONTROL_EXPORTS
 #  define MC_OBSERVER_LOCAL MC_OBSERVER_DLLLOCAL
 #endif // MC_OBSERVER_STATIC

--- a/include/mc_observers/api.h
+++ b/include/mc_observers/api.h
@@ -86,10 +86,10 @@
 #else
 // Depending on whether one is building or using the
 // library define DLLAPI to import or export.
-#  ifdef MC_CONTROL_EXPORTS
+#  ifdef MC_OBSERVER_EXPORTS
 #    define MC_OBSERVER_DLLAPI MC_OBSERVER_DLLEXPORT
 #  else
 #    define MC_OBSERVER_DLLAPI MC_OBSERVER_DLLIMPORT
-#  endif // MC_CONTROL_EXPORTS
+#  endif // MC_OBSERVER_EXPORTS
 #  define MC_OBSERVER_LOCAL MC_OBSERVER_DLLLOCAL
 #endif // MC_OBSERVER_STATIC

--- a/include/mc_rtc/loader.h
+++ b/include/mc_rtc/loader.h
@@ -253,6 +253,14 @@ public:
   template<typename... Args>
   std::shared_ptr<T> create_object(const std::string & name, Args... args);
 
+  /** Returns the runtime directory of an object
+   *
+   * Returns an empty string when the object is registered via a callback or if the object is unknown
+   *
+   * \param name Name of the object
+   */
+  std::string get_object_runtime_directory(const std::string & name) const noexcept;
+
   struct ObjectDeleter
   {
     ObjectDeleter() {}

--- a/include/mc_rtc/loader.hpp
+++ b/include/mc_rtc/loader.hpp
@@ -134,6 +134,14 @@ T * ObjectLoader<T>::create(const std::string & name, Args... args)
 }
 
 template<typename T>
+std::string ObjectLoader<T>::get_object_runtime_directory(const std::string & name) const noexcept
+{
+  auto it = handles_.find(name);
+  if(it == handles_.end()) { return ""; }
+  return it->second->dir();
+}
+
+template<typename T>
 template<typename... Args>
 T * ObjectLoader<T>::create_from_handles(const std::string & name, Args... args)
 {

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -351,7 +351,7 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
   inline const Eigen::Vector3d & targetZMPVelocity() const noexcept { return zmpdTarget_; }
 
   /* Return the current support foot */
-  inline const ContactState supportFoot() const noexcept { return supportFoot_; }
+  inline ContactState supportFoot() const noexcept { return supportFoot_; }
 
   /* Set the current support foot */
   inline void supportFoot(const ContactState & foot) noexcept { supportFoot_ = foot; }
@@ -425,7 +425,7 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
 
   inline const Eigen::Vector3d & comOffsetMeasured() const noexcept { return comOffsetMeasured_; }
 
-  inline const double zmpCoeffMeasured() const noexcept { return zmpCoefMeasured_; }
+  inline double zmpCoeffMeasured() const noexcept { return zmpCoefMeasured_; }
 
   inline bool inContact(ContactState state) const noexcept { return contacts_.count(state); }
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -602,17 +602,6 @@ set(mc_observers_HDR
     ../include/mc_observers/ObserverMacros.h
 )
 
-add_library(mc_observers SHARED ${mc_observers_SRC} ${mc_observers_HDR})
-target_include_directories(
-  mc_observers PUBLIC $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
-                      $<INSTALL_INTERFACE:include>
-)
-set_target_properties(mc_observers PROPERTIES COMPILE_FLAGS "-DMC_OBSERVERS_EXPORTS")
-target_link_libraries(mc_observers PUBLIC mc_filter mc_rbdyn mc_rtc_gui)
-install_mc_rtc_lib(mc_observers)
-
-add_subdirectory(mc_observers)
-
 set(mc_control_SRC
     mc_control/CompletionCriteria.cpp
     mc_control/ControllerServer.cpp
@@ -649,11 +638,13 @@ set(mc_control_HDR
     ../include/mc_control/mc_global_controller.h
 )
 
-add_library(mc_control SHARED ${mc_control_SRC} ${mc_control_HDR})
+add_library(
+  mc_control SHARED ${mc_control_SRC} ${mc_observers_SRC} ${mc_control_HDR}
+                    ${mc_observers_HDR}
+)
 set_target_properties(mc_control PROPERTIES COMPILE_FLAGS "-DMC_CONTROL_EXPORTS")
 target_link_libraries(
-  mc_control PUBLIC mc_tasks mc_solver mc_rtc_loader mc_observers mc_rtc_utils
-                    mc_rtc_gui
+  mc_control PUBLIC mc_tasks mc_solver mc_rtc_loader mc_rtc_utils mc_rtc_gui
 )
 if(NOT MC_RTC_DISABLE_NETWORK)
   target_link_libraries(mc_control PUBLIC nanomsg)
@@ -661,6 +652,10 @@ else()
   target_compile_definitions(mc_control PUBLIC MC_RTC_DISABLE_NETWORK)
 endif()
 install_mc_rtc_lib(mc_control)
+
+add_library(mc_observers ALIAS mc_control)
+add_library(mc_rtc::mc_observers ALIAS mc_control)
+add_subdirectory(mc_observers)
 
 set(mc_control_client_SRC mc_control/ControllerClient.cpp)
 

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -621,7 +621,7 @@ void MCController::createObserverPipelines(const mc_rtc::Configuration & config)
   {
     observerPipelines_.emplace_back(*this);
     auto & pipeline = observerPipelines_.back();
-    pipeline.create(pipelineConfig, timeStep);
+    pipeline.create(pipelineConfig, robot().module().name, timeStep);
     if(pipelineConfig("log", true)) { pipeline.addToLogger(logger()); }
     if(pipelineConfig("gui", false)) { pipeline.addToGUI(*gui()); }
   }

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -621,7 +621,7 @@ void MCController::createObserverPipelines(const mc_rtc::Configuration & config)
   {
     observerPipelines_.emplace_back(*this);
     auto & pipeline = observerPipelines_.back();
-    pipeline.create(pipelineConfig, robot().module().name, timeStep);
+    pipeline.create(pipelineConfig, timeStep);
     if(pipelineConfig("log", true)) { pipeline.addToLogger(logger()); }
     if(pipelineConfig("gui", false)) { pipeline.addToGUI(*gui()); }
   }

--- a/src/mc_control/fsm/states/CMakeLists.txt
+++ b/src/mc_control/fsm/states/CMakeLists.txt
@@ -78,7 +78,8 @@ if(${PYTHON_BINDING})
     )
     target_include_directories(${PYTHON_NAME}State PRIVATE "${PROJECT_SOURCE_DIR}/src")
     add_dependencies(
-      ${PYTHON_NAME}State mc_control_${PYTHON_NAME} mc_rbdyn_${PYTHON_NAME}
+      ${PYTHON_NAME}State mc_control_fsm_${PYTHON_NAME} mc_control_${PYTHON_NAME}
+      mc_rbdyn_${PYTHON_NAME}
     )
     target_include_directories(
       ${PYTHON_NAME}State

--- a/src/mc_control/samples/EndEffector/mc_end_effector_controller.cpp
+++ b/src/mc_control/samples/EndEffector/mc_end_effector_controller.cpp
@@ -24,16 +24,18 @@ MCEndEffectorController::MCEndEffectorController(std::shared_ptr<mc_rbdyn::Robot
   solver().addTask(postureTask.get());
   if(robot().hasSurface("LFullSole") && robot().hasSurface("RFullSole"))
   {
-    solver().setContacts(
-        {mc_rbdyn::Contact(robots(), "LFullSole", "AllGround"), mc_rbdyn::Contact(robots(), "RFullSole", "AllGround")});
+    addContact({robot().name(), env().name(), "LFullSole", "AllGround"});
+    addContact({robot().name(), env().name(), "RFullSole", "AllGround"});
   }
   else if(robot().hasSurface("LeftFoot") && robot().hasSurface("RightFoot"))
   {
-    solver().setContacts(
-        {mc_rbdyn::Contact(robots(), "LeftFoot", "AllGround"), mc_rbdyn::Contact(robots(), "RightFoot", "AllGround")});
+    addContact({robot().name(), env().name(), "LeftFoot", "AllGround"});
+    addContact({robot().name(), env().name(), "RightFoot", "AllGround"});
   }
-  else if(robot().mb().joint(0).dof() == 0) { solver().setContacts({}); }
-  else { mc_rtc::log::error_and_throw("EndEffector sample does not support robot {}", robot().name()); }
+  else if(robot().mb().joint(0).dof() == 6)
+  {
+    mc_rtc::log::error_and_throw("EndEffector sample does not support robot {}", robot().name());
+  }
 
   std::string body = robot().mb().bodies().back().name();
   if(robot().hasBody("RARM_LINK7")) { body = "RARM_LINK7"; }

--- a/src/mc_control/samples/Impedance/mc_impedance_controller.cpp
+++ b/src/mc_control/samples/Impedance/mc_impedance_controller.cpp
@@ -60,8 +60,8 @@ void MCImpedanceController::reset(const ControllerResetData & reset_data)
   {
     comTask_->reset();
     solver().addTask(comTask_);
-    solver().setContacts(
-        {mc_rbdyn::Contact(robots(), "LeftFoot", "AllGround"), mc_rbdyn::Contact(robots(), "RightFoot", "AllGround")});
+    addContact(Contact{robot().name(), env().name(), "LeftFoot", "AllGround"});
+    addContact(Contact{robot().name(), env().name(), "RightFoot", "AllGround"});
   }
 
   impedanceTask_->reset();

--- a/src/mc_control/samples/Posture/mc_posture_controller.cpp
+++ b/src/mc_control/samples/Posture/mc_posture_controller.cpp
@@ -6,8 +6,6 @@
 
 #include <mc_rtc/logging.h>
 
-/* Note all service calls except for controller switches are implemented in mc_global_controller_services.cpp */
-
 namespace mc_control
 {
 
@@ -17,12 +15,11 @@ MCPostureController::MCPostureController(std::shared_ptr<mc_rbdyn::RobotModule> 
                                          Backend backend)
 : MCController(robot_module, dt, backend)
 {
-  qpsolver->addConstraintSet(contactConstraint);
-  qpsolver->addConstraintSet(kinematicsConstraint);
-  qpsolver->addConstraintSet(selfCollisionConstraint);
-  qpsolver->addConstraintSet(*compoundJointConstraint);
-  qpsolver->addTask(postureTask.get());
-  qpsolver->setContacts({});
+  solver().addConstraintSet(contactConstraint);
+  solver().addConstraintSet(kinematicsConstraint);
+  solver().addConstraintSet(selfCollisionConstraint);
+  solver().addConstraintSet(*compoundJointConstraint);
+  solver().addTask(postureTask.get());
 
   postureTask->stiffness(1.0);
   mc_rtc::log::success("MCPostureController init done");

--- a/src/mc_control/samples/Text/mc_text_controller.cpp
+++ b/src/mc_control/samples/Text/mc_text_controller.cpp
@@ -45,7 +45,7 @@ void MCTextController::reset(const mc_control::ControllerResetData & data)
   }
   std::vector<mc_rbdyn::Contact> contacts = {};
   if(config_.has("contacts")) { contacts = mc_rbdyn::Contact::loadVector(robots(), config_("contacts")); }
-  solver().setContacts(contacts);
+  for(const auto & c : contacts) { addContact(Contact::from_mc_rbdyn(*this, c)); }
 }
 
 } // namespace mc_control

--- a/src/mc_rtcMacros.in.cmake
+++ b/src/mc_rtcMacros.in.cmake
@@ -71,6 +71,16 @@ macro(add_controller controller_name)
   )
 endmacro()
 
+macro(install_controller_configuration CONFIG)
+  install(FILES "${CONFIG}" DESTINATION "${MC_CONTROLLER_RUNTIME_INSTALL_PREFIX}/etc")
+endmacro()
+
+macro(install_controller_robot_configuration CONTROLLER_NAME CONFIG)
+  install(FILES "${CONFIG}"
+          DESTINATION "${MC_CONTROLLER_RUNTIME_INSTALL_PREFIX}/${CONTROLLER_NAME}/"
+  )
+endmacro()
+
 # -- Robots --
 
 mc_rtc_set_prefix(ROBOTS mc_robots)
@@ -135,12 +145,22 @@ macro(add_observer observer_name)
   )
 endmacro()
 
-# -- For backward compatibilty we keep mc_observers as an alias to mc_control
-add_library(mc_rtc::mc_observers ALIAS mc_rtc::mc_control)
-
 macro(add_observer_simple observer_base)
   add_observer(${observer_base} ${observer_base}.cpp ${observer_base}.h)
 endmacro()
+
+macro(install_observer_configuration CONFIG)
+  install(FILES "${CONFIG}" DESTINATION "${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX}/etc")
+endmacro()
+
+macro(install_observer_robot_configuration OBSERVER_NAME CONFIG)
+  install(FILES "${CONFIG}"
+          DESTINATION "${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX}/${OBSERVER_NAME}/"
+  )
+endmacro()
+
+# -- For backward compatibilty we keep mc_observers as an alias to mc_control
+add_library(mc_rtc::mc_observers ALIAS mc_rtc::mc_control)
 
 # -- States --
 if(MC_RTC_HONOR_INSTALL_PREFIX)

--- a/src/mc_rtcMacros.in.cmake
+++ b/src/mc_rtcMacros.in.cmake
@@ -135,6 +135,9 @@ macro(add_observer observer_name)
   )
 endmacro()
 
+# -- For backward compatibilty we keep mc_observers as an alias to mc_control
+add_library(mc_rtc::mc_observers ALIAS mc_rtc::mc_control)
+
 macro(add_observer_simple observer_base)
   add_observer(${observer_base} ${observer_base}.cpp ${observer_base}.h)
 endmacro()

--- a/tests/controllers/CMakeLists.txt
+++ b/tests/controllers/CMakeLists.txt
@@ -317,7 +317,10 @@ controller_test_run(TestRobotConfigurationController 1)
 # Create a test observer
 add_library(TestObserver observers/TestObserver.cpp)
 set_target_properties(TestObserver PROPERTIES FOLDER tests/controllers/observers)
-target_link_libraries(TestObserver PUBLIC mc_control)
+target_link_libraries(
+  TestObserver PUBLIC mc_control Boost::unit_test_framework
+                      $<$<BOOL:${Boost_USE_STATIC_LIBS}>:Boost::dynamic_linking>
+)
 set_target_properties(
   TestObserver
   PROPERTIES PREFIX ""

--- a/tests/controllers/CMakeLists.txt
+++ b/tests/controllers/CMakeLists.txt
@@ -51,13 +51,19 @@ macro(controller_test_common NAME)
     target_compile_definitions(${NAME} PRIVATE "-DMC_RTC_FAST_TESTS")
   endif()
   set(TEST_CONTROLLER_NAME ${NAME})
-  set(OBSERVER_MODULE_PATH "${CMAKE_BINARY_DIR}/src/mc_observers")
+  if(DEFINED OVERRIDE_OBSERVER_MODULE_PATH)
+    set(OBSERVER_MODULE_PATH "${OVERRIDE_OBSERVER_MODULE_PATH}")
+  else()
+    set(OBSERVER_MODULE_PATH "${CMAKE_BINARY_DIR}/src/mc_observers")
+  endif()
   set(PYTHON_CONTROLLER_PATH "${CMAKE_BINARY_DIR}/src/mc_control/python")
   set(ROBOT_MODULE_PATH "${CMAKE_BINARY_DIR}/src/mc_robots")
   set(TEST_CONTROLLER_PATH "${CMAKE_CURRENT_BINARY_DIR}/${TEST_CONTROLLER_NAME}")
   set(TEST_CONTROLLER_PATH_BASE "${TEST_CONTROLLER_PATH}")
   if(CMAKE_CONFIGURATION_TYPES)
-    set(OBSERVER_MODULE_PATH "${OBSERVER_MODULE_PATH}/$<CONFIGURATION>")
+    if(NOT DEFINED OVERRIDE_OBSERVER_MODULE_PATH)
+      set(OBSERVER_MODULE_PATH "${OBSERVER_MODULE_PATH}/$<CONFIGURATION>")
+    endif()
     set(PYTHON_CONTROLLER_PATH "${PYTHON_CONTROLLER_PATH}/$<CONFIGURATION>")
     set(ROBOT_MODULE_PATH "${ROBOT_MODULE_PATH}/$<CONFIGURATION>")
     set(TEST_CONTROLLER_PATH "${TEST_CONTROLLER_PATH}/$<CONFIGURATION>")
@@ -85,24 +91,18 @@ macro(controller_test_common NAME)
   endif()
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/mc_rtc.conf.in
-    ${CMAKE_CURRENT_BINARY_DIR}/${NAME}/mc_rtc-${NAME}.conf
+    ${CMAKE_CURRENT_BINARY_DIR}/${NAME}/mc_rtc-${NAME}.cmake.conf
   )
 endmacro()
 
 macro(controller_test_construction_failure NAME)
   controller_test_common(${NAME})
-  if(CMAKE_CONFIGURATION_TYPES)
-    set(CONFIG_OUT
-        "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/$<CONFIGURATION>/mc_rtc-${NAME}.conf"
-    )
-    file(
-      GENERATE
-      OUTPUT ${CONFIG_OUT}
-      INPUT ${CMAKE_CURRENT_BINARY_DIR}/${NAME}/mc_rtc-${NAME}.conf
-    )
-  else()
-    set(CONFIG_OUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/mc_rtc-${NAME}.conf")
-  endif()
+  set(CONFIG_OUT "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/$<CONFIG>/mc_rtc-${NAME}.conf")
+  file(
+    GENERATE
+    OUTPUT ${CONFIG_OUT}
+    INPUT ${CMAKE_CURRENT_BINARY_DIR}/${NAME}/mc_rtc-${NAME}.cmake.conf
+  )
   set_target_properties(${NAME} PROPERTIES FOLDER tests/controllers/failure)
   add_global_controller_test_construction_failure(${NAME} ${CONFIG_OUT})
 endmacro()
@@ -110,18 +110,14 @@ endmacro()
 macro(controller_test_run NAME NRITER)
   controller_test_common(${NAME})
   macro(setup_test_run VARIANT)
-    if(CMAKE_CONFIGURATION_TYPES)
-      set(CONFIG_OUT
-          "${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}/$<CONFIG>/mc_rtc-${VARIANT}.conf"
-      )
-      file(
-        GENERATE
-        OUTPUT ${CONFIG_OUT}
-        INPUT ${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}/mc_rtc-${VARIANT}.conf
-      )
-    else()
-      set(CONFIG_OUT "${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}/mc_rtc-${VARIANT}.conf")
-    endif()
+    set(CONFIG_OUT
+        "${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}/$<CONFIG>/mc_rtc-${VARIANT}.conf"
+    )
+    file(
+      GENERATE
+      OUTPUT ${CONFIG_OUT}
+      INPUT ${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}/mc_rtc-${VARIANT}.cmake.conf
+    )
     if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/${NAME}.in.yaml")
       configure_file(
         ${NAME}.in.yaml "${CMAKE_CURRENT_BINARY_DIR}/${NAME}/etc/${VARIANT}.cmake.yaml"
@@ -171,7 +167,7 @@ macro(controller_test_run NAME NRITER)
   set(LOG_ENABLED "false")
   configure_file(
     ${CMAKE_CURRENT_SOURCE_DIR}/mc_rtc.conf.in
-    ${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}/mc_rtc-${VARIANT}.conf
+    ${CMAKE_CURRENT_BINARY_DIR}/${VARIANT}/mc_rtc-${VARIANT}.cmake.conf
   )
   setup_test_run(${VARIANT})
   set(TEST_CONTROLLER_NAME "${OLD_TEST_CONTROLLER_NAME}")
@@ -317,6 +313,37 @@ controller_test_run(TestCollisionController 2001)
 controller_test_run(TestCanonicalRobotController 2001)
 # Configuration test
 controller_test_run(TestRobotConfigurationController 1)
+
+# Create a test observer
+add_library(TestObserver observers/TestObserver.cpp)
+set_target_properties(TestObserver PROPERTIES FOLDER tests/controllers/observers)
+target_link_libraries(TestObserver PUBLIC mc_control)
+set_target_properties(
+  TestObserver
+  PROPERTIES PREFIX ""
+             ARCHIVE_OUTPUT_DIRECTORY
+             "${CMAKE_CURRENT_BINARY_DIR}/observers/TestObserver"
+             LIBRARY_OUTPUT_DIRECTORY
+             "${CMAKE_CURRENT_BINARY_DIR}/observers/TestObserver"
+             RUNTIME_OUTPUT_DIRECTORY
+             "${CMAKE_CURRENT_BINARY_DIR}/observers/TestObserver"
+)
+file(
+  GENERATE
+  OUTPUT "$<TARGET_FILE_DIR:TestObserver>/etc/TestObserver.yaml"
+  INPUT "${CMAKE_CURRENT_SOURCE_DIR}/observers/TestObserver.yaml"
+)
+file(
+  GENERATE
+  OUTPUT "$<TARGET_FILE_DIR:TestObserver>/TestObserver/jvrc1.yaml"
+  INPUT "${CMAKE_CURRENT_SOURCE_DIR}/observers/TestObserver.jvrc1.yaml"
+)
+
+# This test checks that observer can receive configuration in three way - Runtime path
+# configuration file - Robot-based configuration file - Controller configuration
+set(OVERRIDE_OBSERVER_MODULE_PATH "$<TARGET_FILE_DIR:TestObserver>")
+controller_test_run(TestObserverConfigurationController 1)
+unset(OVERRIDE_OBSERVER_MODULE_PATH)
 
 # Test FSM generic state configuration option
 set(FSM_STATES_INSTALL_PREFIX "${PROJECT_BINARY_DIR}/src/mc_control/fsm/states/")

--- a/tests/controllers/TestObserverConfigurationController.cpp
+++ b/tests/controllers/TestObserverConfigurationController.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2023 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#ifdef BOOST_TEST_MAIN
+#  undef BOOST_TEST_MAIN
+#endif
+#include <mc_control/api.h>
+#include <mc_control/mc_controller.h>
+#include <mc_rtc/logging.h>
+
+#include <boost/test/unit_test.hpp>
+
+namespace mc_control
+{
+
+struct MC_CONTROL_DLLAPI TestObserverConfigurationControllerController : public MCController
+{
+public:
+  TestObserverConfigurationControllerController(mc_rbdyn::RobotModulePtr rm,
+                                                double dt,
+                                                const mc_rtc::Configuration & config,
+                                                Backend backend)
+  : MCController(rm, dt, config, backend)
+  {
+    // Check that the default constructor loads the robot + ground environment
+    BOOST_REQUIRE_EQUAL(robots().size(), 2);
+    // Check that JVRC-1 was loaded
+    BOOST_REQUIRE_EQUAL(robot().name(), "jvrc1");
+    qpsolver->addConstraintSet(contactConstraint);
+    qpsolver->addConstraintSet(kinematicsConstraint);
+    qpsolver->addConstraintSet(selfCollisionConstraint);
+    qpsolver->addConstraintSet(*compoundJointConstraint);
+    qpsolver->addTask(postureTask.get());
+    mc_rtc::log::success("Created TestObserverConfigurationControllerController");
+  }
+
+  virtual bool run() override { return MCController::run(); }
+
+  virtual void reset(const ControllerResetData & reset_data) override { MCController::reset(reset_data); }
+
+private:
+};
+
+} // namespace mc_control
+
+using Controller = mc_control::TestObserverConfigurationControllerController;
+using Backend = mc_control::MCController::Backend;
+MULTI_CONTROLLERS_CONSTRUCTOR("TestObserverConfigurationController",
+                              Controller(rm, dt, config, Backend::Tasks),
+                              "TestObserverConfigurationController_TVM",
+                              Controller(rm, dt, config, Backend::TVM))

--- a/tests/controllers/TestObserverConfigurationController.in.yaml
+++ b/tests/controllers/TestObserverConfigurationController.in.yaml
@@ -1,0 +1,14 @@
+ObserverPipelines:
+  name: "ObserverPipeline"
+  observers:
+    - type: TestObserver
+      name: FullConfiguration
+      config:
+        fromControllerConfig: true
+        finalValue: 3
+    - type: TestObserver
+      name: NoControllerConfiguration
+    - type: TestObserver
+      name: NoControllerOrRobotConfiguration
+      config:
+        robot: jvrc2

--- a/tests/controllers/observers/TestObserver.cpp
+++ b/tests/controllers/observers/TestObserver.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#ifdef BOOST_TEST_MAIN
+#  undef BOOST_TEST_MAIN
+#endif
+
+#include <mc_observers/ObserverMacros.h>
+
+#include <boost/test/unit_test.hpp>
+
+struct TestObserver : public mc_observers::Observer
+{
+
+  using Observer::Observer;
+
+  void configure(const mc_control::MCController &, const mc_rtc::Configuration & config) override
+  {
+    BOOST_REQUIRE(config.has("fromObserverConfig"));
+    if(!config.has("robot")) { BOOST_REQUIRE(config.has("fromRobotConfig")); }
+    if(name() == "FullConfiguration") { BOOST_REQUIRE(config.has("fromControllerConfig")); }
+    BOOST_REQUIRE(config.has("finalValue"));
+    if(name() == "FullConfiguration") { BOOST_REQUIRE(config("finalValue").operator int() == 3); }
+    else if(name() == "NoControllerConfiguration") { BOOST_REQUIRE(config("finalValue").operator int() == 2); }
+    else
+    {
+      BOOST_REQUIRE(name() == "NoControllerOrRobotConfiguration");
+      BOOST_REQUIRE(config("finalValue").operator int() == 1);
+    }
+    desc_ = fmt::format("TestObserver ({})", name());
+  }
+
+  void reset(const mc_control::MCController &) override {}
+
+  bool run(const mc_control::MCController &) override { return true; }
+
+  void update(mc_control::MCController &) override {}
+};
+
+EXPORT_OBSERVER_MODULE("TestObserver", TestObserver)

--- a/tests/controllers/observers/TestObserver.jvrc1.yaml
+++ b/tests/controllers/observers/TestObserver.jvrc1.yaml
@@ -1,0 +1,2 @@
+fromRobotConfig: true
+finalValue: 2

--- a/tests/controllers/observers/TestObserver.yaml
+++ b/tests/controllers/observers/TestObserver.yaml
@@ -1,0 +1,2 @@
+fromObserverConfig: true
+finalValue: 1


### PR DESCRIPTION
This PR adds:
- global observers' configuration files (in `${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX}/etc/${ObserverType}.yaml` and `${HOME}/.config/mc_rtc/observers/${ObserverType}.yaml`
- robot (module) based configuration files (in `${MC_OBSERVERS_RUNTIME_INSTALL_PREFIX}/${ObserverType}/${robot}.yaml` and `${HOME}/.config/mc_rtc/observers/${ObserverType}/${robot}.yaml`)

This also add CMake macro helpers to install those files

ToDo:
- [x] Add documentation