### PR TITLE
[KinematicInertial] Fix use of state-observation

### DIFF
--- a/include/mc_observers/KinematicInertialPoseObserver.h
+++ b/include/mc_observers/KinematicInertialPoseObserver.h
@@ -102,41 +102,6 @@ protected:
   void estimatePosition(const mc_control::MCController & ctl);
 
 protected:
-  /**
-   * @brief Merge roll and pitch orientation from a rotation matrix R1 with yaw (rotation around gravity) from another
-   * rotation matrix R2
-   *
-   * This function was adpated from https://github.com/mehdi-benallegue/state-observation and modified to follow
-   * SpaceVecAlg conventions for rotation. It computes:
-   *
-   *
-   * \f[
-   *  R=\left(
-   *  \begin{array}{ccc}
-   *   \frac{m\times e_{z}}{\left\Vert m\times e_{z}\right\Vert } & \frac{e_{z}\times m\times e_{z}}{\left\Vert m\times
-   * e_{z}\right\Vert } & e_{z}\end{array}\right)\left(\begin{array}{ccc} \frac{m_{l}\times v_{1}}{\left\Vert
-   * m_{l}\times v_{1}\right\Vert } & \frac{v_{1}\times m_{l}\times v_{1}}{\left\Vert m_{l}\times v_{1}\right\Vert } &
-   * v_{1}\end{array}
-   *   \right)^{T}\\
-   *   v_{1}=R_{1}e_{z}\qquad m_{l}=R_{2}m\\
-   *   m = \left\{
-   *   \begin{array}{c}
-   *   e_x \mbox{ if } ||R_2e_x \times v_1||^2 < \epsilon^2\\
-   *   e_y \mbox{ otherwise }
-   *   \end{array}
-   *   \right.
-   *  \f]
-   *
-   * @param R1 First rotation matrix (for roll and pitch)
-   * @param R2 Second rotation matrix (for yaw)
-   *
-   * @return a rotation matrix composed of roll and pitch from R1, yaw from R2
-   */
-  inline Eigen::Matrix3d mergeRoll1Pitch1WithYaw2(const Eigen::Matrix3d & R1,
-                                                  const Eigen::Matrix3d & R2,
-                                                  double epsilonAngle = 1e-16);
-
-protected:
   std::string robot_; /**< Robot to observe (default main robot) */
   std::string realRobot_; /**< Corresponding real robot (default main real robot) */
   std::string imuSensor_; /**< BodySensor containting IMU readings */


### PR DESCRIPTION
This PR fixes the mistakes introduced by #388 (I have temporarely reverted it on master with [d4de8d3](https://github.com/jrl-umi3218/mc_rtc/commit/d4de8d312049420e965a68672cd0abef860df95a))
During walking I could see no differences checking the results of the old versus new method.

However, while perturbing the robot manually (dragging it around in choreonoid), there are still slight differences.
For example (displayed as RPY angles)
```
[info] New:   0.22885 -0.218569    2.3249
[info] Old:  0.234254 -0.212752   2.29964
[info] New:  0.231229 -0.220776   2.32437
[info] Old:  0.236799 -0.214775   2.29859
[info] New:  0.233628 -0.223039   2.32383
[info] Old:   0.23937 -0.216849   2.29751
[info] New:  0.236055 -0.225358   2.32327
[info] Old:  0.241975 -0.218971    2.2964
[info] New:  0.238506 -0.227731    2.3227
[info] Old:  0.244613 -0.221141   2.29526
```

@mehdi-benallegue Could you confirm that this is indeed correct?