### PR TITLE
[mc_control] Correctly log plugin performances 

### DIFF
--- a/include/mc_control/mc_global_controller.h
+++ b/include/mc_control/mc_global_controller.h
@@ -944,6 +944,7 @@ private:
 
   void start_log();
   void setup_log();
+  void setup_plugin_log();
   std::map<std::string, bool> setup_logger_ = {};
 
   /** Timers and performance measure */


### PR DESCRIPTION
This PR adds one feature:
- `log.addLogEntry` can use the `overwrite = true` parameter to force an entry into the log even if it already exists

It also contains a fix to plugin performance logging. This was particularly problematic when the controller includes enough plugin to trigger a resize on the `plugins_before_`/`plugins_after_` vectors since it would then access freed memory during logging.