### PR TITLE
Add Python bindings for ControllerClient

### DIFF
--- a/binding/python/mc_control/c_mc_control.pxd
+++ b/binding/python/mc_control/c_mc_control.pxd
@@ -156,3 +156,15 @@ cdef extern from "mc_control_wrapper.hpp" namespace "mc_control":
 
   void add_anchor_frame_callback[T, U](MCPythonController &, const string &, T, U)
   void remove_anchor_frame_callback(MCPythonController &, const string &)
+
+cdef extern from "<mc_control/ControllerClient.h>" namespace "mc_control":
+  cdef cppclass ElementId:
+    ElementId()
+    ElementId(const vector[string]&, const string&)
+    vector[string] category
+    string name
+  cdef cppclass ControllerClient:
+    ControllerClient()
+    ControllerClient(const string&, const string&, double)
+    void send_request(const ElementId&)
+    void send_request(const ElementId&, c_mc_rtc.Configuration)

--- a/binding/python/mc_control/mc_control.pxd
+++ b/binding/python/mc_control/mc_control.pxd
@@ -29,3 +29,9 @@ cdef public api class MCPythonController(MCController)[object MCPythonController
 
 cdef class MCGlobalController(object):
   cdef c_mc_control.MCGlobalController * impl
+
+cdef class ElementId(object):
+  cdef c_mc_control.ElementId impl
+
+cdef class ControllerClient(object):
+  cdef c_mc_control.ControllerClient * impl

--- a/binding/python/mc_control/mc_control.pyx
+++ b/binding/python/mc_control/mc_control.pyx
@@ -372,7 +372,9 @@ cdef class MCGlobalController(object):
 
 cdef class ElementId(object):
   def __cinit__(self, category, name):
-    self.impl = c_mc_control.ElementId(category, name)
+    if isinstance(name, unicode):
+      name = name.encode(u'ascii')
+    self.impl = c_mc_control.ElementId([s.encode(u'ascii') if isinstance(s, unicode) else s for s in category] , name)
   property category:
     def __get__(self):
       return self.impl.category
@@ -382,6 +384,10 @@ cdef class ElementId(object):
 
 cdef class ControllerClient(object):
   def __cinit__(self, sub_conn_uri, push_conn_uri, timeout = 0.0):
+    if isinstance(sub_conn_uri, unicode):
+      sub_conn_uri = sub_conn_uri.encode(u'ascii')
+    if isinstance(push_conn_uri, unicode):
+      push_conn_uri = push_conn_uri.encode(u'ascii')
     self.impl = new c_mc_control.ControllerClient(sub_conn_uri, push_conn_uri, timeout)
   def send_request(self, element_id, data = None):
     if data is None:

--- a/binding/python/mc_control/mc_control.pyx
+++ b/binding/python/mc_control/mc_control.pyx
@@ -369,3 +369,22 @@ cdef class MCGlobalController(object):
       return self.impl.running
     def __set__(self, b):
       self.impl.running = b
+
+cdef class ElementId(object):
+  def __cinit__(self, category, name):
+    self.impl = c_mc_control.ElementId(category, name)
+  property category:
+    def __get__(self):
+      return self.impl.category
+  property name:
+    def __get__(self):
+      return self.impl.name
+
+cdef class ControllerClient(object):
+  def __cinit__(self, sub_conn_uri, push_conn_uri, timeout = 0.0):
+    self.impl = new c_mc_control.ControllerClient(sub_conn_uri, push_conn_uri, timeout)
+  def send_request(self, element_id, data = None):
+    if data is None:
+      deref(self.impl).send_request((<ElementId>element_id).impl)
+    else:
+      deref(self.impl).send_request((<ElementId>element_id).impl, deref((<mc_rtc.Configuration>data).impl))

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -185,7 +185,7 @@ protected:
   virtual void stopped() {}
 
   /** Should be implemented to create a new category container */
-  virtual void category(const std::vector<std::string> & parent, const std::string & category) {};
+  virtual void category(const std::vector<std::string> & parent, const std::string & category){};
 
   /** Should be implemented to create a label for data that can be displayed as string */
   inline virtual void label(const ElementId & id, const std::string &)

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -185,7 +185,7 @@ protected:
   virtual void stopped() {}
 
   /** Should be implemented to create a new category container */
-  virtual void category(const std::vector<std::string> & parent, const std::string & category) = 0;
+  virtual void category(const std::vector<std::string> & parent, const std::string & category) {};
 
   /** Should be implemented to create a label for data that can be displayed as string */
   inline virtual void label(const ElementId & id, const std::string &)


### PR DESCRIPTION
This is just an introduction to a new feature I am experimenting with right now. I thought it was interesting and will submit a PR, but it may not necessarily need to be merged.

I thought it would be useful If we could send commands (walking, reaching, etc.) of mc_rtc controller from a Python script or interpreter, and I realized this by using Python bindings in [ControllerClient](https://github.com/jrl-umi3218/mc_rtc/blob/47177743b1df404c5a039ef159396a2ab93d0cd1/include/mc_control/ControllerClient.h#L51). This PR adds that bindings. 

This allows the Python interpreter to send walking and gripper opening/closing commands, as shown in the video below, using BaselineWalkingController as an example. (BaselineWalkingController does not require any changes for this purpose.) In addition to calling it from the interpreter, it will be easy to determine the destination of a walk based on the results of a deep learning model and send walking commands in a Python script.

https://github.com/jrl-umi3218/mc_rtc/assets/6636600/73590010-e4c1-414b-8749-759cd17a67e1

Here is the ControllerClient wrapper for Python.
```python
import mc_rtc
import mc_control

def setup():
    global cli
    cli = mc_control.ControllerClient(b"ipc:///tmp/mc_rtc_pub.ipc", b"ipc:///tmp/mc_rtc_rep.ipc")

def walk(x, y, theta):
    global cli
    elem = mc_control.ElementId([b"BWC", b"GuiWalk"], b"Walk")
    config = mc_rtc.Configuration()
    config.add("goal x [m]", x)
    config.add("goal y [m]", y)
    config.add("goal theta [deg]", theta)
    config.add("number of last footstep", 0)
    cli.send_request(elem, config)

def openGripper():
    global cli
    elem = mc_control.ElementId([b"Global", b"Grippers", b"jvrc1", b"r_gripper"], b"Open")
    cli.send_request(elem)

def closeGripper():
    elem = mc_control.ElementId([b"Global", b"Grippers", b"jvrc1", b"r_gripper"], b"Close")
    cli.send_request(elem)
```
