### PR TITLE
[mc_solver] Allow to select active joints in CoMIncPlaneConstr

### DIFF
--- a/include/mc_solver/CoMIncPlaneConstr.h
+++ b/include/mc_solver/CoMIncPlaneConstr.h
@@ -26,9 +26,18 @@ struct MC_SOLVER_DLLAPI CoMIncPlaneConstr : public ConstraintSet
 public:
   CoMIncPlaneConstr(const mc_rbdyn::Robots & robots, unsigned int robotIndex, double dt);
 
-  virtual void addToSolverImpl(QPSolver & solver) override;
+  void addToSolverImpl(QPSolver & solver) override;
 
-  virtual void removeFromSolverImpl(QPSolver & solver) override;
+  void removeFromSolverImpl(QPSolver & solver) override;
+
+  /** Set joints that participate in the constraint */
+  void setActiveJoints(const std::vector<std::string> & joints);
+
+  /** Set joints that do not participate in the constraint */
+  void setInactiveJoints(const std::vector<std::string> & joints);
+
+  /** Enable all joints for the constraint */
+  void resetActiveJoints();
 
   MC_RTC_DEPRECATED inline void set_planes(QPSolver & solver,
                                            const std::vector<mc_rbdyn::Plane> & planes,

--- a/include/mc_tvm/CoMInConvexFunction.h
+++ b/include/mc_tvm/CoMInConvexFunction.h
@@ -58,6 +58,12 @@ public:
     return *planes_[i];
   }
 
+  /** Access the selector */
+  Eigen::VectorXd & selector() noexcept { return selector_; }
+
+  /** Access the selector (const) */
+  const Eigen::VectorXd & selector() const noexcept { return selector_; }
+
 protected:
   void updateValue();
   void updateVelocity();
@@ -68,6 +74,9 @@ protected:
 
   /** Set of planes */
   std::vector<tvm::geometry::PlanePtr> planes_;
+
+  /** Selector */
+  Eigen::VectorXd selector_;
 };
 
 using CoMInConvexFunctionPtr = std::shared_ptr<CoMInConvexFunction>;

--- a/src/mc_solver/CollisionsConstraint.cpp
+++ b/src/mc_solver/CollisionsConstraint.cpp
@@ -21,6 +21,8 @@
 
 #include <tvm/task_dynamics/VelocityDamper.h>
 
+#include "utils/jointsToSelector.h"
+
 namespace mc_solver
 {
 
@@ -298,19 +300,6 @@ void CollisionsConstraint::__addCollision(mc_solver::QPSolver & solver, const mc
   int collId = __createCollId(col);
   if(collId < 0) { return; }
   cols.push_back(col);
-  auto jointsToSelector = [](const mc_rbdyn::Robot & robot, const std::vector<std::string> & joints) -> Eigen::VectorXd
-  {
-    if(joints.size() == 0) { return Eigen::VectorXd::Zero(0); }
-    Eigen::VectorXd ret = Eigen::VectorXd::Zero(robot.mb().nrDof());
-    for(const auto & j : joints)
-    {
-      auto mbcIndex = robot.jointIndexByName(j);
-      auto dofIndex = robot.mb().jointPosInDof(static_cast<int>(mbcIndex));
-      const auto & joint = robot.mb().joint(static_cast<int>(mbcIndex));
-      ret.segment(dofIndex, joint.dof()).setOnes();
-    }
-    return ret;
-  };
   auto r1Selector = jointsToSelector(robots.robot(r1Index), col.r1Joints);
   auto r2Selector =
       r1Index == r2Index ? Eigen::VectorXd::Zero(0).eval() : jointsToSelector(robots.robot(r2Index), col.r2Joints);

--- a/src/mc_solver/utils/jointsToSelector.h
+++ b/src/mc_solver/utils/jointsToSelector.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <mc_rbdyn/Robot.h>
+
+namespace mc_solver
+{
+
+template<bool Select = true>
+static inline Eigen::VectorXd jointsToSelector(const mc_rbdyn::Robot & robot, const std::vector<std::string> & joints)
+{
+  if(joints.size() == 0) { return Eigen::VectorXd::Zero(0); }
+  Eigen::VectorXd ret = [&robot]()
+  {
+    if constexpr(Select) { return Eigen::VectorXd::Zero(robot.mb().nrDof()); }
+    else { return Eigen::VectorXd::Ones(robot.mb().nrDof()); }
+  }();
+  for(const auto & j : joints)
+  {
+    auto mbcIndex = robot.jointIndexByName(j);
+    auto dofIndex = robot.mb().jointPosInDof(static_cast<int>(mbcIndex));
+    const auto & joint = robot.mb().joint(static_cast<int>(mbcIndex));
+    if constexpr(Select) { ret.segment(dofIndex, joint.dof()).setOnes(); }
+    else { ret.segment(dofIndex, joint.dof()).setZero(); }
+  }
+  return ret;
+}
+
+} // namespace mc_solver

--- a/tests/controllers/TestCoMInBoxController.cpp
+++ b/tests/controllers/TestCoMInBoxController.cpp
@@ -85,9 +85,13 @@ public:
     comTask->weight(1e5);
     /** Add an orientation task to keep the chest straight */
     auto chestTask = std::make_shared<mc_tasks::OrientationTask>(robot().frame("WAIST_R_S"));
-    solver().addTask(chestTask);
+    // solver().addTask(chestTask);
     /** Create the constraint */
     comConstraint = std::make_shared<mc_solver::CoMIncPlaneConstr>(robots(), 0, solver().dt());
+    comConstraint->setInactiveJoints({"NECK_Y", "NECK_R", "NECK_P"});
+    //  comConstraint->setActiveJoints({"Root", "R_HIP_P", "R_HIP_R", "R_HIP_Y", "R_KNEE", "R_ANKLE_R", "R_ANKLE_P",
+    //                                  "L_HIP_P", "L_HIP_R", "L_HIP_Y", "L_KNEE", "L_ANKLE_R", "L_ANKLE_P", "WAIST_Y",
+    //                                  "WAIST_P", "WAIST_R"});
     solver().addConstraintSet(*comConstraint);
 
     mc_rtc::log::success("Created TestCoMInBoxController");


### PR DESCRIPTION
Follow up jrl-umi3218/Tasks#88

Note that (as done in the test) it is recommended to give it the same joints as the CoM task (if any) to avoid surprising interactions between the constraint and the task