### PR TITLE
[bugfix] Fix out-of-bound access when loading canonical robots

### DIFF
--- a/src/mc_rbdyn/RobotModule.cpp
+++ b/src/mc_rbdyn/RobotModule.cpp
@@ -217,7 +217,7 @@ bool check_module_compatibility(const RobotModule & lhs, const RobotModule & rhs
   {
     const auto & lhs_devices = lhs.devices();
     const auto & rhs_devices = rhs.devices();
-    for(size_t i = 0; lhs_devices.size(); ++i)
+    for(size_t i = 0; i < lhs_devices.size(); ++i)
     {
       const auto & lhs_d = *lhs_devices[i];
       const auto & rhs_d = *rhs_devices[i];

--- a/src/mc_robots/jvrc1.cpp
+++ b/src/mc_robots/jvrc1.cpp
@@ -11,6 +11,7 @@
 
 #include "jvrc1.h"
 
+#include <mc_rbdyn/Device.h>
 #include <mc_rbdyn/RobotModuleMacros.h>
 
 #include <mc_rtc/logging.h>
@@ -24,6 +25,13 @@ namespace bfs = boost::filesystem;
 
 namespace mc_robots
 {
+
+mc_rbdyn::DevicePtr JVRC1DummySpeaker::clone() const
+{
+  auto dummy = new JVRC1DummySpeaker(name_);
+  dummy->text_ = text_;
+  return mc_rbdyn::DevicePtr(dummy);
+}
 
 JVRC1RobotModule::JVRC1RobotModule(bool fixed, bool filter_mimics)
 : RobotModule(std::string(JVRC_VAL_VAL(JVRC_DESCRIPTION_PATH)), "jvrc1")
@@ -61,6 +69,7 @@ JVRC1RobotModule::JVRC1RobotModule(bool fixed, bool filter_mimics)
                       "R_LLITTLE",    "L_SHOULDER_P", "L_SHOULDER_R", "L_SHOULDER_Y", "L_ELBOW_P", "L_ELBOW_Y",
                       "L_WRIST_R",    "L_WRIST_Y",    "L_UTHUMB",     "L_LTHUMB",     "L_UINDEX",  "L_LINDEX",
                       "L_ULITTLE",    "L_LLITTLE"};
+  _devices.emplace_back(new JVRC1DummySpeaker{"DummySpeaker"});
 
   std::string convexPath = path + "/convex/" + name + "/";
   bfs::path p(convexPath);

--- a/src/mc_robots/jvrc1.h
+++ b/src/mc_robots/jvrc1.h
@@ -11,6 +11,32 @@
 namespace mc_robots
 {
 
+struct JVRC1DummySpeaker : public mc_rbdyn::Device
+{
+  inline JVRC1DummySpeaker() : JVRC1DummySpeaker("") {}
+  inline JVRC1DummySpeaker(const std::string & name) : mc_rbdyn::Device(name) { type_ = "JVRC1DummySpeaker"; }
+  ~JVRC1DummySpeaker() override = default;
+
+  /** Return the text to say and reset the initial state */
+  inline const std::string say()
+  {
+    std::string out = "";
+    std::swap(out, text_);
+    return out;
+  }
+
+  /** Set the text to be said */
+  inline void say(const std::string & text) { text_ = text; }
+
+  /** Return true if text to say is not empty */
+  inline bool hasSomethingToSay() { return text_ != ""; }
+
+  mc_rbdyn::DevicePtr clone() const override;
+
+private:
+  std::string text_ = "";
+};
+
 struct MC_ROBOTS_DLLAPI JVRC1RobotModule : public mc_rbdyn::RobotModule
 {
 public:

--- a/tests/testCanonicalRobot.cpp
+++ b/tests/testCanonicalRobot.cpp
@@ -5,6 +5,7 @@
 #include "utils.h"
 
 #include <mc_rbdyn/RobotConverter.h>
+#include <mc_rbdyn/RobotModule.h>
 #include <mc_rbdyn/Robots.h>
 #include <boost/test/unit_test.hpp>
 #include <random>
@@ -22,6 +23,11 @@ BOOST_AUTO_TEST_CASE(TestCanonicalRobot)
   auto robots = mc_rbdyn::loadRobot(*rm);
   auto & canonicalRobot = canonicalRobots->robot();
   auto & robot = robots->robot();
+
+  BOOST_REQUIRE(mc_rbdyn::check_module_compatibility(*rm, *rmc));
+  BOOST_REQUIRE(robot.devices().size() == 1);
+  BOOST_REQUIRE(canonicalRobot.devices().size() == 1);
+  BOOST_REQUIRE(robot.devices()[0]->name() == canonicalRobot.devices()[0]->name());
 
   auto filteredLinks =
       std::vector<std::string>{"R_UTHUMB_S", "R_LTHUMB_S", "R_UINDEX_S", "R_LINDEX_S", "R_ULITTLE_S", "R_LLITTLE_S",


### PR DESCRIPTION
Due to an erroneous stopping condition in the loop comparing robot devices between canonical and non-canonical robots, we had an infinite loop that would result in out-of-bound access of the devices arrays.

This PR fixes the bug and adds the corresponding unit test.

Will merge when CI passes.

Thanks @Dwaaap for debugging the issue :+1: 