### PR TITLE
[mc_rtc/Configuration] Improvements for Schema introduction

### DIFF
--- a/doc/_data/schemas/SpaceVecAlg/ForceVecd.json
+++ b/doc/_data/schemas/SpaceVecAlg/ForceVecd.json
@@ -1,6 +1,7 @@
 {
   "title": "sva::ForceVecd",
   "type": "object",
+  "description": "Either couple or force can be ommited if the other is present",
   "properties":
   {
     "couple": { "$ref": "/../../Eigen/Vector3d.json" },

--- a/doc/_data/schemas/SpaceVecAlg/ImpedanceVecd.json
+++ b/doc/_data/schemas/SpaceVecAlg/ImpedanceVecd.json
@@ -1,6 +1,7 @@
 {
   "title": "sva::ImpedanceVecd",
   "type": "object",
+  "description": "Either angular or linear can be ommited if the other is present",
   "properties":
   {
     "angular": { "$ref": "/../../Eigen/Vector3d.json" },

--- a/doc/_data/schemas/SpaceVecAlg/MotionVecd.json
+++ b/doc/_data/schemas/SpaceVecAlg/MotionVecd.json
@@ -1,6 +1,7 @@
 {
   "title": "sva::MotionVecd",
   "type": "object",
+  "description": "Either angular or linear can be ommited if the other is present",
   "properties":
   {
     "angular": { "$ref": "/../../Eigen/Vector3d.json" },

--- a/doc/_i18n/en/tutorials/usage/mc_rtc_configuration.md
+++ b/doc/_i18n/en/tutorials/usage/mc_rtc_configuration.md
@@ -305,12 +305,12 @@ struct Foo
   // ...
 
   // This will be called to load your object from a Configuration object
-  static Foo load(const mc_rtc::Configuration & in);
+  static Foo fromConfiguration(const mc_rtc::Configuration & in);
 
   // This will be called save your object to a Configuration object
-  mc_rtc::Configuration save() const;
+  mc_rtc::Configuration toConfiguration() const;
 
   // This also supports arguments
-  mc_rtc::Configuration save(bool verbose) const;
+  mc_rtc::Configuration toConfiguration(bool verbose) const;
 };
 ```

--- a/doc/_i18n/en/tutorials/usage/mc_rtc_configuration.md
+++ b/doc/_i18n/en/tutorials/usage/mc_rtc_configuration.md
@@ -263,8 +263,9 @@ This feature allows you to specialize `mc_rtc::Configuration`
 to support loading/save to/from your own type. This feature is
 a C++ only feature for now.
 
-It works by adding a specialization template in the `mc_rtc`
-namespace of the following form:
+#### Non-intrusive approach
+
+You can add a specialization to the `ConfigurationLoader` template in the `mc_rtc` namespace of the following form:
 
 ```cpp
 template<>
@@ -291,5 +292,25 @@ struct ConfigurationLoader<MyType>
   static MyType load(const mc_rtc::Configuration & config);
 
   static mc_rtc::Configuration save(const MyType & object, bool verbose = false);
+};
+```
+
+#### Intrusive approach
+
+You can also implement methods in your object, `mc_rtc` will then pick these methods automatically:
+
+```cpp
+struct Foo
+{
+  // ...
+
+  // This will be called to load your object from a Configuration object
+  static Foo load(const mc_rtc::Configuration & in);
+
+  // This will be called save your object to a Configuration object
+  mc_rtc::Configuration save() const;
+
+  // This also supports arguments
+  mc_rtc::Configuration save(bool verbose) const;
 };
 ```

--- a/doc/_i18n/jp/tutorials/usage/mc_rtc_configuration.md
+++ b/doc/_i18n/jp/tutorials/usage/mc_rtc_configuration.md
@@ -279,11 +279,12 @@ struct Foo
   // ...
 
   // このメソッドは、オブジェクトをConfigurationオブジェクトから読み込むために呼び出されます
-  static Foo load(const mc_rtc::Configuration & in);
+  static Foo fromConfiguration(const mc_rtc::Configuration & in);
 
   // このメソッドは、オブジェクトをConfigurationオブジェクトに保存するために呼び出されます
-  mc_rtc::Configuration save() const;
+  mc_rtc::Configuration toConfiguration() const;
 
   // これは引数もサポートしています
-  mc_rtc::Configuration save(bool verbose) const;
+  mc_rtc::Configuration toConfiguration(bool verbose) const;
 };
+```

--- a/doc/_i18n/jp/tutorials/usage/mc_rtc_configuration.md
+++ b/doc/_i18n/jp/tutorials/usage/mc_rtc_configuration.md
@@ -238,9 +238,12 @@ std::vector<std::pair<std::vector<Eigen::Vector3d>, std::vector<double>> inequal
 
 ### 独自の型のサポート
 
+
 この機能では、独自の型を持つデータの読み込みや保存を行えるように`mc_rtc::Configuration`を特殊化することができます。現在、この機能はC++でのみサポートされています。
 
-この機能を使用するには、`mc_rtc`名前空間に以下の形式で特殊化テンプレートを追加します。
+#### 非侵入的な方法
+
+次の形式で、mc_rtc名前空間内のConfigurationLoaderテンプレートに特殊化を追加することができます：
 
 ```cpp
 template<>
@@ -265,3 +268,22 @@ struct ConfigurationLoader<MyType>
   static mc_rtc::Configuration save(const MyType & object, bool verbose = false);
 };
 ```
+
+#### 侵入的な方法
+
+また、オブジェクト内にメソッドを実装することもできます。`mc_rtc`はこれらのメソッドを自動的に選択します：
+
+```cpp
+struct Foo
+{
+  // ...
+
+  // このメソッドは、オブジェクトをConfigurationオブジェクトから読み込むために呼び出されます
+  static Foo load(const mc_rtc::Configuration & in);
+
+  // このメソッドは、オブジェクトをConfigurationオブジェクトに保存するために呼び出されます
+  mc_rtc::Configuration save() const;
+
+  // これは引数もサポートしています
+  mc_rtc::Configuration save(bool verbose) const;
+};

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -190,6 +190,8 @@ private:
      * \throws If key does not belong in keys()
      */
     Json operator[](const std::string & key) const;
+    /** Try to find an element at the provided key */
+    std::optional<Json> find(const std::string & key) const;
     /** True if the value is a string */
     bool isString() const noexcept;
     /** True if the value is numeric */

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -813,6 +813,32 @@ public:
    */
   Configuration operator()(const std::string & key) const;
 
+  /*! \brief Returns the Configuration entry if it exists, std::nullopt otherwise
+   *
+   * \param Key key used to store the value
+   *
+   * \returns Configuration entry if it exists, std::nullopt otherwise
+   */
+  std::optional<Configuration> find(const std::string & key) const;
+
+  /*! \brief Returns the value stored within the configuration if it exists, std::nullopt otherwise
+   *
+   * \param key Key used to store the value
+   *
+   * \returns Value if key is in the configuration, std::nullopt otherwise
+   *
+   * \tparam T Type of the entry retrieved
+   *
+   * \throws If the conversion to \tparam T fails
+   */
+  template<typename T>
+  std::optional<T> find(const std::string & key) const
+  {
+    auto maybe_cfg = find(key);
+    if(maybe_cfg) { return maybe_cfg->operator T(); }
+    return std::nullopt;
+  }
+
   /*! \brief Returns true if the underlying array or underlying object is empty */
   bool empty() const;
 

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -817,26 +817,43 @@ public:
 
   /*! \brief Returns the Configuration entry if it exists, std::nullopt otherwise
    *
-   * \param Key key used to store the value
+   * \param key key used to store the value
    *
    * \returns Configuration entry if it exists, std::nullopt otherwise
    */
   std::optional<Configuration> find(const std::string & key) const;
 
-  /*! \brief Returns the value stored within the configuration if it exists, std::nullopt otherwise
+  /*! \brief Return the Configuration entry at (key, others...) if it exists, std::nullopt otherwise
    *
-   * \param key Key used to store the value
+   * This is equivalent if(auto a = cfg.find("a")) { if(auto b = cfg.find("b")) { ... } }
    *
-   * \returns Value if key is in the configuration, std::nullopt otherwise
+   * \param key key used to store the value
+   *
+   * \param others Keys searched one after the other
+   *
+   * \returns Configuration entry if it exists, std::nullopt otherwise
+   */
+  template<typename... Args>
+  std::optional<Configuration> find(const std::string & key, Args &&... others) const
+  {
+    auto out = find(key);
+    return out ? out->find(std::forward<Args>(others)...) : std::nullopt;
+  }
+
+  /*! \brief Return the Configuration entry at (key, others...) if it exists, std::nullopt otherwise
+   *
+   * \param key key used to store the value
+   *
+   * \param others Keys searched one after the other
    *
    * \tparam T Type of the entry retrieved
    *
-   * \throws If the conversion to \tparam T fails
+   * \throws If the key exists but the conversion to \tparam T fails
    */
-  template<typename T>
-  std::optional<T> find(const std::string & key) const
+  template<typename T, typename... Args>
+  std::optional<T> find(const std::string & key, Args &&... others) const
   {
-    auto maybe_cfg = find(key);
+    auto maybe_cfg = find(key, std::forward<Args>(others)...);
     if(maybe_cfg) { return maybe_cfg->operator T(); }
     return std::nullopt;
   }

--- a/include/mc_rtc/Default.h
+++ b/include/mc_rtc/Default.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include <SpaceVecAlg/SpaceVecAlg>
+
+#include <string>
+#include <type_traits>
+#include <variant>
+
+namespace mc_rtc
+{
+
+/** Helper to get a default value for a given type
+ *
+ * When this is implemented, the template should provide Default<T>::value of type T
+ *
+ * Enable is used to SFINAE generic definitions
+ */
+template<typename T, typename Enable = void>
+struct Default
+{
+  static_assert(!std::is_same_v<T, T>, "Must be specialized");
+};
+
+template<typename T>
+struct Default<T, std::enable_if_t<std::is_arithmetic_v<T>>>
+{
+  inline static constexpr T value = 0;
+};
+
+template<typename Scalar, int N, int Options, int MaxRows, int MaxCols>
+struct Default<Eigen::Matrix<Scalar, N, 1, Options, MaxRows, MaxCols>, std::enable_if_t<(N > 0)>>
+{
+  inline static const Eigen::Matrix<Scalar, N, 1, Options, MaxRows, MaxCols> value =
+      Eigen::Matrix<Scalar, N, 1, Options, MaxRows, MaxCols>::Zero();
+};
+
+template<typename Scalar, int N, int Options, int MaxRows, int MaxCols>
+struct Default<Eigen::Matrix<Scalar, N, N, Options, MaxRows, MaxCols>, std::enable_if_t<(N > 1)>>
+{
+  inline static const Eigen::Matrix<Scalar, N, N, Options, MaxRows, MaxCols> value =
+      Eigen::Matrix<Scalar, N, N, Options, MaxRows, MaxCols>::Identity();
+};
+
+template<>
+struct Default<sva::PTransformd>
+{
+  inline static const sva::PTransformd value = sva::PTransformd::Identity();
+};
+
+template<>
+struct Default<sva::MotionVecd>
+{
+  inline static const sva::MotionVecd value = sva::MotionVecd::Zero();
+};
+
+template<>
+struct Default<sva::ForceVecd>
+{
+  inline static const sva::ForceVecd value = sva::ForceVecd::Zero();
+};
+
+template<>
+struct Default<sva::ImpedanceVecd>
+{
+  inline static const sva::ImpedanceVecd value = sva::ImpedanceVecd::Zero();
+};
+
+template<>
+struct Default<sva::AdmittanceVecd>
+{
+  inline static const sva::AdmittanceVecd value = sva::AdmittanceVecd::Zero();
+};
+
+template<>
+struct Default<std::string>
+{
+  inline static const std::string value;
+};
+
+template<typename T, typename... Others>
+struct Default<std::variant<T, Others...>> : public Default<T>
+{
+};
+
+} // namespace mc_rtc

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -41,7 +41,7 @@ std::vector<std::string> Configuration::Json::keys() const noexcept
 {
   assert(isObject());
   std::vector<std::string> ret;
-  auto v = static_cast<const internal::RapidJSONValue *>(value_);
+  const auto * v = static_cast<const internal::RapidJSONValue *>(value_);
   for(auto it = v->MemberBegin(); it != v->MemberEnd(); ++it) { ret.push_back(it->name.GetString()); }
   return ret;
 }
@@ -83,59 +83,59 @@ void Configuration::Json::path(std::string & out) const noexcept
 {
   assert(doc_.get());
   assert(value_);
-  auto root = static_cast<const internal::RapidJSONValue *>(doc_.get());
-  auto value = static_cast<const internal::RapidJSONValue *>(value_);
+  const auto * root = static_cast<const internal::RapidJSONValue *>(doc_.get());
+  const auto * value = static_cast<const internal::RapidJSONValue *>(value_);
   findPath(root, value, out);
 }
 
 bool Configuration::empty() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(v.isArray()) { return value->Empty(); }
-  else if(v.isObject()) { return value->ObjectEmpty(); }
+  if(v.isObject()) { return value->ObjectEmpty(); }
   return value->IsNull();
 }
 
 size_t Configuration::Json::size() const noexcept
 {
   assert(value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(value_);
   return value->Size();
 }
 
 Configuration::Json Configuration::Json::operator[](size_t idx) const
 {
   assert(value_);
-  auto value = static_cast<internal::RapidJSONValue *>(value_);
+  auto * value = static_cast<internal::RapidJSONValue *>(value_);
   return {static_cast<void *>(&(*value)[idx]), doc_};
 }
 
 Configuration::Json Configuration::Json::operator[](const std::string & key) const
 {
   assert(value_);
-  auto value = static_cast<internal::RapidJSONValue *>(value_);
+  auto * value = static_cast<internal::RapidJSONValue *>(value_);
   return {static_cast<void *>(&(*value)[key]), doc_};
 }
 
 bool Configuration::Json::isString() const noexcept
 {
   assert(value_);
-  auto value = static_cast<internal::RapidJSONValue *>(value_);
+  auto * value = static_cast<internal::RapidJSONValue *>(value_);
   return value->IsString();
 }
 
 bool Configuration::Json::isNumeric() const noexcept
 {
   assert(value_);
-  auto value = static_cast<internal::RapidJSONValue *>(value_);
+  auto * value = static_cast<internal::RapidJSONValue *>(value_);
   return value->IsNumber();
 }
 
 double Configuration::Json::asDouble() const
 {
   assert(isNumeric());
-  auto value = static_cast<internal::RapidJSONValue *>(value_);
+  auto * value = static_cast<internal::RapidJSONValue *>(value_);
   return value->GetDouble();
 }
 
@@ -143,7 +143,7 @@ Configuration::Exception::Exception(const std::string & msg, const Json & v) : m
 
 Configuration::Exception::~Exception() noexcept
 {
-  if(msg().size()) { log::error(msg()); }
+  if(!msg().empty()) { log::error(msg()); }
 }
 
 const char * Configuration::Exception::what() const noexcept
@@ -163,7 +163,7 @@ const std::string & Configuration::Exception::msg() const noexcept
   {
     std::string path;
     v_.path(path);
-    msg_ = fmt::format("{} (error path: {})", msg_, path.size() ? path : "()");
+    msg_ = fmt::format("{} (error path: {})", msg_, path.empty() ? "()" : path);
     v_.value_ = nullptr;
   }
   return msg_;
@@ -172,7 +172,7 @@ const std::string & Configuration::Exception::msg() const noexcept
 Configuration::Configuration() : v{nullptr, std::shared_ptr<void>(new internal::RapidJSONDocument())}
 {
   auto doc = std::static_pointer_cast<internal::RapidJSONDocument>(v.doc_);
-  auto value = rapidjson::GenericPointer<internal::RapidJSONValue>("/").Get(*doc);
+  auto * value = rapidjson::GenericPointer<internal::RapidJSONValue>("/").Get(*doc);
   if(!value) { value = doc.get(); }
   v.value_ = value;
   doc->SetObject();
@@ -190,7 +190,7 @@ bool Configuration::isMember(const std::string & key) const
 bool Configuration::has(const std::string & key) const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   return v.isObject() && value->HasMember(key);
 }
 
@@ -215,17 +215,17 @@ Configuration Configuration::operator[](size_t i) const
 Configuration::operator bool() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsBool()) { return value->GetBool(); }
-  else if(value->IsUint()) { return value->GetUint(); }
-  else if(value->IsInt()) { return value->GetInt(); }
+  if(value->IsUint()) { return value->GetUint(); }
+  if(value->IsInt()) { return value->GetInt(); }
   throw Exception("Stored Json value is not a bool", v);
 }
 
 Configuration::operator int8_t() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsInt())
   {
     int32_t i = value->GetInt();
@@ -241,7 +241,7 @@ Configuration::operator int8_t() const
 Configuration::operator int16_t() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsInt())
   {
     int32_t i = value->GetInt();
@@ -257,7 +257,7 @@ Configuration::operator int16_t() const
 Configuration::operator int32_t() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsInt()) { return value->GetInt(); }
   throw Exception("Stored Json value is not an int32_t", v);
 }
@@ -265,7 +265,7 @@ Configuration::operator int32_t() const
 Configuration::operator int64_t() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsInt64()) { return value->GetInt64(); }
   throw Exception("Stored Json value is not an int64_t", v);
 }
@@ -273,7 +273,7 @@ Configuration::operator int64_t() const
 Configuration::operator uint8_t() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsUint())
   {
     uint32_t i = value->GetUint();
@@ -286,7 +286,7 @@ Configuration::operator uint8_t() const
 Configuration::operator uint16_t() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsUint())
   {
     uint32_t i = value->GetUint();
@@ -299,7 +299,7 @@ Configuration::operator uint16_t() const
 Configuration::operator uint32_t() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsUint()) { return value->GetUint(); }
   throw Exception("Stored Json value is not an uint32_t", v);
 }
@@ -307,7 +307,7 @@ Configuration::operator uint32_t() const
 Configuration::operator uint64_t() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsUint64() || (value->IsInt64() && value->GetInt64() >= 0)) { return value->GetUint64(); }
   throw Exception("Stored Json value is not an uint64_t", v);
 }
@@ -315,7 +315,7 @@ Configuration::operator uint64_t() const
 Configuration::operator double() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsNumber()) { return value->GetDouble(); }
   throw Exception("Stored Json value is not a double", v);
 }
@@ -323,7 +323,7 @@ Configuration::operator double() const
 Configuration::operator std::string() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsString()) { return std::string(value->GetString(), value->GetStringLength()); }
   throw Exception("Stored Json value is not a string", v);
 }
@@ -375,7 +375,7 @@ Configuration::operator Eigen::Vector6d() const
 Configuration::operator mc_rbdyn::Gains2d() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsNumber()) { return value->GetDouble(); }
   return this->operator Eigen::Vector2d();
 }
@@ -383,7 +383,7 @@ Configuration::operator mc_rbdyn::Gains2d() const
 Configuration::operator mc_rbdyn::Gains3d() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsNumber()) { return value->GetDouble(); }
   return this->operator Eigen::Vector3d();
 }
@@ -391,7 +391,7 @@ Configuration::operator mc_rbdyn::Gains3d() const
 Configuration::operator mc_rbdyn::Gains6d() const
 {
   assert(v.value_);
-  auto value = static_cast<const internal::RapidJSONValue *>(v.value_);
+  const auto * value = static_cast<const internal::RapidJSONValue *>(v.value_);
   if(value->IsNumber()) { return value->GetDouble(); }
   return this->operator Eigen::Vector6d();
 }
@@ -415,7 +415,7 @@ Configuration::operator Eigen::Quaterniond() const
     {
       return Eigen::Quaterniond(v[0].asDouble(), v[1].asDouble(), v[2].asDouble(), v[3].asDouble()).normalized();
     }
-    else if(v.size() == 9)
+    if(v.size() == 9)
     {
       Eigen::Matrix3d m;
       for(size_t i = 0; i < 3; ++i)
@@ -424,7 +424,7 @@ Configuration::operator Eigen::Quaterniond() const
       }
       return Eigen::Quaterniond(m).normalized();
     }
-    else if(v.size() == 3)
+    if(v.size() == 3)
     {
       return Eigen::Quaterniond(mc_rbdyn::rpyToMat(v[0].asDouble(), v[1].asDouble(), v[2].asDouble())).normalized();
     }
@@ -501,20 +501,20 @@ Configuration::operator sva::PTransformd() const
     }
     return {r};
   }
-  else if(has("translation"))
+  if(has("translation"))
   {
     Eigen::Vector3d t = (*this)("translation");
     return {t};
   }
-  else if(size() == 7)
+  if(size() == 7)
   {
-    auto & config = *this;
+    const auto & config = *this;
     return {Eigen::Quaterniond{config[0], config[1], config[2], config[3]}.normalized(),
             {config[4], config[5], config[6]}};
   }
-  else if(size() == 12)
+  if(size() == 12)
   {
-    auto & config = *this;
+    const auto & config = *this;
     Eigen::Matrix3d rot;
     rot << config[0], config[1], config[2], config[3], config[4], config[5], config[6], config[7], config[8];
     return {rot, {config[9], config[10], config[11]}};
@@ -525,9 +525,9 @@ Configuration::operator sva::PTransformd() const
 Configuration::operator sva::ForceVecd() const
 {
   if(has("couple") && has("force")) { return {(*this)("couple"), (*this)("force")}; }
-  else if(size() == 6)
+  if(size() == 6)
   {
-    auto & config = *this;
+    const auto & config = *this;
     return {{config[0], config[1], config[2]}, {config[3], config[4], config[5]}};
   }
   throw Exception("Stored Json value is not a ForceVecd", v);
@@ -536,9 +536,9 @@ Configuration::operator sva::ForceVecd() const
 Configuration::operator sva::MotionVecd() const
 {
   if(has("angular") && has("linear")) { return {(*this)("angular"), (*this)("linear")}; }
-  else if(size() == 6)
+  if(size() == 6)
   {
-    auto & config = *this;
+    const auto & config = *this;
     return {{config[0], config[1], config[2]}, {config[3], config[4], config[5]}};
   }
   throw Exception("Stored Json value is not a MotionVecd", v);
@@ -551,9 +551,9 @@ Configuration::operator sva::ImpedanceVecd() const
     Eigen::Vector3d angular = (*this)("angular");
     return {angular, (*this)("linear")};
   }
-  else if(size() == 6)
+  if(size() == 6)
   {
-    auto & config = *this;
+    const auto & config = *this;
     return {{config[0], config[1], config[2]}, {config[3], config[4], config[5]}};
   }
   throw Exception("Stored Json value is not an ImpedanceVecd", v);
@@ -643,7 +643,7 @@ void Configuration::load(const mc_rtc::Configuration & config)
     const auto & v = *static_cast<internal::RapidJSONValue *>(config.v.value_);
     if(v.IsObject())
     {
-      for(auto & m : v.GetObject())
+      for(const auto & m : v.GetObject())
       {
         if(target.HasMember(m.name))
         {
@@ -652,7 +652,7 @@ void Configuration::load(const mc_rtc::Configuration & config)
             (*this)(m.name.GetString()).load(config(m.name.GetString()));
             continue;
           }
-          else { target.RemoveMember(m.name); }
+          target.RemoveMember(m.name);
         }
         internal::RapidJSONValue n(m.name, doc.GetAllocator());
         internal::RapidJSONValue v(m.value, doc.GetAllocator());
@@ -662,7 +662,7 @@ void Configuration::load(const mc_rtc::Configuration & config)
     else if(v.IsArray())
     {
       if(!target.IsArray()) { target.SetArray(); }
-      for(auto & value : v.GetArray())
+      for(const auto & value : v.GetArray())
       {
         target.PushBack(internal::RapidJSONValue{value, doc.GetAllocator()}.Move(), doc.GetAllocator());
       }
@@ -708,11 +708,9 @@ void Configuration::save(const std::string & path, bool pretty) const
 std::string Configuration::dump(bool pretty, bool yaml) const
 {
   if(yaml) { return mc_rtc::internal::dumpYAML(*this); }
-  else
-  {
-    auto & value = *static_cast<internal::RapidJSONValue *>(v.value_);
-    return mc_rtc::internal::dumpDocument(value, pretty);
-  }
+
+  auto & value = *static_cast<internal::RapidJSONValue *>(v.value_);
+  return mc_rtc::internal::dumpDocument(value, pretty);
 }
 
 size_t Configuration::toMessagePack(std::vector<char> & data) const

--- a/src/mc_rtc/Configuration.cpp
+++ b/src/mc_rtc/Configuration.cpp
@@ -200,6 +200,22 @@ Configuration Configuration::operator()(const std::string & key) const
   throw Exception("No entry named " + key + " in the configuration", v);
 }
 
+std::optional<Configuration> Configuration::find(const std::string & key) const
+{
+  assert(v.value_);
+  auto * value = static_cast<internal::RapidJSONValue *>(v.value_);
+  if(v.isObject())
+  {
+    auto ret = value->FindMember(key);
+    if(ret != value->MemberEnd())
+    {
+      internal::RapidJSONValue * kvalue = &(ret->value);
+      return Configuration(Configuration::Json{static_cast<void *>(kvalue), v.doc_});
+    }
+  }
+  return std::nullopt;
+}
+
 size_t Configuration::size() const
 {
   if(v.isArray()) { return v.size(); }

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -16,6 +16,14 @@ namespace bfs = boost::filesystem;
 #include <fstream>
 #include <iostream>
 
+bool silence_exception(const mc_rtc::Configuration::Exception & e)
+{
+  e.silence();
+  return true;
+}
+#define MC_RTC_CHECK_THROW(statement) \
+  BOOST_CHECK_EXCEPTION(statement, mc_rtc::Configuration::Exception, silence_exception)
+
 namespace Eigen
 {
 
@@ -176,9 +184,11 @@ std::string sampleConfig2(bool fromDisk, bool json)
 void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bool json2)
 {
   /*! Check that accessing a non-existing entry throws */
-  BOOST_CHECK_THROW(config("NONE"), mc_rtc::Configuration::Exception);
+  MC_RTC_CHECK_THROW(config("NONE"));
 
   BOOST_CHECK(config("NONE", std::optional<mc_rtc::Configuration>{}) == std::nullopt);
+
+  BOOST_CHECK(config.find("NONE") == std::nullopt);
 
   /* int tests */
   {
@@ -227,6 +237,11 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
 
     auto k = config("double", std::optional<int>{std::nullopt});
     BOOST_CHECK(k == std::nullopt);
+
+    auto l = config.find<int>("int");
+    BOOST_CHECK(l.has_value() && *l == 42);
+
+    MC_RTC_CHECK_THROW([[maybe_unused]] auto m = config.find<int>("double"));
   }
 
   /* unsigned int tests */
@@ -253,9 +268,9 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
     BOOST_CHECK_EQUAL(d, 10);
 
     /*! Check int to unsigned int does not happen */
-    unsigned int h = 10;
-    config("sint", h);
-    BOOST_CHECK_EQUAL(h, 10);
+    unsigned int e = 10;
+    config("sint", e);
+    BOOST_CHECK_EQUAL(e, 10);
 
     /*! Access a unsigned int from a dict */
     unsigned int f = 0;
@@ -266,6 +281,11 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
     unsigned int g = 0;
     config("dict")("int", g);
     BOOST_CHECK_EQUAL(g, 42);
+
+    auto h = config.find<unsigned int>("int");
+    BOOST_CHECK(h.has_value() && *h == 42);
+
+    MC_RTC_CHECK_THROW([[maybe_unused]] auto i = config.find<unsigned int>("double"));
   }
 
   /* double tests */
@@ -349,7 +369,8 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
 
     MC_RTC_diagnostic_push
     MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
-    BOOST_CHECK_THROW(Eigen::Vector2d d = config("v6d"), mc_rtc::Configuration::Exception);
+    MC_RTC_CHECK_THROW(Eigen::Vector2d d = config("v6d"));
+    MC_RTC_CHECK_THROW(auto d = config.find<Eigen::Vector2d>("v6d"));
     MC_RTC_diagnostic_pop
 
     Eigen::Vector2d e = Eigen::Vector2d::Zero();
@@ -380,7 +401,8 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
 
     MC_RTC_diagnostic_push
     MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
-    BOOST_CHECK_THROW(mc_rbdyn::Gains2d d = config("v6d"), mc_rtc::Configuration::Exception);
+    MC_RTC_CHECK_THROW(mc_rbdyn::Gains2d d = config("v6d"));
+    MC_RTC_CHECK_THROW(auto d = config.find<mc_rbdyn::Gains2d>("v6d"));
     MC_RTC_diagnostic_pop
 
     mc_rbdyn::Gains2d e = mc_rbdyn::Gains2d::Zero();
@@ -424,7 +446,8 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
 
     MC_RTC_diagnostic_push
     MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
-    BOOST_CHECK_THROW(Eigen::Vector3d d = config("v6d"), mc_rtc::Configuration::Exception);
+    MC_RTC_CHECK_THROW(Eigen::Vector3d d = config("v6d"));
+    MC_RTC_CHECK_THROW(auto d = config.find<Eigen::Vector3d>("v6d"));
     MC_RTC_diagnostic_pop
 
     Eigen::Vector3d e = Eigen::Vector3d::Zero();
@@ -455,7 +478,8 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
 
     MC_RTC_diagnostic_push
     MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
-    BOOST_CHECK_THROW(mc_rbdyn::Gains3d d = config("v6d"), mc_rtc::Configuration::Exception);
+    MC_RTC_CHECK_THROW(mc_rbdyn::Gains3d d = config("v6d"));
+    MC_RTC_CHECK_THROW(auto d = config.find<mc_rbdyn::Gains3d>("v6d"));
     MC_RTC_diagnostic_pop
 
     mc_rbdyn::Gains3d e = mc_rbdyn::Gains3d::Zero();
@@ -499,7 +523,8 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
 
     MC_RTC_diagnostic_push
     MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
-    BOOST_CHECK_THROW(Eigen::Vector4d d = config("v6d"), mc_rtc::Configuration::Exception);
+    MC_RTC_CHECK_THROW(Eigen::Vector4d d = config("v6d"));
+    MC_RTC_CHECK_THROW(auto d = config.find<Eigen::Vector4d>("v6d"));
     MC_RTC_diagnostic_pop
 
     Eigen::Vector4d e = Eigen::Vector4d::Zero();
@@ -530,7 +555,8 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
 
     MC_RTC_diagnostic_push
     MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
-    BOOST_CHECK_THROW(Eigen::Vector6d d = config("v3d"), mc_rtc::Configuration::Exception);
+    MC_RTC_CHECK_THROW(Eigen::Vector6d d = config("v3d"));
+    MC_RTC_CHECK_THROW(auto d = config.find<Eigen::Vector6d>("v3d"));
     MC_RTC_diagnostic_pop
 
     Eigen::Vector6d e = Eigen::Vector6d::Zero();
@@ -561,7 +587,8 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
 
     MC_RTC_diagnostic_push
     MC_RTC_diagnostic_ignored(GCC, "-Wunused", ClangOnly, "-Wunknown-warning-option", GCC, "-Wunused-but-set-variable")
-    BOOST_CHECK_THROW(mc_rbdyn::Gains6d d = config("v3d"), mc_rtc::Configuration::Exception);
+    MC_RTC_CHECK_THROW(mc_rbdyn::Gains6d d = config("v3d"));
+    MC_RTC_CHECK_THROW(auto d = config.find<mc_rbdyn::Gains6d>("v3d"));
     MC_RTC_diagnostic_pop
 
     mc_rbdyn::Gains6d e = mc_rbdyn::Gains6d::Zero();
@@ -611,7 +638,8 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
     Eigen::VectorXd d = config("vXd");
     BOOST_CHECK_EQUAL(d, ref);
 
-    BOOST_CHECK_THROW(Eigen::VectorXd e = config("int"), mc_rtc::Configuration::Exception);
+    MC_RTC_CHECK_THROW(Eigen::VectorXd e = config("int"));
+    MC_RTC_CHECK_THROW(auto d = config.find<Eigen::VectorXd>("int"));
 
     Eigen::VectorXd f = Eigen::VectorXd::Zero(0);
     f = config("dict")("v6d");
@@ -755,8 +783,8 @@ void testConfigurationReading(mc_rtc::Configuration & config, bool fromDisk2, bo
     config("dict")("doubleDoublePair", c);
     BOOST_CHECK(c == ref);
 
-    BOOST_CHECK_THROW(c = (std::pair<double, double>)config("quat"), mc_rtc::Configuration::Exception);
-    BOOST_CHECK_THROW(c = (std::pair<double, double>)config("doubleStringPair"), mc_rtc::Configuration::Exception);
+    MC_RTC_CHECK_THROW(c = (std::pair<double, double>)config("quat"));
+    MC_RTC_CHECK_THROW(c = (std::pair<double, double>)config("doubleStringPair"));
   }
 
   /* pair<double, string> test */
@@ -992,8 +1020,10 @@ BOOST_AUTO_TEST_CASE(TestConfigurationWriting)
   BOOST_CHECK(config_test("a3_v") == ref_a3_v);
   BOOST_CHECK(config_test("a3_a") == ref_a3_a);
   BOOST_REQUIRE(config_test.has("dict"));
+  BOOST_REQUIRE(config_test.find("dict").has_value());
   BOOST_CHECK(config_test("dict")("int") == ref_int);
   BOOST_REQUIRE(config_test.has("dict2"));
+  BOOST_REQUIRE(config_test.find("dict2").has_value());
   BOOST_CHECK(config_test("dict2")("double_v") == ref_double_v);
 
   /* Save a part of the configuration */
@@ -1210,10 +1240,10 @@ BOOST_AUTO_TEST_CASE(TestNestedLoading)
   mc_rtc::Configuration c3;
   c3.load(c2("nested")("b"));
   BOOST_REQUIRE(c3 == true);
-  BOOST_CHECK_THROW(c3.add("nested"), mc_rtc::Configuration::Exception);
+  MC_RTC_CHECK_THROW(c3.add("nested"));
   c1.load(c2("nested")("b"));
   BOOST_REQUIRE(c1 == true);
-  BOOST_CHECK_THROW(c1.add("nested"), mc_rtc::Configuration::Exception);
+  MC_RTC_CHECK_THROW(c1.add("nested"));
 }
 
 BOOST_AUTO_TEST_CASE(TestConfigurartionRemove)

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -1391,3 +1391,54 @@ BOOST_AUTO_TEST_CASE(TestIntegralTypes)
     builder.finish();
   }
 }
+
+BOOST_AUTO_TEST_CASE(TestVariant)
+{
+  using variant_t = std::variant<double, std::string>;
+  variant_t v = 42.42;
+  mc_rtc::Configuration config;
+  config.add("v", v);
+  {
+    std::pair<size_t, double> serialized = config("v");
+    BOOST_REQUIRE_EQUAL(serialized.first, 0);
+    BOOST_REQUIRE_EQUAL(serialized.second, 42.42);
+  }
+  {
+    variant_t out = config("v");
+    BOOST_REQUIRE(out.index() == 0);
+    BOOST_REQUIRE(std::get<0>(out) == 42.42);
+  }
+  {
+    auto array = config.array("array");
+    array.push(v);
+  }
+  {
+    std::vector<variant_t> variant_array = config("array");
+    BOOST_REQUIRE(variant_array.size() == 1);
+    BOOST_REQUIRE(variant_array[0].index() == 0);
+    BOOST_REQUIRE(std::get<0>(variant_array[0]) == 42.42);
+  }
+  v = "hello";
+  config.add("v", v);
+  {
+    std::pair<size_t, std::string> serialized = config("v");
+    BOOST_REQUIRE_EQUAL(serialized.first, 1);
+    BOOST_REQUIRE_EQUAL(serialized.second, "hello");
+  }
+  {
+    variant_t out = config("v");
+    BOOST_REQUIRE(out.index() == 1);
+    BOOST_REQUIRE(std::get<1>(out) == "hello");
+  }
+  {
+    config("array").push(v);
+  }
+  {
+    std::vector<variant_t> variant_array = config("array");
+    BOOST_REQUIRE(variant_array.size() == 2);
+    BOOST_REQUIRE(variant_array[0].index() == 0);
+    BOOST_REQUIRE(std::get<0>(variant_array[0]) == 42.42);
+    BOOST_REQUIRE(variant_array[1].index() == 1);
+    BOOST_REQUIRE(std::get<1>(variant_array[1]) == "hello");
+  }
+}

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -1044,7 +1044,7 @@ struct Foo
 {
   Foo() {}
   Foo(const std::string & name, double d) : name(name), d(d) {}
-  std::string name = "";
+  std::string name;
   double d = 0.0;
   bool operator==(const Foo & rhs) const { return rhs.name == this->name && rhs.d == this->d; }
 };
@@ -1073,13 +1073,13 @@ struct Bar
 {
   Bar() {}
   Bar(const std::string & name, double d) : name(name), d(d) {}
-  std::string name = "";
+  std::string name;
   double d = 0.0;
   inline bool operator==(const Bar & rhs) const { return rhs.name == this->name && rhs.d == this->d; }
 
-  static Bar load(const mc_rtc::Configuration & config) { return {config("name"), config("d")}; }
+  static Bar fromConfiguration(const mc_rtc::Configuration & config) { return {config("name"), config("d")}; }
 
-  mc_rtc::Configuration save() const
+  mc_rtc::Configuration toConfiguration() const
   {
     mc_rtc::Configuration config;
     config.add("name", name);
@@ -1090,13 +1090,13 @@ struct Bar
 
 } // namespace test
 
-static_assert(!mc_rtc::internal::has_static_load_configuration_v<double>);
-static_assert(!mc_rtc::internal::has_static_load_configuration_v<Foo>);
-static_assert(mc_rtc::internal::has_static_load_configuration_v<test::Bar>);
+static_assert(!mc_rtc::internal::has_static_fromConfiguration_v<double>);
+static_assert(!mc_rtc::internal::has_static_fromConfiguration_v<Foo>);
+static_assert(mc_rtc::internal::has_static_fromConfiguration_v<test::Bar>);
 
-static_assert(!mc_rtc::internal::has_configuration_save_method_v<double>);
-static_assert(!mc_rtc::internal::has_configuration_save_method_v<Foo>);
-static_assert(mc_rtc::internal::has_configuration_save_method_v<test::Bar>);
+static_assert(!mc_rtc::internal::has_toConfiguration_method_v<double>);
+static_assert(!mc_rtc::internal::has_toConfiguration_method_v<Foo>);
+static_assert(mc_rtc::internal::has_toConfiguration_method_v<test::Bar>);
 
 using user_types = boost::mpl::list<Foo, test::Bar>;
 
@@ -1115,7 +1115,7 @@ BOOST_AUTO_TEST_CASE_TEMPLATE(TestUserDefinedConversions, T, user_types)
     }
     else
     {
-      T f1 = T::load(config("foo"));
+      T f1 = T::fromConfiguration(config("foo"));
       return f1;
     }
   }();

--- a/tests/testConfiguration.cpp
+++ b/tests/testConfiguration.cpp
@@ -5,10 +5,12 @@
 #include <mc_rtc/Configuration.h>
 #include <mc_rtc/pragma.h>
 
+#include <boost/test/unit_test.hpp>
+
 #include <boost/filesystem.hpp>
 namespace bfs = boost::filesystem;
 
-#include <boost/test/unit_test.hpp>
+#include <boost/mpl/list.hpp>
 
 #include "utils.h"
 #include <fstream>
@@ -1064,31 +1066,77 @@ struct ConfigurationLoader<Foo>
 };
 } // namespace mc_rtc
 
-BOOST_AUTO_TEST_CASE(TestUserDefinedConversions)
+namespace test
 {
-  Foo f_ref{"foo", 1.0};
+
+struct Bar
+{
+  Bar() {}
+  Bar(const std::string & name, double d) : name(name), d(d) {}
+  std::string name = "";
+  double d = 0.0;
+  inline bool operator==(const Bar & rhs) const { return rhs.name == this->name && rhs.d == this->d; }
+
+  static Bar load(const mc_rtc::Configuration & config) { return {config("name"), config("d")}; }
+
+  mc_rtc::Configuration save() const
+  {
+    mc_rtc::Configuration config;
+    config.add("name", name);
+    config.add("d", d);
+    return config;
+  }
+};
+
+} // namespace test
+
+static_assert(!mc_rtc::internal::has_static_load_configuration_v<double>);
+static_assert(!mc_rtc::internal::has_static_load_configuration_v<Foo>);
+static_assert(mc_rtc::internal::has_static_load_configuration_v<test::Bar>);
+
+static_assert(!mc_rtc::internal::has_configuration_save_method_v<double>);
+static_assert(!mc_rtc::internal::has_configuration_save_method_v<Foo>);
+static_assert(mc_rtc::internal::has_configuration_save_method_v<test::Bar>);
+
+using user_types = boost::mpl::list<Foo, test::Bar>;
+
+BOOST_AUTO_TEST_CASE_TEMPLATE(TestUserDefinedConversions, T, user_types)
+{
+  T f_ref{"foo", 1.0};
   mc_rtc::Configuration config;
   config.add("foo", f_ref);
 
-  Foo f1 = mc_rtc::ConfigurationLoader<Foo>::load(config("foo"));
+  T f1 = [&config]()
+  {
+    if constexpr(mc_rtc::internal::has_configuration_load_object_v<T>)
+    {
+      T f1 = mc_rtc::ConfigurationLoader<T>::load(config("foo"));
+      return f1;
+    }
+    else
+    {
+      T f1 = T::load(config("foo"));
+      return f1;
+    }
+  }();
   BOOST_CHECK(f1 == f_ref);
 
-  Foo f2;
+  T f2;
   f2 = config("foo");
   BOOST_CHECK(f2 == f_ref);
 
-  Foo f3 = config("foo");
+  T f3 = config("foo");
   BOOST_CHECK(f3 == f_ref);
 
-  std::vector<Foo> v_ref{f1, f2};
+  std::vector<T> v_ref{f1, f2};
   config.add("foo_v", v_ref);
 
-  std::vector<Foo> v1 = config("foo_v");
+  std::vector<T> v1 = config("foo_v");
   BOOST_CHECK(v1 == v_ref);
 
   config.array("foo_v2");
   for(const auto & f : v_ref) { config("foo_v2").push(f); }
-  std::vector<Foo> v2 = config("foo_v2");
+  std::vector<T> v2 = config("foo_v2");
   BOOST_CHECK(v2 == v_ref);
 }
 

--- a/tests/testConfigurationHelpers.cpp
+++ b/tests/testConfigurationHelpers.cpp
@@ -5,6 +5,13 @@
 #include <mc_rtc/ConfigurationHelpers.h>
 #include <boost/test/unit_test.hpp>
 
+bool silence_exception(const mc_rtc::Configuration::Exception & e)
+{
+  e.silence();
+  return true;
+}
+#define MC_RTC_REQUIRE_THROW(statement, exception) BOOST_REQUIRE_EXCEPTION(statement, exception, silence_exception)
+
 template<typename ElemT,
          typename WrongElemT,
          typename VecT = std::vector<ElemT>,
@@ -21,21 +28,20 @@ void test_fromVectorOrElement(const ElemT & elem,
   vectorConf.add("vectorNonConvertible", wrongVec);
   vectorConf.add("elem", elem);
   vectorConf.add("elemNonConvertible", wrongElem);
-  mc_rtc::log::info(vectorConf.dump(true));
 
   VecT elemVec{elem};
 
   // Try to load from element
   BOOST_CHECK(fromVectorOrElement<ElemT>(vectorConf, "elem") == elemVec);
   BOOST_CHECK(fromVectorOrElement<ElemT>(vectorConf, "elemNonExisting", elemVec) == elemVec);
-  BOOST_REQUIRE_THROW(fromVectorOrElement<ElemT>(vectorConf, "elemNonExisting"), Configuration::Exception);
-  BOOST_REQUIRE_THROW(fromVectorOrElement<ElemT>(vectorConf, "elemNonConvertible"), Configuration::Exception);
+  MC_RTC_REQUIRE_THROW(fromVectorOrElement<ElemT>(vectorConf, "elemNonExisting"), Configuration::Exception);
+  MC_RTC_REQUIRE_THROW(fromVectorOrElement<ElemT>(vectorConf, "elemNonConvertible"), Configuration::Exception);
 
   // Try to load from vector of elements
   BOOST_CHECK(fromVectorOrElement<ElemT>(vectorConf, "vector") == vec);
   BOOST_CHECK(fromVectorOrElement<ElemT>(vectorConf, "vectorNonExisting", vec) == vec);
-  BOOST_REQUIRE_THROW(fromVectorOrElement<ElemT>(vectorConf, "vectorNonExisting"), Configuration::Exception);
-  BOOST_REQUIRE_THROW(fromVectorOrElement<ElemT>(vectorConf, "vectorNonConvertible"), Configuration::Exception);
+  MC_RTC_REQUIRE_THROW(fromVectorOrElement<ElemT>(vectorConf, "vectorNonExisting"), Configuration::Exception);
+  MC_RTC_REQUIRE_THROW(fromVectorOrElement<ElemT>(vectorConf, "vectorNonConvertible"), Configuration::Exception);
 }
 
 BOOST_AUTO_TEST_CASE(TestIOUtils)

--- a/tests/testJsonIO.cpp
+++ b/tests/testJsonIO.cpp
@@ -406,12 +406,8 @@ struct AllocatorHelper<mc_rbdyn::RobotModule>
 
 BOOST_AUTO_TEST_CASE_TEMPLATE(TestJsonIO, T, test_types)
 {
-  static_assert(mc_rtc::internal::has_configuration_load_object<T>::value,
-                "No Configuration load function for this type");
-  static_assert(mc_rtc::internal::has_configuration_save_object<T>::value,
-                "No Configuration save function for this type");
-  BOOST_CHECK(mc_rtc::internal::has_configuration_load_object<T>::value);
-  BOOST_CHECK(mc_rtc::internal::has_configuration_save_object<T>::value);
+  static_assert(mc_rtc::internal::has_configuration_load_object_v<T>, "No Configuration load function for this type");
+  static_assert(mc_rtc::internal::has_configuration_save_object_v<T>, "No Configuration save function for this type");
 
   T ref = make_ref<T>();
   mc_rtc::Configuration config;


### PR DESCRIPTION
This PR introduces changes to `mc_rtc::Configuration` that will be used in a subsequent PR that introduces a schema-like structure builder to mc_rtc. It is the first of three PRs leading to `mc_rtc::Schema` introduction

The following features have been added:
- Support for loading/saving `std::variant`
- Support for intrusive methods for user-defined load/save operations (in addition to the existing and non-intrusive approach)
- Add `Configuration::find(key)`, `Configuration(key, others...)` and `Configuration.find<T>(keys, others...)`

I started to refactor the use `Configuration::has` (e.g. replace the very common usage of `if(cfg.has("foo")) { foo = cfg("foo"); do_something(foo); }` with `if(auto foo = cfg.find("foo")) { do_something(foo); }` but many of these instances will be better served by introducing Schema-like structures so I'll wait for this PR to come