### PR TITLE
[FSM/Executor] Make resetting posture tasks optional

### DIFF
--- a/doc/_data/schemas/State/Meta.json
+++ b/doc/_data/schemas/State/Meta.json
@@ -8,8 +8,8 @@
       "properties":
       {
         "Managed": { "type": "boolean", "default": false, "description": "If true, this state does not handle transitions by itself"},
-        "StepByStep": { "type": "boolean", "default": true, "description": "Affects the StepByStep transition behaviour<br/>If not set, inherits the setting from its parent FSM" },
-        "ResetPostures": { "type": "boolean", "default": true, "description": "When true rest the posture tasks to the current posture before transitioning to the next state" },
+        "StepByStep": { "type": "boolean", "description": "Affects the StepByStep transition behaviour<br/>Defaults to true for the main executor, false otherwise" },
+        "ResetPostures": { "type": "boolean", "description": "When true reset the posture tasks to the current posture before transitioning to the next state. Defaults to true for the main executor, false otherwise (Meta states)" },
         "transitions": { "type": "array", "description": "A transition map, required if Managed is false",
           "items":
           {

--- a/doc/_data/schemas/State/Meta.json
+++ b/doc/_data/schemas/State/Meta.json
@@ -8,7 +8,8 @@
       "properties":
       {
         "Managed": { "type": "boolean", "default": false, "description": "If true, this state does not handle transitions by itself"},
-        "StepByStep": { "type": "boolean", "description": "Affects the StepByStep transition behaviour<br/>If not set, inherits the setting from its parent FSM" },
+        "StepByStep": { "type": "boolean", "default": true, "description": "Affects the StepByStep transition behaviour<br/>If not set, inherits the setting from its parent FSM" },
+        "ResetPostures": { "type": "boolean", "default": true, "description": "When true rest the posture tasks to the current posture before transitioning to the next state" },
         "transitions": { "type": "array", "description": "A transition map, required if Managed is false",
           "items":
           {

--- a/include/mc_control/fsm/Executor.h
+++ b/include/mc_control/fsm/Executor.h
@@ -137,6 +137,8 @@ private:
   bool managed_ = false;
   /** If true and not managed, waits for trigger before transitions */
   bool step_by_step_ = true;
+  /** When true reset the posture tasks to the current posture before transitionning to the next state */
+  bool reset_postures_ = true;
 
   /** Transition map, empty if managed */
   TransitionMap transition_map_;

--- a/src/mc_control/fsm/Executor.cpp
+++ b/src/mc_control/fsm/Executor.cpp
@@ -33,6 +33,7 @@ void Executor::init(Controller & ctl,
   name_ = name;
   config("Managed", managed_);
   config("StepByStep", step_by_step_);
+  config("ResetPostures", reset_postures_);
   if(!managed_)
   {
     transition_map_.init(ctl.factory(), config);
@@ -176,7 +177,7 @@ void Executor::next(Controller & ctl)
   {
     auto state_teardown_start = clock::now();
     state_->teardown_(ctl);
-    ctl.resetPostures();
+    if(reset_postures_) { ctl.resetPostures(); }
     state_teardown_dt_ = clock::now() - state_teardown_start;
   }
   mc_rtc::log::success("Starting state {}", next_state_);

--- a/src/mc_control/fsm/states/Meta.cpp
+++ b/src/mc_control/fsm/states/Meta.cpp
@@ -14,6 +14,7 @@ namespace fsm
 void MetaState::start(Controller & ctl)
 {
   if(!config_.has("StepByStep")) { config_.add("StepByStep", false); }
+  if(!config_.has("ResetPostures")) { config_.add("ResetPostures", false); }
   executor_.init(ctl, config_, name(), config_("category", std::vector<std::string>{}));
   run(ctl);
 }


### PR DESCRIPTION
This PR allows to skip the reset of the posture tasks before transitioning to the next state. This has been requested multiple times, and proves useful in some cases where the user does not want to keep the current posture. Example:
```yaml
base: Meta
ResetPostures: false
transitions:
- [ChooseState, A, StateA, Auto]
- [ChooseState, B, StateB, Auto]
- [StateA, OK, HalfSitting, Auto]
- [StateB, OK, HalfSitting, Auto]
- [HalfSitting, OK, ChooseState, Auto]
```
This will set the desired posture to HalfSitting instead of keeping it to the current posture. Not that with `ResetPostures: true` in this example, the behaviour would be counterintuitive: the effet of the HalfSitting state is immediately canceled by the resetting of the posture tasks done by the Exectutor (as we are not awaiting for completion of the HalfSitting state).