### PR TITLE
Topic/improve force distrib

### DIFF
--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -447,6 +447,10 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
 
   bool constrainCoP = true; /**<If true, the wrench computation constraint the CoP of each contact to be inside the foot
                                support rectangle. */
+  
+  bool useTargetPressure = true; /**<If true, the CoP tasks compute the target torque using the target vertical force, otherwise, the torque is computed
+                                      using the measured one. */
+  
 
   Eigen::Vector2d copAdmittance = Eigen::Vector2d::Zero(); /**< Admittance gains for foot damping control */
   sva::MotionVecd copMaxVel{{0.3, 0.3, 0.3}, {0.1, 0.1, 0.1}}; /**< Maximal velocity of the cop tasks */
@@ -540,6 +544,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     {
       auto admittance = config("admittance");
       admittance("cop", copAdmittance);
+      admittance("useTargetPressure",useTargetPressure);
       admittance("copFzLambda", copFzLambda);
       admittance("copFzDelay", delayCoP);
       admittance("maxVel", copMaxVel);
@@ -670,6 +675,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
 
     conf.add("admittance");
     conf("admittance").add("cop", copAdmittance);
+    conf("admittance").add("useTargetPressure",useTargetPressure);
     conf("admittance").add("df", dfAdmittance);
     conf("admittance").add("df_damping", dfDamping);
     conf("admittance").add("maxVel", copMaxVel);

--- a/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
+++ b/include/mc_rbdyn/lipm_stabilizer/StabilizerConfiguration.h
@@ -447,10 +447,9 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
 
   bool constrainCoP = true; /**<If true, the wrench computation constraint the CoP of each contact to be inside the foot
                                support rectangle. */
-  
-  bool useTargetPressure = true; /**<If true, the CoP tasks compute the target torque using the target vertical force, otherwise, the torque is computed
-                                      using the measured one. */
-  
+
+  bool useTargetPressure = true; /**<If true, the CoP tasks compute the target torque using the target vertical force,
+                                    otherwise, the torque is computed using the measured one. */
 
   Eigen::Vector2d copAdmittance = Eigen::Vector2d::Zero(); /**< Admittance gains for foot damping control */
   sva::MotionVecd copMaxVel{{0.3, 0.3, 0.3}, {0.1, 0.1, 0.1}}; /**< Maximal velocity of the cop tasks */
@@ -544,7 +543,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
     {
       auto admittance = config("admittance");
       admittance("cop", copAdmittance);
-      admittance("useTargetPressure",useTargetPressure);
+      admittance("useTargetPressure", useTargetPressure);
       admittance("copFzLambda", copFzLambda);
       admittance("copFzDelay", delayCoP);
       admittance("maxVel", copMaxVel);
@@ -675,7 +674,7 @@ struct MC_RBDYN_DLLAPI StabilizerConfiguration
 
     conf.add("admittance");
     conf("admittance").add("cop", copAdmittance);
-    conf("admittance").add("useTargetPressure",useTargetPressure);
+    conf("admittance").add("useTargetPressure", useTargetPressure);
     conf("admittance").add("df", dfAdmittance);
     conf("admittance").add("df_damping", dfDamping);
     conf("admittance").add("maxVel", copMaxVel);

--- a/include/mc_tasks/CoPTask.h
+++ b/include/mc_tasks/CoPTask.h
@@ -102,12 +102,12 @@ public:
    *
    * @param s
    */
-  void useTargetPressure(bool s) { useTargetPressure_ = s; }
+  inline void useTargetPressure(bool s) noexcept { useTargetPressure_ = s; }
 
   /**
    * @brief Wether the computeddesired torque is done with the target pressure (true) of the measured one (false)
    */
-  bool useTargetPressure() noexcept { return useTargetPressure_; }
+  inline bool useTargetPressure() const noexcept { return useTargetPressure_; }
 
   /*! \brief Measured CoP in target frame.
    *

--- a/include/mc_tasks/CoPTask.h
+++ b/include/mc_tasks/CoPTask.h
@@ -107,6 +107,14 @@ public:
     useTargetPressure_ = s;
   }
 
+  /**
+   * @brief Wether the computeddesired torque is done with the target pressure (true) of the measured one (false)
+   */
+  bool useTargetPressure() noexcept 
+  {
+    return useTargetPressure_;
+  }
+
   /*! \brief Measured CoP in target frame.
    *
    */

--- a/include/mc_tasks/CoPTask.h
+++ b/include/mc_tasks/CoPTask.h
@@ -102,9 +102,9 @@ public:
    * 
    * @param s 
    */
-  void setUsedPressure(bool s)
+  void useTargetPressure(bool s)
   {
-    useTargetPressure = s;
+    useTargetPressure_ = s;
   }
 
   /*! \brief Measured CoP in target frame.
@@ -181,7 +181,7 @@ private:
   Eigen::Vector2d targetCoP_ = Eigen::Vector2d::Zero();
   Eigen::Vector3d targetForce_ = Eigen::Vector3d::Zero();
 
-  bool useTargetPressure = false;
+  bool useTargetPressure_ = false;
 
   void update(mc_solver::QPSolver &) override;
 

--- a/include/mc_tasks/CoPTask.h
+++ b/include/mc_tasks/CoPTask.h
@@ -99,21 +99,15 @@ public:
 
   /**
    * @brief Wether to compute the desired torque with the target pressure (true) of the measured one (false)
-   * 
-   * @param s 
+   *
+   * @param s
    */
-  void useTargetPressure(bool s)
-  {
-    useTargetPressure_ = s;
-  }
+  void useTargetPressure(bool s) { useTargetPressure_ = s; }
 
   /**
    * @brief Wether the computeddesired torque is done with the target pressure (true) of the measured one (false)
    */
-  bool useTargetPressure() noexcept 
-  {
-    return useTargetPressure_;
-  }
+  bool useTargetPressure() noexcept { return useTargetPressure_; }
 
   /*! \brief Measured CoP in target frame.
    *

--- a/include/mc_tasks/CoPTask.h
+++ b/include/mc_tasks/CoPTask.h
@@ -97,6 +97,16 @@ public:
       double dt,
       const mc_rtc::Configuration & config) const override;
 
+  /**
+   * @brief Wether to compute the desired torque with the target pressure (true) of the measured one (false)
+   * 
+   * @param s 
+   */
+  void setUsedPressure(bool s)
+  {
+    useTargetPressure = s;
+  }
+
   /*! \brief Measured CoP in target frame.
    *
    */
@@ -170,6 +180,8 @@ protected:
 private:
   Eigen::Vector2d targetCoP_ = Eigen::Vector2d::Zero();
   Eigen::Vector3d targetForce_ = Eigen::Vector3d::Zero();
+
+  bool useTargetPressure = false;
 
   void update(mc_solver::QPSolver &) override;
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -369,8 +369,8 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
   {
     horizonZmpRef_ = ref;
     horizonDelta_ = delta;
-    tComputation_ = 0;
     horizonCoPDistribution_ = true;
+    newCoPHorizonRef_ = true;
 
   }
 
@@ -971,6 +971,7 @@ protected:
   double horizonDelta_ = 0.05; /**< Sequence sampling period */
   /**<Is set to true when a new zmp sequence is provided and overided classical distribution */
   bool horizonCoPDistribution_ = false;
+  bool newCoPHorizonRef_ = false;
   Eigen::Vector2d modeledCoPLeft_ = Eigen::Vector2d::Zero(); /**< Used for logging*/
   Eigen::Vector2d modeledCoPRight_ = Eigen::Vector2d::Zero(); /**< Used for logging*/
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -371,7 +371,6 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     horizonDelta_ = delta;
     horizonCoPDistribution_ = true;
     newCoPHorizonRef_ = true;
-
   }
 
   /**
@@ -723,7 +722,7 @@ private:
    */
   void distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, double delta);
 
-  void computeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, const double delta,const double t_delay);
+  void computeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, const double delta, const double t_delay);
 
   /** Project desired wrench to single support foot.
    *

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -370,7 +370,7 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
     horizonZmpRef_ = ref;
     horizonDelta_ = delta;
     horizonCoPDistribution_ = true;
-    newCoPHorizonRef_ = true;
+    horizonRefUpdated_ = true;
   }
 
   /**
@@ -972,7 +972,7 @@ protected:
   double horizonDelta_ = 0.05; /**< Sequence sampling period */
   /**<Is set to true when a new zmp sequence is provided and overided classical distribution */
   bool horizonCoPDistribution_ = false;
-  bool newCoPHorizonRef_ = false;
+  bool horizonRefUpdated_ = false;
   Eigen::Vector2d modeledCoPLeft_ = Eigen::Vector2d::Zero(); /**< Used for logging*/
   Eigen::Vector2d modeledCoPRight_ = Eigen::Vector2d::Zero(); /**< Used for logging*/
 

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -723,6 +723,8 @@ private:
    */
   void distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, double delta);
 
+  void computeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, const double delta,const double t_delay);
+
   /** Project desired wrench to single support foot.
    *
    * \param desiredWrench Desired resultant reaction wrench.

--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -369,7 +369,9 @@ struct MC_TASKS_DLLAPI StabilizerTask : public MetaTask
   {
     horizonZmpRef_ = ref;
     horizonDelta_ = delta;
+    tComputation_ = 0;
     horizonCoPDistribution_ = true;
+
   }
 
   /**

--- a/src/mc_tasks/CoPTask.cpp
+++ b/src/mc_tasks/CoPTask.cpp
@@ -46,10 +46,7 @@ void CoPTask::reset()
 void CoPTask::update(mc_solver::QPSolver & solver)
 {
   double pressure = std::max(0., measuredWrench().force().z());
-  if(useTargetPressure_)
-  {
-    pressure = std::max(0.,targetForce_.z());
-  }
+  if(useTargetPressure_) { pressure = std::max(0., targetForce_.z()); }
   Eigen::Vector3d targetTorque = {+targetCoP_.y() * pressure, -targetCoP_.x() * pressure, 0.};
   DampingTask::targetWrench({targetTorque, targetForce_});
   DampingTask::update(solver);
@@ -67,7 +64,9 @@ void CoPTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
 {
   gui.addElement({"Tasks", name_},
                  mc_rtc::gui::ArrayLabel("cop_measured", [this]() -> Eigen::Vector2d { return this->measuredCoP(); }),
-                 mc_rtc::gui::Checkbox("Use Target Pressure", [this] {return useTargetPressure_;}, [this](){useTargetPressure(!useTargetPressure_);} ),
+                 mc_rtc::gui::Checkbox(
+                     "Use Target Pressure", [this] { return useTargetPressure_; },
+                     [this]() { useTargetPressure(!useTargetPressure_); }),
                  mc_rtc::gui::ArrayInput(
                      "cop_target", [this]() -> const Eigen::Vector2d & { return this->targetCoP(); },
                      [this](const Eigen::Vector2d & cop) { this->targetCoP(cop); }));

--- a/src/mc_tasks/CoPTask.cpp
+++ b/src/mc_tasks/CoPTask.cpp
@@ -46,7 +46,7 @@ void CoPTask::reset()
 void CoPTask::update(mc_solver::QPSolver & solver)
 {
   double pressure = std::max(0., measuredWrench().force().z());
-  if(useTargetPressure)
+  if(useTargetPressure_)
   {
     pressure = std::max(0.,targetForce_.z());
   }
@@ -60,14 +60,14 @@ void CoPTask::addToLogger(mc_rtc::Logger & logger)
   DampingTask::addToLogger(logger);
   MC_RTC_LOG_HELPER(name_ + "_measured_cop", measuredCoP);
   MC_RTC_LOG_HELPER(name_ + "_target_cop", targetCoP_);
-  MC_RTC_LOG_HELPER(name_ + "_useTargetPressure", useTargetPressure);
+  MC_RTC_LOG_HELPER(name_ + "_useTargetPressure", useTargetPressure_);
 }
 
 void CoPTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
 {
   gui.addElement({"Tasks", name_},
                  mc_rtc::gui::ArrayLabel("cop_measured", [this]() -> Eigen::Vector2d { return this->measuredCoP(); }),
-                 mc_rtc::gui::Checkbox("Use Target Pressure", [this] {return useTargetPressure;}, [this](){setUsedPressure(!useTargetPressure);} ),
+                 mc_rtc::gui::Checkbox("Use Target Pressure", [this] {return useTargetPressure_;}, [this](){useTargetPressure(!useTargetPressure_);} ),
                  mc_rtc::gui::ArrayInput(
                      "cop_target", [this]() -> const Eigen::Vector2d & { return this->targetCoP(); },
                      [this](const Eigen::Vector2d & cop) { this->targetCoP(cop); }));

--- a/src/mc_tasks/CoPTask.cpp
+++ b/src/mc_tasks/CoPTask.cpp
@@ -128,6 +128,7 @@ void CoPTask::load(mc_solver::QPSolver & solver, const mc_rtc::Configuration & c
   DampingTask::load(solver, config);
   if(config.has("cop")) { targetCoP(config("cop")); }
   if(config.has("force")) { targetForce(config("force")); }
+  if(config.has("useTargetPressure")) { useTargetPressure(config("useTargetPressure")); }
 }
 
 } // namespace force

--- a/src/mc_tasks/CoPTask.cpp
+++ b/src/mc_tasks/CoPTask.cpp
@@ -45,8 +45,7 @@ void CoPTask::reset()
 
 void CoPTask::update(mc_solver::QPSolver & solver)
 {
-  double pressure = std::max(0., measuredWrench().force().z());
-  if(useTargetPressure_) { pressure = std::max(0., targetForce_.z()); }
+  double pressure = std::max(0., useTargetPressure_ ? targetForce_.z() : measuredWrench().force().z());
   Eigen::Vector3d targetTorque = {+targetCoP_.y() * pressure, -targetCoP_.x() * pressure, 0.};
   DampingTask::targetWrench({targetTorque, targetForce_});
   DampingTask::update(solver);

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1249,12 +1249,12 @@ void StabilizerTask::computeCoPonHorizon(const std::vector<Eigen::Vector2d> & zm
         X_0_rc.inv().rotation().block(0, 0, 2, 2) * ratio * Acop_view;
 
     // clang-format off
-      bcop.segment(2 * i, 2) =
-          zmp_ref[i]
-          - X_0_lc.translation().segment(0, 2) * (1 - ratio)
-          - X_0_rc.translation().segment(0, 2) * (ratio)
-          - X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * exp_mat * measuredLeftCoP_delayed.segment(0, 2)
-          - X_0_rc.inv().rotation().block(0, 0, 2, 2) * (ratio) * exp_mat * measuredRightCoP_delayed.segment(0, 2);
+    bcop.segment(2 * i, 2) =
+        zmp_ref[i]
+        - X_0_lc.translation().segment(0, 2) * (1 - ratio)
+        - X_0_rc.translation().segment(0, 2) * (ratio)
+        - X_0_lc.inv().rotation().block(0, 0, 2, 2) * (1 - ratio) * exp_mat * measuredLeftCoP_delayed.segment(0, 2)
+        - X_0_rc.inv().rotation().block(0, 0, 2, 2) * (ratio) * exp_mat * measuredRightCoP_delayed.segment(0, 2);
     // clang-format on
 
     McopReg.block(2 * i, 0, 2, Acop_view.cols()) = Acop_view;
@@ -1372,9 +1372,9 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
   }
   const double t_delay = clamp((c_.delayCoP - (t_ - tComputation_)), 0, c_.delayCoP);
 
-  if(newCoPHorizonRef_)
+  if(horizonRefUpdated_)
   {
-    newCoPHorizonRef_ = false;
+    horizonRefUpdated_ = false;
     computeCoPonHorizon(zmp_ref, delta, t_delay);
   }
   // We update the model CoP for logging

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1053,6 +1053,8 @@ void StabilizerTask::distributeWrench(const sva::ForceVecd & desiredWrench)
   sva::ForceVecd w_r_rc = X_0_rc.dualMul(w_r_0);
   Eigen::Vector2d leftCoP = (constants::vertical.cross(w_l_lc.couple()) / w_l_lc.force()(2)).head<2>();
   Eigen::Vector2d rightCoP = (constants::vertical.cross(w_r_rc.couple()) / w_r_rc.force()(2)).head<2>();
+  
+  for(auto & t : footTasks){t.second->setUsedPressure(true);}
   footTasks[ContactState::Left]->targetCoP(leftCoP);
   footTasks[ContactState::Left]->targetForce(w_l_lc.force());
   footTasks[ContactState::Right]->targetCoP(rightCoP);

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -714,7 +714,7 @@ void StabilizerTask::run()
 
   if(inDoubleSupport())
   {
-    if(horizonCoPDistribution_)
+    if(horizonCoPDistribution_ && horizonZmpRef_.size() != 0)
     {
       distributeCoPonHorizon(horizonZmpRef_, horizonDelta_);
     }
@@ -1053,96 +1053,67 @@ void StabilizerTask::distributeWrench(const sva::ForceVecd & desiredWrench)
   Eigen::Vector2d leftCoP = (constants::vertical.cross(w_l_lc.couple()) / w_l_lc.force()(2)).head<2>();
   Eigen::Vector2d rightCoP = (constants::vertical.cross(w_r_rc.couple()) / w_r_rc.force()(2)).head<2>();
   
-  for(auto & t : footTasks){t.second->setUsedPressure(true);}
+  for(auto & t : footTasks){t.second->useTargetPressure(true);}
   footTasks[ContactState::Left]->targetCoP(leftCoP);
   footTasks[ContactState::Left]->targetForce(w_l_lc.force());
   footTasks[ContactState::Right]->targetCoP(rightCoP);
   footTasks[ContactState::Right]->targetForce(w_r_rc.force());
 }
 
-void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, const double delta)
+void StabilizerTask::computeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, const double delta,const double t_delay)
 {
-  // Variables
-  // ---------
-  // sequence [ul_1_x,ul_1_y, ..., ul_n_x,ul_n_y,ur_1_x,ur_1_y, ..., ur_n_x,ur_n_y]
-  // [ur_i_x,ur_i_y]: Right CoP reference in the foot frame at the ith iteration
-  // [ul_i_x,ul_i_y]: Left  CoP reference in the foot frame at the ith iteration
-  // Objective
-  // ---------
-  // Weighted minimization of the following tasks:
-  //
-  // -- minimize the CoP position to be under the ankle for each foot
-  // -- minimize the CoP position difference between both feet in their respective frame
-  //
-  // (fr_i_z * ur_i_x + fl_i_z * ul_i_x)/(fl_i_z + fr_i_z) == zmp_ref_i  -- modeled CoP must match zmp reference (same
-  // for y)
-  //
-  // Constraints
-  // -----------
-  //
-  //  CoP within the contact polygon
-  //
-  // The decision variable are organised such as :
-  // indx i of the left CoP reference : 2 * i
-  // indx i of the right CoP reference : 2 * (n + i)
+    // Variables
+    // ---------
+    // sequence [ul_1_x,ul_1_y, ..., ul_n_x,ul_n_y,ur_1_x,ur_1_y, ..., ur_n_x,ur_n_y]
+    // [ur_i_x,ur_i_y]: Right CoP reference in the foot frame at the ith iteration
+    // [ul_i_x,ul_i_y]: Left  CoP reference in the foot frame at the ith iteration
+    // Objective
+    // ---------
+    // Weighted minimization of the following tasks:
+    //
+    // -- minimize the CoP position to be under the ankle for each foot
+    // -- minimize the CoP position difference between both feet in their respective frame
+    //
+    // (fr_i_z * ur_i_x + fl_i_z * ul_i_x)/(fl_i_z + fr_i_z) == zmp_ref_i  -- modeled CoP must match zmp reference (same
+    // for y)
+    //
+    // Constraints
+    // -----------
+    //
+    //  CoP within the contact polygon
+    //
+    // The decision variable are organised such as :
+    // indx i of the left CoP reference : 2 * i
+    // indx i of the right CoP reference : 2 * (n + i)   
+    const auto & leftContact = contacts_.at(ContactState::Left);
+    const auto & rightContact = contacts_.at(ContactState::Right);
+    const double fz_tot = fSumFilter_.eval().z(); // Vertical force applied by gravity on the whole robot
 
-  if(zmp_ref.size() == 0)
-  {
-    mc_rtc::log::error_and_throw<std::runtime_error>("[{}] [distributeCoPonHorizon] no zmp reference given");
-  }
+    const sva::PTransformd & X_0_lc = leftContact.surfacePose();
+    const sva::PTransformd & X_0_rc = rightContact.surfacePose();
 
-  const auto & leftContact = contacts_.at(ContactState::Left);
-  const auto & rightContact = contacts_.at(ContactState::Right);
-  const double fz_tot = fSumFilter_.eval().z(); // Vertical force applied by gravity on the whole robot
+    // translation vector from contact center to contact ankle in contact frame
+    //{
+    const Eigen::Vector3d t_rankle_rc = (X_0_rc * contacts_.at(ContactState::Right).anklePose().inv()).translation();
+    const Eigen::Vector3d t_lankle_lc = (X_0_lc * contacts_.at(ContactState::Left).anklePose().inv()).translation();
+    //}
 
-  const sva::PTransformd & X_0_lc = leftContact.surfacePose();
-  const sva::PTransformd & X_0_rc = rightContact.surfacePose();
+    const Eigen::Vector3d & lankle = contacts_.at(ContactState::Left).anklePose().translation();
+    const Eigen::Vector3d & rankle = contacts_.at(ContactState::Right).anklePose().translation();
+    const Eigen::Vector2d t_lankle_rankle = (rankle - lankle).segment(0, 2);
 
-  // translation vector from contact center to contact ankle in contact frame
-  //{
-  const Eigen::Vector3d t_rankle_rc = (X_0_rc * contacts_.at(ContactState::Right).anklePose().inv()).translation();
-  const Eigen::Vector3d t_lankle_lc = (X_0_lc * contacts_.at(ContactState::Left).anklePose().inv()).translation();
-  //}
+    // The measured CoP is clamped in contact polygon
+    const Eigen::Vector2d measuredRightCoP = clamp(footTasks[ContactState::Right]->measuredCoP(),
+                                                  Eigen::Vector2d{-rightContact.halfLength(), -rightContact.halfWidth()},
+                                                  Eigen::Vector2d{rightContact.halfLength(), rightContact.halfWidth()});
+    const double measuredFzLeft =
+        clamp(X_0_rc.inv().dualMul(footTasks[ContactState::Left]->measuredWrench()).force().z(), 0, fz_tot);
+    const Eigen::Vector2d measuredLeftCoP = clamp(footTasks[ContactState::Left]->measuredCoP(),
+                                                  Eigen::Vector2d{-leftContact.halfLength(), -leftContact.halfWidth()},
+                                                  Eigen::Vector2d{leftContact.halfLength(), leftContact.halfWidth()});
+    const double measuredFzRight =
+        clamp(X_0_lc.inv().dualMul(footTasks[ContactState::Right]->measuredWrench()).force().z(), 0, fz_tot);
 
-  const Eigen::Vector3d & lankle = contacts_.at(ContactState::Left).anklePose().translation();
-  const Eigen::Vector3d & rankle = contacts_.at(ContactState::Right).anklePose().translation();
-  const Eigen::Vector2d t_lankle_rankle = (rankle - lankle).segment(0, 2);
-
-  // The measured CoP is clamped in contact polygon
-  const Eigen::Vector2d measuredRightCoP = clamp(footTasks[ContactState::Right]->measuredCoP(),
-                                                 Eigen::Vector2d{-rightContact.halfLength(), -rightContact.halfWidth()},
-                                                 Eigen::Vector2d{rightContact.halfLength(), rightContact.halfWidth()});
-  const double measuredFzLeft =
-      clamp(X_0_rc.inv().dualMul(footTasks[ContactState::Left]->measuredWrench()).force().z(), 0, fz_tot);
-  const Eigen::Vector2d measuredLeftCoP = clamp(footTasks[ContactState::Left]->measuredCoP(),
-                                                Eigen::Vector2d{-leftContact.halfLength(), -leftContact.halfWidth()},
-                                                Eigen::Vector2d{leftContact.halfLength(), leftContact.halfWidth()});
-  const double measuredFzRight =
-      clamp(X_0_lc.inv().dualMul(footTasks[ContactState::Right]->measuredWrench()).force().z(), 0, fz_tot);
-
-  // double fz_tot = clamp( measuredFzRight + measuredFzLeft,0. ,robot().mass() * constants::GRAVITY );
-  
-  // We consider an input to be considered as the reference for the delay
-  // At every sampling period
-  if(t_ - tComputation_ >= delta)
-  {
-    tComputation_ = t_;
-    delayedTargetCoPLeft_ = footTasks[ContactState::Left]->targetCoP();
-    delayedTargetCoPRight_ = footTasks[ContactState::Right]->targetCoP();
-    delayedTargetFzLeft_ = footTasks[ContactState::Left]->targetWrench().force().z();
-    delayedTargetFzRight_ = footTasks[ContactState::Right]->targetWrench().force().z();
-    modeledCoPLeft_ = measuredLeftCoP;
-    modeledCoPRight_ = measuredRightCoP;
-    modeledFzLeft_ = measuredFzLeft;
-    modeledFzRight_ = measuredFzRight;
-  }
-  const double t_delay = clamp((c_.delayCoP - (t_ - tComputation_)), 0, c_.delayCoP);
-
-
-
-  if(newCoPHorizonRef_)
-  {
-    newCoPHorizonRef_ = false;
     Eigen::Vector3d targetForceLeft = Eigen::Vector3d::Zero();
     Eigen::Vector3d targetForceRight = Eigen::Vector3d::Zero();
 
@@ -1350,13 +1321,63 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
     sva::ForceVecd w_r_rc = sva::ForceVecd{
         Eigen::Vector3d{rightCoP.y() * targetForceRight.z(), -rightCoP.x() * targetForceRight.z(), 0}, targetForceRight};
 
-    for(auto & t : footTasks){t.second->setUsedPressure(true);}
+    for(auto & t : footTasks){t.second->useTargetPressure(true);}
 
     footTasks[ContactState::Left]->targetCoP(leftCoP);
     footTasks[ContactState::Left]->targetForce(w_l_lc.force());
     footTasks[ContactState::Right]->targetCoP(rightCoP);
     footTasks[ContactState::Right]->targetForce(w_r_rc.force());
     distribWrench_ = X_0_lc.inv().dualMul(w_l_lc) + X_0_rc.inv().dualMul(w_r_rc);
+}
+
+void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> & zmp_ref, const double delta)
+{
+  if(zmp_ref.size() == 0)
+  {
+    mc_rtc::log::error_and_throw<std::runtime_error>("[{}] [distributeCoPonHorizon] no zmp reference given");
+  }
+
+  const auto & leftContact = contacts_.at(ContactState::Left);
+  const auto & rightContact = contacts_.at(ContactState::Right);
+  const double fz_tot = fSumFilter_.eval().z(); // Vertical force applied by gravity on the whole robot
+
+  const sva::PTransformd & X_0_lc = leftContact.surfacePose();
+  const sva::PTransformd & X_0_rc = rightContact.surfacePose();
+
+  // The measured CoP is clamped in contact polygon
+  const Eigen::Vector2d measuredRightCoP = clamp(footTasks[ContactState::Right]->measuredCoP(),
+                                                 Eigen::Vector2d{-rightContact.halfLength(), -rightContact.halfWidth()},
+                                                 Eigen::Vector2d{rightContact.halfLength(), rightContact.halfWidth()});
+  const double measuredFzLeft =
+      clamp(X_0_rc.inv().dualMul(footTasks[ContactState::Left]->measuredWrench()).force().z(), 0, fz_tot);
+  const Eigen::Vector2d measuredLeftCoP = clamp(footTasks[ContactState::Left]->measuredCoP(),
+                                                Eigen::Vector2d{-leftContact.halfLength(), -leftContact.halfWidth()},
+                                                Eigen::Vector2d{leftContact.halfLength(), leftContact.halfWidth()});
+  const double measuredFzRight =
+      clamp(X_0_lc.inv().dualMul(footTasks[ContactState::Right]->measuredWrench()).force().z(), 0, fz_tot);
+
+  // double fz_tot = clamp( measuredFzRight + measuredFzLeft,0. ,robot().mass() * constants::GRAVITY );
+  
+  // We consider an input to be considered as the reference for the delay
+  // At every sampling period
+  if(t_ - tComputation_ >= delta)
+  {
+    tComputation_ = t_;
+    delayedTargetCoPLeft_ = footTasks[ContactState::Left]->targetCoP();
+    delayedTargetCoPRight_ = footTasks[ContactState::Right]->targetCoP();
+    delayedTargetFzLeft_ = footTasks[ContactState::Left]->targetWrench().force().z();
+    delayedTargetFzRight_ = footTasks[ContactState::Right]->targetWrench().force().z();
+    modeledCoPLeft_ = measuredLeftCoP;
+    modeledCoPRight_ = measuredRightCoP;
+    modeledFzLeft_ = measuredFzLeft;
+    modeledFzRight_ = measuredFzRight;
+  }
+  const double t_delay = clamp((c_.delayCoP - (t_ - tComputation_)), 0, c_.delayCoP);
+
+  if(newCoPHorizonRef_)
+  {
+    newCoPHorizonRef_ = false;
+    computeCoPonHorizon(zmp_ref,delta,t_delay);
   }
   // We update the model CoP for logging
   if(c_.delayCoP != 0 && t_delay > 0)

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -352,6 +352,7 @@ void StabilizerTask::configure_(mc_solver::QPSolver & solver)
   {
     footTask.second->maxLinearVel(c_.copMaxVel.linear());
     footTask.second->maxAngularVel(c_.copMaxVel.angular());
+    footTask.second->useTargetPressure(c_.useTargetPressure);
   }
 
   dcmBiasEstimatorConfiguration(c_.dcmBias);
@@ -1053,7 +1054,6 @@ void StabilizerTask::distributeWrench(const sva::ForceVecd & desiredWrench)
   Eigen::Vector2d leftCoP = (constants::vertical.cross(w_l_lc.couple()) / w_l_lc.force()(2)).head<2>();
   Eigen::Vector2d rightCoP = (constants::vertical.cross(w_r_rc.couple()) / w_r_rc.force()(2)).head<2>();
   
-  for(auto & t : footTasks){t.second->useTargetPressure(true);}
   footTasks[ContactState::Left]->targetCoP(leftCoP);
   footTasks[ContactState::Left]->targetForce(w_l_lc.force());
   footTasks[ContactState::Right]->targetCoP(rightCoP);
@@ -1320,8 +1320,6 @@ void StabilizerTask::computeCoPonHorizon(const std::vector<Eigen::Vector2d> & zm
         Eigen::Vector3d{leftCoP.y() * targetForceLeft.z(), -leftCoP.x() * targetForceLeft.z(), 0}, targetForceLeft};
     sva::ForceVecd w_r_rc = sva::ForceVecd{
         Eigen::Vector3d{rightCoP.y() * targetForceRight.z(), -rightCoP.x() * targetForceRight.z(), 0}, targetForceRight};
-
-    for(auto & t : footTasks){t.second->useTargetPressure(true);}
 
     footTasks[ContactState::Left]->targetCoP(leftCoP);
     footTasks[ContactState::Left]->targetForce(w_l_lc.force());

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -1341,7 +1341,7 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
     QPCoPRight_ = exp_mat * measuredRightCoP_delayed.segment(0, 2) + (Eigen::Matrix2d::Identity() - exp_mat) * rightCoP;
 
     // Check that the computed modeled ZMP coincide with the ZMP reference
-    QPzmp = (1 - ratio0) * (X_0_lc.translation().segment(0, 2) + X_0_lc.rotation().block(0,0,2,2).transpose() * QPCoPLeft_)
+    Eigen::Vector2d QPzmp = (1 - ratio0) * (X_0_lc.translation().segment(0, 2) + X_0_lc.rotation().block(0,0,2,2).transpose() * QPCoPLeft_)
                     + ratio0 * (X_0_rc.translation().segment(0, 2) + X_0_rc.rotation().block(0,0,2,2).transpose() * QPCoPRight_);
     
     distribCheck_ = QPzmp - zmp_ref[0];

--- a/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
+++ b/src/mc_tasks/lipm_stabilizer/StabilizerTask.cpp
@@ -717,7 +717,6 @@ void StabilizerTask::run()
     if(horizonCoPDistribution_)
     {
       distributeCoPonHorizon(horizonZmpRef_, horizonDelta_);
-      //horizonCoPDistribution_ = false;
     }
     else { distributeWrench(desiredWrench_); }
   }
@@ -1125,7 +1124,7 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
   
   // We consider an input to be considered as the reference for the delay
   // At every sampling period
-  if(tComputation_ == 0.)
+  if(t_ - tComputation_ >= delta)
   {
     tComputation_ = t_;
     delayedTargetCoPLeft_ = footTasks[ContactState::Left]->targetCoP();
@@ -1137,13 +1136,13 @@ void StabilizerTask::distributeCoPonHorizon(const std::vector<Eigen::Vector2d> &
     modeledFzLeft_ = measuredFzLeft;
     modeledFzRight_ = measuredFzRight;
   }
-  double t_delay = clamp((c_.delayCoP - (t_ - tComputation_)), 0, c_.delayCoP);
+  const double t_delay = clamp((c_.delayCoP - (t_ - tComputation_)), 0, c_.delayCoP);
 
 
 
-  if(t_ ==  tComputation_)
+  if(newCoPHorizonRef_)
   {
-
+    newCoPHorizonRef_ = false;
     Eigen::Vector3d targetForceLeft = Eigen::Vector3d::Zero();
     Eigen::Vector3d targetForceRight = Eigen::Vector3d::Zero();
 


### PR DESCRIPTION
This PR contains two updates:
[CopTask]
-The reference CoP apply a torque w.r.t the target CoP using the measured vertical force instead of the desired one. An option is now available to switch between using desired or measure vertical force.
-The StabilizerTask now uses the desired vertical force to compute the desired torque

[StabilizerTask WrenchDistribution]
-The force distribution on an horizon is now updated at the sampling rate of the given references