### PR TITLE
[mc_rbdyn::Robot] Update the convex

### DIFF
--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -1180,7 +1180,6 @@ void Robot::forwardKinematics(rbd::MultiBodyConfig & mbc) const
     unsigned int index = static_cast<unsigned int>(mb().bodyIndexByName(cvx.second.first));
     sch::mc_rbdyn::transform(*(cvx.second.second.get()), mbc.bodyPosW[index]);
   }
-
 }
 
 void Robot::forwardVelocity()

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -1169,11 +1169,18 @@ unsigned int mc_rbdyn::Robot::robotIndex() const
 
 void Robot::forwardKinematics()
 {
-  rbd::forwardKinematics(mb(), mbc());
+  forwardKinematics(mbc());
 }
 void Robot::forwardKinematics(rbd::MultiBodyConfig & mbc) const
 {
   rbd::forwardKinematics(mb(), mbc);
+
+  for(auto & cvx : convexes_)
+  {
+    unsigned int index = static_cast<unsigned int>(mb().bodyIndexByName(cvx.second.first));
+    sch::mc_rbdyn::transform(*(cvx.second.second.get()), mbc.bodyPosW[index]);
+  }
+
 }
 
 void Robot::forwardVelocity()


### PR DESCRIPTION
This PR modifies the `mc_rbdyn::Robot::forwardKinematics` such as the convexes attached to a robot are also updated. Otherwise, the convexes' location keeps their initial pose unless they are used in a constraint.

This allows `mc_rbdyn::Robot::convex` function to return an up-to-date convex.