### PR TITLE
[GUI] Add many form elements

### DIFF
--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -741,6 +741,24 @@ protected:
    */
   virtual void end_form_object_array_input() {}
 
+  /** Start a one-of input within a form
+   *
+   * After this call, each call related to form elements is one option offered by the one-of selector. The name of the
+   * element should be used to distinguish the selected type
+   *
+   * \p name Name of the one-of selection
+   *
+   * \p required If true, it must hold a valid value when sent
+   */
+  virtual void start_form_one_of_input(const std::string & /*name*/, bool /*required*/) {}
+
+  /** Pendant to \ref start_form_one_of_input
+   *
+   * After this call, all calls related to form elements must be interpreted as belonging to the form's parent
+   *
+   */
+  virtual void end_form_one_of_input() {}
+
   /** Called when new plot data arrives
    *
    * This should open a new plotting window with the provided title.

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -654,12 +654,15 @@ protected:
    * \p default_ Default value in the form
    *
    * \p default_from_user Default is provided by the user
+   *
+   * \p interactive Should display an interactive marker
    */
   virtual void form_point3d_input(const ElementId & /*formId*/,
                                   const std::string & /*name*/,
                                   bool /*required*/,
                                   const Eigen::Vector3d & /*default_*/,
-                                  bool /*default_from_user*/)
+                                  bool /*default_from_user*/,
+                                  bool /*interactive*/)
   {
   }
 
@@ -677,12 +680,15 @@ protected:
    * \p default_ Default value in the form
    *
    * \p default_from_user Default is provided by the user
+   *
+   * \p interactive Should display an interactive marker
    */
   virtual void form_rotation_input(const ElementId & /*formId*/,
                                    const std::string & /*name*/,
                                    bool /*required*/,
                                    const sva::PTransformd & /*default_*/,
-                                   bool /*default_from_user*/)
+                                   bool /*default_from_user*/,
+                                   bool /*interactive*/)
   {
   }
 
@@ -697,12 +703,15 @@ protected:
    * \p default_ Default value in the form
    *
    * \p default_from_user Default is provided by the user
+   *
+   * \p interactive Should display an interactive marker
    */
   virtual void form_transform_input(const ElementId & /*formId*/,
                                     const std::string & /*name*/,
                                     bool /*required*/,
                                     const sva::PTransformd & /*default_*/,
-                                    bool /*default_from_user*/)
+                                    bool /*default_from_user*/,
+                                    bool /*interactive*/)
   {
   }
 

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -643,6 +643,26 @@ protected:
   {
   }
 
+  /** A 3D point that can be edited from a Form
+   *
+   * \p formId Identifier of the form
+   *
+   * \p name Name of the entry
+   *
+   * \p required If true, it must hold a value when the form is sent
+   *
+   * \p default_ Default value in the form
+   *
+   * \p default_from_user Default is provided by the user
+   */
+  virtual void form_point3d_input(const ElementId & /*formId*/,
+                                  const std::string & /*name*/,
+                                  bool /*required*/,
+                                  const Eigen::Vector3d & /*default_*/,
+                                  bool /*default_from_user*/)
+  {
+  }
+
   /** Called when new plot data arrives
    *
    * This should open a new plotting window with the provided title.

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -781,8 +781,14 @@ protected:
    * \p name Name of the one-of selection
    *
    * \p required If true, it must hold a valid value when sent
+   *
+   * \p data Active data
    */
-  virtual void start_form_one_of_input(const std::string & /*name*/, bool /*required*/) {}
+  virtual void start_form_one_of_input(const std::string & /*name*/,
+                                       bool /*required*/,
+                                       const std::optional<std::pair<size_t, Configuration>> & /*data*/)
+  {
+  }
 
   /** Pendant to \ref start_form_one_of_input
    *

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -763,30 +763,12 @@ protected:
   {
   }
 
-  /** Pendant to \ref start_form_object_array_input
+  /** Pendant to \ref start_form_generic_array_input
    *
    * After this call, all calls related to form elements must be interpreted as belonging to the form's parent
    *
    */
   virtual void end_form_generic_array_input() {}
-
-  /** Starts an array of objects input within a form
-   *
-   * After this call, all calls related to form elements must be interpreted as describing a form to generate one member
-   * of the array
-   *
-   * \p name Name of the array this generates
-   *
-   * \p required If true, it must hold a value (can be an empty array) when the form is sent
-   */
-  virtual void start_form_object_array_input(const std::string & /*name*/, bool /*required*/) {}
-
-  /** Pendant to \ref start_form_object_array_input
-   *
-   * After this call, all calls related to form elements must be interpreted as belonging to the form's parent
-   *
-   */
-  virtual void end_form_object_array_input() {}
 
   /** Start a one-of input within a form
    *

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -730,8 +730,14 @@ protected:
    * \p name Name of the array this generates
    *
    * \p required If true, it must hold a value (can be an empty array) when the form is sent
+   *
+   * \p data Existing data in the array, must be sent along with the form if provided
    */
-  virtual void start_form_generic_array_input(const std::string & /*name*/, bool /*required*/) {}
+  virtual void start_form_generic_array_input(const std::string & /*name*/,
+                                              bool /*required*/,
+                                              std::optional<std::vector<Configuration>> /*data*/)
+  {
+  }
 
   /** Pendant to \ref start_form_object_array_input
    *

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -643,7 +643,7 @@ protected:
   {
   }
 
-  /** A 3D point that can be edited from a Form
+  /** A 3D point that can be edited within a Form
    *
    * \p formId Identifier of the form
    *
@@ -660,6 +660,49 @@ protected:
                                   bool /*required*/,
                                   const Eigen::Vector3d & /*default_*/,
                                   bool /*default_from_user*/)
+  {
+  }
+
+  /** A rotation that can be edited within a Form
+   *
+   * Note: this requires a PTransformd to place the rotation in space but only the rotation should be provided in the
+   * callback
+   *
+   * \p formId Identifier of the form
+   *
+   * \p name Name of the entry
+   *
+   * \p required If true, it must hold a value when the form is sent
+   *
+   * \p default_ Default value in the form
+   *
+   * \p default_from_user Default is provided by the user
+   */
+  virtual void form_rotation_input(const ElementId & /*formId*/,
+                                   const std::string & /*name*/,
+                                   bool /*required*/,
+                                   const sva::PTransformd & /*default_*/,
+                                   bool /*default_from_user*/)
+  {
+  }
+
+  /** A transform that can be edited within a Form
+   *
+   * \p formId Identifier of the form
+   *
+   * \p name Name of the entry
+   *
+   * \p required If true, it must hold a value when the form is sent
+   *
+   * \p default_ Default value in the form
+   *
+   * \p default_from_user Default is provided by the user
+   */
+  virtual void form_transform_input(const ElementId & /*formId*/,
+                                    const std::string & /*name*/,
+                                    bool /*required*/,
+                                    const sva::PTransformd & /*default_*/,
+                                    bool /*default_from_user*/)
   {
   }
 

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -706,6 +706,41 @@ protected:
   {
   }
 
+  /** Starts a form within a form
+   *
+   * After this call, all calls related to form elements must be interpreted as belonging to this sub-form
+   *
+   * \p name Name of the object
+   *
+   * \p required If true, it must hold a value when the form is sent
+   */
+  virtual void start_form_object_input(const std::string & /*name*/, bool /*required*/) {}
+
+  /** Pendant to \ref start_form_object_input
+   *
+   * After this call, all calls related to form elements must be interpreted as belonging to the form's parent
+   *
+   */
+  virtual void end_form_object_input() {}
+
+  /** Starts an array of objects input within a form
+   *
+   * After this call, all calls related to form elements must be interpreted as describing a form to generate one member
+   * of the array
+   *
+   * \p name Name of the array this generates
+   *
+   * \p required If true, it must hold a value (can be an empty array) when the form is sent
+   */
+  virtual void start_form_object_array_input(const std::string & /*name*/, bool /*required*/) {}
+
+  /** Pendant to \ref start_form_object_array_input
+   *
+   * After this call, all calls related to form elements must be interpreted as belonging to the form's parent
+   *
+   */
+  virtual void end_form_object_array_input() {}
+
   /** Called when new plot data arrives
    *
    * This should open a new plotting window with the provided title.

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -574,7 +574,10 @@ protected:
   {
   }
 
-  /** An array input within a form */
+  /** An array input within a form
+   *
+   * This is kept for backward compatibility, mc_rtc never calls this version and you should implement the full version
+   */
   virtual void form_array_input(const ElementId & formId,
                                 const std::string & name,
                                 bool required,
@@ -583,6 +586,18 @@ protected:
                                 bool /*default_from_user*/)
   {
     form_array_input(formId, name, required, default_, fixed_size);
+  }
+
+  /** An array input within a form */
+  virtual void form_array_input(const ElementId & formId,
+                                const std::string & name,
+                                bool required,
+                                const std::vector<std::string> & /*labels*/,
+                                const Eigen::VectorXd & default_,
+                                bool fixed_size,
+                                bool default_from_user)
+  {
+    form_array_input(formId, name, required, default_, fixed_size, default_from_user);
   }
 
   /** A combo input within a form

--- a/include/mc_control/ControllerClient.h
+++ b/include/mc_control/ControllerClient.h
@@ -723,6 +723,23 @@ protected:
    */
   virtual void end_form_object_input() {}
 
+  /** Starts a generic array input
+   *
+   * The next call related to form elements must be interpreted as describing the type of members the array expects
+   *
+   * \p name Name of the array this generates
+   *
+   * \p required If true, it must hold a value (can be an empty array) when the form is sent
+   */
+  virtual void start_form_generic_array_input(const std::string & /*name*/, bool /*required*/) {}
+
+  /** Pendant to \ref start_form_object_array_input
+   *
+   * After this call, all calls related to form elements must be interpreted as belonging to the form's parent
+   *
+   */
+  virtual void end_form_generic_array_input() {}
+
   /** Starts an array of objects input within a form
    *
    * After this call, all calls related to form elements must be interpreted as describing a form to generate one member

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -1481,9 +1481,9 @@ public:
 
   /*! \brief Add a variant object into the JSON document
    *
-   * The variant is written as [value.index(), std::get<value.index()>(value)] if it holds a value
+   * The variant is written as [value.index(), std::get<value.index()>(value)]
    *
-   * Otherwise it is written as [std::variant_npos, std::variant_npos]
+   * \throws If the variant is in valueless state
    *
    * \param key Key of the element
    *
@@ -1494,11 +1494,7 @@ public:
   {
     Configuration v = array(key, 2);
     v.push(value.index());
-    if(value.index() != std::variant_npos)
-    {
-      std::visit([&v](const auto & hold) { v.push(hold); }, value);
-    }
-    else { v.push(value.index()); }
+    std::visit([&v](const auto & hold) { v.push(hold); }, value);
   }
 
   /** Integral type conversions
@@ -1628,9 +1624,9 @@ public:
 
   /*! \brief Push a variant object into the JSON document
    *
-   * The variant is written as [value.index(), std::get<value.index()>(value)] if it holds a value
+   * The variant is written as [value.index(), std::get<value.index()>(value)]
    *
-   * Otherwise it is written as [std::variant_npos, std::variant_npos]
+   * \throws If the variant is in valueless state
    *
    * \param key Key of the element
    *
@@ -1641,11 +1637,7 @@ public:
   {
     Configuration v = array(2);
     v.push(value.index());
-    if(value.index() != std::variant_npos)
-    {
-      std::visit([&v](const auto & hold) { v.push(hold); }, value);
-    }
-    else { v.push(value.index()); }
+    std::visit([&v](const auto & hold) { v.push(hold); }, value);
   }
 
   /** Remove a given element

--- a/include/mc_rtc/MessagePackBuilder.h
+++ b/include/mc_rtc/MessagePackBuilder.h
@@ -133,31 +133,31 @@ struct MC_RTC_UTILS_DLLAPI MessagePackBuilder
 
   /** Write an Eigen::Vector2d
    *
-   * Serializes as an array of size 2
+   * Serialized as an array of size 2
    */
   void write(const Eigen::Vector2d & v);
 
   /** Write an Eigen::Vector3d
    *
-   * Serializes as an array of size 3
+   * Serialized as an array of size 3
    */
   void write(const Eigen::Vector3d & v);
 
   /** Write an Eigen::Vector4d
    *
-   * Serializes as an array of size 4
+   * Serialized as an array of size 4
    */
   void write(const Eigen::Vector4d & v);
 
   /** Write an Eigen::Vector6d
    *
-   * Serializes as an array of size 6
+   * Serialized as an array of size 6
    */
   void write(const Eigen::Vector6d & v);
 
   /** Write an Eigen::VectorXd
    *
-   * Serializes as an array of size X
+   * Serialized as an array of size X
    */
   void write(const Eigen::VectorXd & v);
 
@@ -172,19 +172,19 @@ struct MC_RTC_UTILS_DLLAPI MessagePackBuilder
 
   /** Write an Eigen::Quaterniond
    *
-   * Serializes as an array of size X
+   * Serialized as an array of size 4
    */
   void write(const Eigen::Quaterniond & q);
 
   /** Write an Eigen::Matrix3d
    *
-   * Serializes as an array of size 9
+   * Serialized as an array of size 9
    */
   void write(const Eigen::Matrix3d & m);
 
   /** Write an sva::PTransformd
    *
-   * Serializes as an array of size 12 (Matrix3d + Vector3d)
+   * Serialized as an array of size 12 (Matrix3d + Vector3d)
    */
   void write(const sva::PTransformd & pt);
 
@@ -208,7 +208,7 @@ struct MC_RTC_UTILS_DLLAPI MessagePackBuilder
 
   /** Write an mc_rtc::Configuration
    *
-   * Serialied as the JSON data it holds
+   * Serialized as the JSON data it holds
    */
   void write(const mc_rtc::Configuration & config);
 

--- a/include/mc_rtc/MessagePackBuilder.h
+++ b/include/mc_rtc/MessagePackBuilder.h
@@ -14,6 +14,7 @@
 #include <set>
 #include <string>
 #include <type_traits>
+#include <variant>
 #include <vector>
 
 namespace mc_rtc
@@ -315,6 +316,16 @@ struct MC_RTC_UTILS_DLLAPI MessagePackBuilder
   {
     start_array(sizeof...(Args));
     write_impl<0>(t);
+    finish_array();
+  }
+
+  /** Write an std::variant<Args...> */
+  template<typename... Args>
+  void write(const std::variant<Args...> & value)
+  {
+    start_array(2);
+    write(value.index());
+    std::visit([this](const auto & v) { write(v); }, value);
     finish_array();
   }
 

--- a/include/mc_rtc/gui/Form.h
+++ b/include/mc_rtc/gui/Form.h
@@ -367,6 +367,36 @@ struct FormObjectInput : public FormElement<FormObjectInput, Elements::Form>, de
   {
   }
 
+  static constexpr bool is_dynamic() { return true; }
+
+  static constexpr size_t write_size_() { return 1; }
+
+  void write_(mc_rtc::MessagePackBuilder & builder) { FormElements::write_impl(builder); }
+};
+
+/** Creates an inputs to build a generic array
+ *
+ * The element you pass to this element will be used to build the list, e.g.:
+ * - FormCheckbox will output a list of booleans
+ * - FormStringInput a list of strings
+ * - FormPoint3DInput a list of 3D points
+ *
+ * The name of the element you pass to this function has no effect
+ *
+ * For more complex objects you can use a FormObjectInput or use FormObjectArrayInput which is more explicit
+ */
+struct FormGenericArrayInput : public FormElement<FormGenericArrayInput, Elements::GenericArray>,
+                               private details::FormElements
+{
+  template<typename Element>
+  FormGenericArrayInput(const std::string & name, bool required, Element && element)
+  : FormElement<FormGenericArrayInput, Elements::GenericArray>(name, required),
+    FormElements(std::forward<Element>(element))
+  {
+  }
+
+  static constexpr bool is_dynamic() { return true; }
+
   static constexpr size_t write_size_() { return 1; }
 
   void write_(mc_rtc::MessagePackBuilder & builder) { FormElements::write_impl(builder); }
@@ -384,6 +414,8 @@ struct FormObjectArrayInput : public FormElement<FormObjectArrayInput, Elements:
   : FormElement<FormObjectArrayInput, Elements::ObjectArray>(name, required), FormElements(std::forward<Args>(args)...)
   {
   }
+
+  static constexpr bool is_dynamic() { return true; }
 
   static constexpr size_t write_size_() { return 1; }
 
@@ -403,6 +435,8 @@ struct FormOneOfInput : public FormElement<FormOneOfInput, Elements::OneOf>, det
   : FormElement<FormOneOfInput, Elements::OneOf>(name, required), FormElements(std::forward<Args>(args)...)
   {
   }
+
+  static constexpr bool is_dynamic() { return true; }
 
   static constexpr size_t write_size_() { return 1; }
 

--- a/include/mc_rtc/gui/Form.h
+++ b/include/mc_rtc/gui/Form.h
@@ -354,6 +354,11 @@ private:
   bool send_index_;
 };
 
+/** Creates a form within another form
+ *
+ * If the object is required then it will be received in the callback and its own required elements are also contained
+ * in the object
+ */
 struct FormObjectInput : public FormElement<FormObjectInput, Elements::Form>, details::FormElements
 {
   template<typename... Args>
@@ -367,11 +372,35 @@ struct FormObjectInput : public FormElement<FormObjectInput, Elements::Form>, de
   void write_(mc_rtc::MessagePackBuilder & builder) { FormElements::write_impl(builder); }
 };
 
+/** Creates an inputs to build an array of objects
+ *
+ * If the array is required the list is always sent even if it is empty otherwise it is only sent if it has at least one
+ * item
+ */
 struct FormObjectArrayInput : public FormElement<FormObjectArrayInput, Elements::ObjectArray>, details::FormElements
 {
   template<typename... Args>
   FormObjectArrayInput(const std::string & name, bool required, Args &&... args)
   : FormElement<FormObjectArrayInput, Elements::ObjectArray>(name, required), FormElements(std::forward<Args>(args)...)
+  {
+  }
+
+  static constexpr size_t write_size_() { return 1; }
+
+  void write_(mc_rtc::MessagePackBuilder & builder) { FormElements::write_impl(builder); }
+};
+
+/** Creates a one-of selector
+ *
+ * Only one of the item provided to this input will be active, the item name will tell which was selected
+ *
+ * If required, one of the element must be selected
+ */
+struct FormOneOfInput : public FormElement<FormOneOfInput, Elements::OneOf>, details::FormElements
+{
+  template<typename... Args>
+  FormOneOfInput(const std::string & name, bool required, Args &&... args)
+  : FormElement<FormOneOfInput, Elements::OneOf>(name, required), FormElements(std::forward<Args>(args)...)
   {
   }
 

--- a/include/mc_rtc/gui/Form.h
+++ b/include/mc_rtc/gui/Form.h
@@ -387,8 +387,7 @@ struct FormObjectInput : public FormElement<FormObjectInput, Elements::Form>, de
  *
  * For more complex objects you can use a FormObjectInput or use FormObjectArrayInput which is more explicit
  */
-struct FormGenericArrayInput : public FormElement<FormGenericArrayInput, Elements::GenericArray>,
-                               private details::FormElements
+struct FormGenericArrayInput : public FormElement<FormGenericArrayInput, Elements::GenericArray>, details::FormElements
 {
   FormGenericArrayInput(const std::string & name, bool required)
   : FormElement<FormGenericArrayInput, Elements::GenericArray>(name, required)
@@ -402,18 +401,15 @@ struct FormGenericArrayInput : public FormElement<FormGenericArrayInput, Element
   {
   }
 
-  template<typename T>
-  void addElement(T && element)
-  {
-    if(count_ == 1) { mc_rtc::log::error_and_throw("FormGenericArrayInput can only contain one element"); }
-    details::FormElements::addElement(std::forward<T>(element));
-  }
-
   static constexpr bool is_dynamic() { return true; }
 
   static constexpr size_t write_size_() { return 1; }
 
-  void write_(mc_rtc::MessagePackBuilder & builder) { FormElements::write_impl(builder); }
+  void write_(mc_rtc::MessagePackBuilder & builder)
+  {
+    if(count_ != 1) { mc_rtc::log::error_and_throw("FormGenericArrayInput must have exactly one element"); }
+    FormElements::write_impl(builder);
+  }
 };
 
 /** Creates an inputs to build an array of objects

--- a/include/mc_rtc/gui/Form.h
+++ b/include/mc_rtc/gui/Form.h
@@ -213,6 +213,8 @@ MAKE_DATA_INPUT_HELPER(int, Elements::IntegerInput, FormIntegerInput)
 MAKE_DATA_INPUT_HELPER(double, Elements::NumberInput, FormNumberInput)
 MAKE_DATA_INPUT_HELPER(std::string, Elements::StringInput, FormStringInput)
 MAKE_DATA_INPUT_HELPER(Eigen::Vector3d, Elements::Point3D, FormPoint3DInput)
+MAKE_DATA_INPUT_HELPER(sva::PTransformd, Elements::Rotation, FormRotationInput)
+MAKE_DATA_INPUT_HELPER(sva::PTransformd, Elements::Transform, FormTransformInput)
 
 #undef MAKE_DATA_INPUT_HELPER
 

--- a/include/mc_rtc/gui/Form.h
+++ b/include/mc_rtc/gui/Form.h
@@ -481,10 +481,10 @@ struct FormObjectInput : public FormElement<FormObjectInput, Elements::Form>, de
  * - FormCheckbox will output a list of booleans
  * - FormStringInput a list of strings
  * - FormPoint3DInput a list of 3D points
+ * - FormObjectInput will output a list of objects
  *
  * The name of the element you pass to this function has no effect
  *
- * For more complex objects you can use a FormObjectInput or use FormObjectArrayInput which is more explicit
  */
 template<typename T = details::VoidValue>
 struct FormGenericArrayInput : public FormElement<FormGenericArrayInput<T>, Elements::GenericArray>,
@@ -516,26 +516,6 @@ struct FormGenericArrayInput : public FormElement<FormGenericArrayInput<T>, Elem
 
 private:
   details::CallbackOrValue<T> data_;
-};
-
-/** Creates an inputs to build an array of objects
- *
- * If the array is required the list is always sent even if it is empty otherwise it is only sent if it has at least one
- * item
- */
-struct FormObjectArrayInput : public FormElement<FormObjectArrayInput, Elements::ObjectArray>, details::FormElements
-{
-  template<typename... Args>
-  FormObjectArrayInput(const std::string & name, bool required, Args &&... args)
-  : FormElement<FormObjectArrayInput, Elements::ObjectArray>(name, required), FormElements(std::forward<Args>(args)...)
-  {
-  }
-
-  static constexpr bool is_dynamic() { return true; }
-
-  static constexpr size_t write_size_() { return 1; }
-
-  void write_(mc_rtc::MessagePackBuilder & builder) { FormElements::write_impl(builder); }
 };
 
 /** Creates a one-of selector

--- a/include/mc_rtc/gui/Form.h
+++ b/include/mc_rtc/gui/Form.h
@@ -212,6 +212,7 @@ MAKE_DATA_INPUT_HELPER(bool, Elements::Checkbox, FormCheckbox)
 MAKE_DATA_INPUT_HELPER(int, Elements::IntegerInput, FormIntegerInput)
 MAKE_DATA_INPUT_HELPER(double, Elements::NumberInput, FormNumberInput)
 MAKE_DATA_INPUT_HELPER(std::string, Elements::StringInput, FormStringInput)
+MAKE_DATA_INPUT_HELPER(Eigen::Vector3d, Elements::Point3D, FormPoint3DInput)
 
 #undef MAKE_DATA_INPUT_HELPER
 

--- a/include/mc_rtc/gui/Form.h
+++ b/include/mc_rtc/gui/Form.h
@@ -7,6 +7,8 @@
 #include <mc_rtc/gui/details/traits.h>
 #include <mc_rtc/gui/elements.h>
 
+#include <mc_rtc/logging.h>
+
 namespace mc_rtc::gui
 {
 
@@ -388,11 +390,23 @@ struct FormObjectInput : public FormElement<FormObjectInput, Elements::Form>, de
 struct FormGenericArrayInput : public FormElement<FormGenericArrayInput, Elements::GenericArray>,
                                private details::FormElements
 {
+  FormGenericArrayInput(const std::string & name, bool required)
+  : FormElement<FormGenericArrayInput, Elements::GenericArray>(name, required)
+  {
+  }
+
   template<typename Element>
   FormGenericArrayInput(const std::string & name, bool required, Element && element)
   : FormElement<FormGenericArrayInput, Elements::GenericArray>(name, required),
     FormElements(std::forward<Element>(element))
   {
+  }
+
+  template<typename T>
+  void addElement(T && element)
+  {
+    if(count_ == 1) { mc_rtc::log::error_and_throw("FormGenericArrayInput can only contain one element"); }
+    details::FormElements::addElement(std::forward<T>(element));
   }
 
   static constexpr bool is_dynamic() { return true; }

--- a/include/mc_rtc/gui/details/traits.h
+++ b/include/mc_rtc/gui/details/traits.h
@@ -14,6 +14,7 @@
 
 #include <array>
 #include <type_traits>
+#include <variant>
 #include <vector>
 
 namespace mc_rtc::gui::details
@@ -214,5 +215,19 @@ auto GetValueOrCallbackValue(const T & value_or_cb)
   if constexpr(std::is_invocable_v<T>) { return value_or_cb(); }
   else { return value_or_cb; }
 }
+
+/** Type trait to detect a variant */
+template<typename T>
+struct is_variant : public std::false_type
+{
+};
+
+template<typename... Args>
+struct is_variant<std::variant<Args...>> : public std::true_type
+{
+};
+
+template<typename T>
+inline constexpr bool is_variant_v = is_variant<T>::value;
 
 } // namespace mc_rtc::gui::details

--- a/include/mc_rtc/gui/details/traits.h
+++ b/include/mc_rtc/gui/details/traits.h
@@ -116,6 +116,7 @@ template<typename T>
 struct Labels
 {
   static constexpr bool has_labels = false;
+  inline static const std::vector<std::string> labels = {};
 };
 
 template<>

--- a/include/mc_rtc/gui/elements.h
+++ b/include/mc_rtc/gui/elements.h
@@ -47,6 +47,7 @@ enum class Elements
   Visual,
   PolyhedronTrianglesList,
   PolyhedronVerticesTriangles,
+  GenericArray,
   ObjectArray,
   OneOf
 };

--- a/include/mc_rtc/gui/elements.h
+++ b/include/mc_rtc/gui/elements.h
@@ -46,7 +46,8 @@ enum class Elements
   Robot,
   Visual,
   PolyhedronTrianglesList,
-  PolyhedronVerticesTriangles
+  PolyhedronVerticesTriangles,
+  ObjectArray
 };
 
 /** Element is the common class for every element's type available in the

--- a/include/mc_rtc/gui/elements.h
+++ b/include/mc_rtc/gui/elements.h
@@ -48,7 +48,6 @@ enum class Elements
   PolyhedronTrianglesList,
   PolyhedronVerticesTriangles,
   GenericArray,
-  ObjectArray,
   OneOf
 };
 

--- a/include/mc_rtc/gui/elements.h
+++ b/include/mc_rtc/gui/elements.h
@@ -47,7 +47,8 @@ enum class Elements
   Visual,
   PolyhedronTrianglesList,
   PolyhedronVerticesTriangles,
-  ObjectArray
+  ObjectArray,
+  OneOf
 };
 
 /** Element is the common class for every element's type available in the

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -757,6 +757,9 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
       case Elements::DataComboInput:
         form_data_combo_input(id, name, required, el[3], el[4]);
         break;
+      case Elements::Point3D:
+        form_point3d_input(id, name, required, el[3], el[4]);
+        break;
       default:
         mc_rtc::log::error("Form cannot handle element of type {}", static_cast<int>(type));
     }

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -760,6 +760,12 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
       case Elements::Point3D:
         form_point3d_input(id, name, required, el[3], el[4]);
         break;
+      case Elements::Rotation:
+        form_rotation_input(id, name, required, el[3], el[4]);
+        break;
+      case Elements::Transform:
+        form_transform_input(id, name, required, el[3], el[4]);
+        break;
       default:
         mc_rtc::log::error("Form cannot handle element of type {}", static_cast<int>(type));
     }

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -785,7 +785,9 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
               name);
           break;
         }
-        start_form_generic_array_input(name, required);
+        std::optional<std::vector<Configuration>> data = std::nullopt;
+        if(el[4].isArray()) { data = el[4]; }
+        start_form_generic_array_input(name, required, data);
         handle_form(id, el[3]);
         end_form_generic_array_input();
         break;

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -751,7 +751,8 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
         form_string_input(id, name, required, el[3], el.size() > 4 ? el[4] : true);
         break;
       case Elements::ArrayInput:
-        form_array_input(id, name, required, el[3], el[4], el.size() > 5 ? el[5] : true);
+        form_array_input(id, name, required, el.size() > 6 ? el[6] : std::vector<std::string>{}, el[3], el[4],
+                         el.size() > 5 ? el[5] : true);
         break;
       case Elements::ComboInput:
         form_combo_input(id, name, required, el[3], el[4], el.size() > 5 ? el[5] : -1);

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -775,6 +775,21 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
         end_form_object_input();
         break;
       }
+      case Elements::GenericArray:
+      {
+        if(el[3].size() != 1)
+        {
+          mc_rtc::log::error(
+              "GenericArray ({}) has more than one element describing its content, perhaps you meant to use "
+              "ObjectArray instead",
+              name);
+          break;
+        }
+        start_form_generic_array_input(name, required);
+        handle_form(id, el[3]);
+        end_form_generic_array_input();
+        break;
+      }
       case Elements::ObjectArray:
       {
         start_form_object_array_input(name, required);

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -784,7 +784,7 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
           break;
         }
         std::optional<std::vector<Configuration>> data = std::nullopt;
-        if(el[4].isArray()) { data = el[4]; }
+        if(el[4].isArray()) { data = el[4].operator std::vector<Configuration>(); }
         start_form_generic_array_input(name, required, data);
         handle_form(id, el[3]);
         end_form_generic_array_input();
@@ -793,7 +793,7 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
       case Elements::OneOf:
       {
         std::optional<std::pair<size_t, Configuration>> data = std::nullopt;
-        if(el[3].isArray()) { data = el[3]; }
+        if(el[3].isArray()) { data = el[3].operator std::pair<size_t, Configuration>(); }
         start_form_one_of_input(name, required, data);
         handle_form(id, el[4]);
         end_form_one_of_input();

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -780,10 +780,7 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
       {
         if(el[3].size() != 1)
         {
-          mc_rtc::log::error(
-              "GenericArray ({}) has more than one element describing its content, perhaps you meant to use "
-              "ObjectArray instead",
-              name);
+          mc_rtc::log::error("GenericArray ({}) has more than one element describing its content!", name);
           break;
         }
         std::optional<std::vector<Configuration>> data = std::nullopt;
@@ -791,13 +788,6 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
         start_form_generic_array_input(name, required, data);
         handle_form(id, el[3]);
         end_form_generic_array_input();
-        break;
-      }
-      case Elements::ObjectArray:
-      {
-        start_form_object_array_input(name, required);
-        handle_form(id, el[3]);
-        end_form_object_array_input();
         break;
       }
       case Elements::OneOf:

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -782,6 +782,13 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
         end_form_object_array_input();
         break;
       }
+      case Elements::OneOf:
+      {
+        start_form_one_of_input(name, required);
+        handle_form(id, el[3]);
+        end_form_one_of_input();
+        break;
+      }
       default:
         mc_rtc::log::error("Form cannot handle element of type {}", static_cast<int>(type));
     }

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -801,8 +801,10 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
       }
       case Elements::OneOf:
       {
-        start_form_one_of_input(name, required);
-        handle_form(id, el[3]);
+        std::optional<std::pair<size_t, Configuration>> data = std::nullopt;
+        if(el[3].isArray()) { data = el[3]; }
+        start_form_one_of_input(name, required, data);
+        handle_form(id, el[4]);
         end_form_one_of_input();
         break;
       }

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -360,8 +360,11 @@ void ControllerClient::handle_widget(const ElementId & id, const mc_rtc::Configu
         schema(id, data[3]);
         break;
       case Elements::Form:
+      {
+        form(id);
         handle_form(id, data[3]);
         break;
+      }
       case Elements::XYTheta:
         handle_xytheta(id, data);
         break;
@@ -726,7 +729,6 @@ void ControllerClient::handle_xytheta(const ElementId & id, const mc_rtc::Config
 
 void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configuration & gui)
 {
-  form(id);
   for(size_t i = 0; i < gui.size(); ++i)
   {
     auto el = gui[i];
@@ -766,6 +768,20 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
       case Elements::Transform:
         form_transform_input(id, name, required, el[3], el[4]);
         break;
+      case Elements::Form:
+      {
+        start_form_object_input(name, required);
+        handle_form(id, el[3]);
+        end_form_object_input();
+        break;
+      }
+      case Elements::ObjectArray:
+      {
+        start_form_object_array_input(name, required);
+        handle_form(id, el[3]);
+        end_form_object_array_input();
+        break;
+      }
       default:
         mc_rtc::log::error("Form cannot handle element of type {}", static_cast<int>(type));
     }

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -760,13 +760,13 @@ void ControllerClient::handle_form(const ElementId & id, const mc_rtc::Configura
         form_data_combo_input(id, name, required, el[3], el[4]);
         break;
       case Elements::Point3D:
-        form_point3d_input(id, name, required, el[3], el[4]);
+        form_point3d_input(id, name, required, el[3], el[4], el[5]);
         break;
       case Elements::Rotation:
-        form_rotation_input(id, name, required, el[3], el[4]);
+        form_rotation_input(id, name, required, el[3], el[4], el[5]);
         break;
       case Elements::Transform:
-        form_transform_input(id, name, required, el[3], el[4]);
+        form_transform_input(id, name, required, el[3], el[4], el[5]);
         break;
       case Elements::Form:
       {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -226,14 +226,19 @@ mc_rtc_test(test_mc_rbdyn mc_rbdyn)
 # -- Network test -- #
 # ######################################################################################
 
-add_executable(dummyClient dummyClient.cpp)
-set_target_properties(dummyClient PROPERTIES FOLDER tests/GUI)
-target_link_libraries(dummyClient PUBLIC mc_control_client)
+add_executable(gui_SampleClient gui_SampleClient.cpp)
+set_target_properties(gui_SampleClient PROPERTIES FOLDER tests/GUI)
+target_link_libraries(gui_SampleClient PUBLIC mc_control_client)
 
-add_executable(dummyServer dummyServer.cpp)
-target_include_directories(dummyServer PRIVATE ${CONFIG_HEADER_INCLUDE_DIR})
-set_target_properties(dummyServer PROPERTIES FOLDER tests/GUI)
-target_link_libraries(dummyServer PUBLIC mc_control)
+add_executable(gui_SampleServer gui_SampleServer.cpp)
+target_include_directories(gui_SampleServer PRIVATE ${CONFIG_HEADER_INCLUDE_DIR})
+set_target_properties(gui_SampleServer PROPERTIES FOLDER tests/GUI)
+target_link_libraries(gui_SampleServer PUBLIC mc_control)
+
+add_executable(gui_AdvancedForm gui_AdvancedForm.cpp)
+target_include_directories(gui_AdvancedForm PRIVATE ${CONFIG_HEADER_INCLUDE_DIR})
+set_target_properties(gui_AdvancedForm PROPERTIES FOLDER tests/GUI)
+target_link_libraries(gui_AdvancedForm PUBLIC mc_control)
 
 # ######################################################################################
 # -- Filters test -- #

--- a/tests/gui_AdvancedForm.cpp
+++ b/tests/gui_AdvancedForm.cpp
@@ -14,6 +14,16 @@ struct AdvancedFormServer : public TestServer
                            mc_rtc::gui::FormPoint3DInput("Point3D", true, Eigen::Vector3d::Zero()),
                            mc_rtc::gui::FormRotationInput("Rotation", true, {Eigen::Vector3d(1, 0, 0)}),
                            mc_rtc::gui::FormTransformInput("Transform", true, {Eigen::Vector3d(0, 0, 1)})));
+    builder.addElement(
+        {"3D elements (persistent)"},
+        mc_rtc::gui::Form(
+            "Send data",
+            [this](const mc_rtc::Configuration & data)
+            {
+              callback(data);
+              point_ = data("Point3D");
+            },
+            mc_rtc::gui::FormPoint3DInput("Point3D", true, [this]() -> const Eigen::Vector3d & { return point_; })));
     builder.addElement({"Object"},
                        mc_rtc::gui::Form(
                            "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
@@ -66,6 +76,7 @@ struct AdvancedFormServer : public TestServer
   }
 
   std::vector<std::string> str_vector_ = {"a", "b", "c", "d"};
+  Eigen::Vector3d point_ = Eigen::Vector3d::Ones();
 };
 
 int main()

--- a/tests/gui_AdvancedForm.cpp
+++ b/tests/gui_AdvancedForm.cpp
@@ -24,6 +24,23 @@ struct AdvancedFormServer : public TestServer
                                                 "array of objects", true,
                                                 mc_rtc::gui::FormComboInput("name", true, {"a", "b", "c", "d"}),
                                                 mc_rtc::gui::FormNumberInput("number", false, 42.42))));
+    builder.addElement(
+        {"GenericArray"},
+        mc_rtc::gui::Form(
+            "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+            mc_rtc::gui::FormGenericArrayInput("array of strings", true, mc_rtc::gui::FormStringInput("name", true))));
+    builder.addElement(
+        {"Trajectory maker", "Point3D"},
+        mc_rtc::gui::Form(
+            "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+            mc_rtc::gui::FormGenericArrayInput("trajectory", true,
+                                               mc_rtc::gui::FormPoint3DInput("point", true, Eigen::Vector3d::Zero()))));
+    builder.addElement(
+        {"Trajectory maker", "Transform"},
+        mc_rtc::gui::Form(
+            "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+            mc_rtc::gui::FormGenericArrayInput(
+                "trajectory", true, mc_rtc::gui::FormTransformInput("point", true, sva::PTransformd::Identity()))));
     builder.addElement({"OneOf"},
                        mc_rtc::gui::Form(
                            "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },

--- a/tests/gui_AdvancedForm.cpp
+++ b/tests/gui_AdvancedForm.cpp
@@ -28,12 +28,14 @@ struct AdvancedFormServer : public TestServer
                        mc_rtc::gui::Form(
                            "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
                            mc_rtc::gui::FormObjectInput("nested", true, mc_rtc::gui::FormStringInput("name", true))));
-    builder.addElement({"ObjectArray"}, mc_rtc::gui::Form(
-                                            "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
-                                            mc_rtc::gui::FormObjectArrayInput(
-                                                "array of objects", true,
-                                                mc_rtc::gui::FormComboInput("name", true, {"a", "b", "c", "d"}),
-                                                mc_rtc::gui::FormNumberInput("number", false, 42.42))));
+    builder.addElement({"ObjectArray"},
+                       mc_rtc::gui::Form(
+                           "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+                           mc_rtc::gui::FormGenericArrayInput(
+                               "array of objects", true,
+                               mc_rtc::gui::FormObjectInput(
+                                   "object", true, mc_rtc::gui::FormComboInput("name", true, {"a", "b", "c", "d"}),
+                                   mc_rtc::gui::FormNumberInput("number", false, 42.42)))));
     builder.addElement(
         {"GenericArray"},
         mc_rtc::gui::Form(

--- a/tests/gui_AdvancedForm.cpp
+++ b/tests/gui_AdvancedForm.cpp
@@ -8,11 +8,16 @@ struct AdvancedFormServer : public TestServer
 {
   AdvancedFormServer()
   {
-    builder.addElement({}, mc_rtc::gui::Form(
-                               "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
-                               mc_rtc::gui::FormPoint3DInput("Point3D", true, Eigen::Vector3d::Zero()),
-                               mc_rtc::gui::FormRotationInput("Rotation", true, {Eigen::Vector3d(1, 0, 0)}),
-                               mc_rtc::gui::FormTransformInput("Transform", true, {Eigen::Vector3d(0, 0, 1)})));
+    builder.addElement(
+        {}, mc_rtc::gui::Form(
+                "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+                mc_rtc::gui::FormPoint3DInput("Point3D", true, Eigen::Vector3d::Zero()),
+                mc_rtc::gui::FormRotationInput("Rotation", true, {Eigen::Vector3d(1, 0, 0)}),
+                mc_rtc::gui::FormTransformInput("Transform", true, {Eigen::Vector3d(0, 0, 1)}),
+                mc_rtc::gui::FormObjectInput("nested", true, mc_rtc::gui::FormStringInput("name", true)),
+                mc_rtc::gui::FormObjectArrayInput("array of objects", true,
+                                                  mc_rtc::gui::FormComboInput("name", true, {"a", "b", "c", "d"}),
+                                                  mc_rtc::gui::FormNumberInput("number", false, 42.42))));
   }
 
   void callback(const mc_rtc::Configuration & data)

--- a/tests/gui_AdvancedForm.cpp
+++ b/tests/gui_AdvancedForm.cpp
@@ -32,7 +32,12 @@ struct AdvancedFormServer : public TestServer
     builder.addElement(
         {"GenericArray with data"},
         mc_rtc::gui::Form(
-            "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+            "Send data",
+            [this](const mc_rtc::Configuration & data)
+            {
+              callback(data);
+              str_vector_ = data("array of strings");
+            },
             mc_rtc::gui::FormGenericArrayInput("array of strings", true, mc_rtc::gui::FormStringInput("name", true),
                                                [this]() -> const std::vector<std::string> & { return str_vector_; })));
     builder.addElement(

--- a/tests/gui_AdvancedForm.cpp
+++ b/tests/gui_AdvancedForm.cpp
@@ -8,16 +8,28 @@ struct AdvancedFormServer : public TestServer
 {
   AdvancedFormServer()
   {
-    builder.addElement(
-        {}, mc_rtc::gui::Form(
-                "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
-                mc_rtc::gui::FormPoint3DInput("Point3D", true, Eigen::Vector3d::Zero()),
-                mc_rtc::gui::FormRotationInput("Rotation", true, {Eigen::Vector3d(1, 0, 0)}),
-                mc_rtc::gui::FormTransformInput("Transform", true, {Eigen::Vector3d(0, 0, 1)}),
-                mc_rtc::gui::FormObjectInput("nested", true, mc_rtc::gui::FormStringInput("name", true)),
-                mc_rtc::gui::FormObjectArrayInput("array of objects", true,
-                                                  mc_rtc::gui::FormComboInput("name", true, {"a", "b", "c", "d"}),
-                                                  mc_rtc::gui::FormNumberInput("number", false, 42.42))));
+    builder.addElement({"3D elements"},
+                       mc_rtc::gui::Form(
+                           "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+                           mc_rtc::gui::FormPoint3DInput("Point3D", true, Eigen::Vector3d::Zero()),
+                           mc_rtc::gui::FormRotationInput("Rotation", true, {Eigen::Vector3d(1, 0, 0)}),
+                           mc_rtc::gui::FormTransformInput("Transform", true, {Eigen::Vector3d(0, 0, 1)})));
+    builder.addElement({"Object"},
+                       mc_rtc::gui::Form(
+                           "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+                           mc_rtc::gui::FormObjectInput("nested", true, mc_rtc::gui::FormStringInput("name", true))));
+    builder.addElement({"ObjectArray"}, mc_rtc::gui::Form(
+                                            "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+                                            mc_rtc::gui::FormObjectArrayInput(
+                                                "array of objects", true,
+                                                mc_rtc::gui::FormComboInput("name", true, {"a", "b", "c", "d"}),
+                                                mc_rtc::gui::FormNumberInput("number", false, 42.42))));
+    builder.addElement({"OneOf"},
+                       mc_rtc::gui::Form(
+                           "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+                           mc_rtc::gui::FormOneOfInput("oneof", true, mc_rtc::gui::FormCheckbox("bool", true, false),
+                                                       mc_rtc::gui::FormNumberInput("number", true, 42.42),
+                                                       mc_rtc::gui::FormStringInput("string", true, "empty"))));
   }
 
   void callback(const mc_rtc::Configuration & data)

--- a/tests/gui_AdvancedForm.cpp
+++ b/tests/gui_AdvancedForm.cpp
@@ -30,6 +30,12 @@ struct AdvancedFormServer : public TestServer
             "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
             mc_rtc::gui::FormGenericArrayInput("array of strings", true, mc_rtc::gui::FormStringInput("name", true))));
     builder.addElement(
+        {"GenericArray with data"},
+        mc_rtc::gui::Form(
+            "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+            mc_rtc::gui::FormGenericArrayInput("array of strings", true, mc_rtc::gui::FormStringInput("name", true),
+                                               [this]() -> const std::vector<std::string> & { return str_vector_; })));
+    builder.addElement(
         {"Trajectory maker", "Point3D"},
         mc_rtc::gui::Form(
             "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
@@ -53,6 +59,8 @@ struct AdvancedFormServer : public TestServer
   {
     mc_rtc::log::info("Data from callback:\n{}", data.dump(true, true));
   }
+
+  std::vector<std::string> str_vector_ = {"a", "b", "c", "d"};
 };
 
 int main()

--- a/tests/gui_AdvancedForm.cpp
+++ b/tests/gui_AdvancedForm.cpp
@@ -68,6 +68,18 @@ struct AdvancedFormServer : public TestServer
                            mc_rtc::gui::FormOneOfInput("oneof", true, mc_rtc::gui::FormCheckbox("bool", true, false),
                                                        mc_rtc::gui::FormNumberInput("number", true, 42.42),
                                                        mc_rtc::gui::FormStringInput("string", true, "empty"))));
+    builder.addElement({"OneOf with data"}, mc_rtc::gui::Form(
+                                                "Send data",
+                                                [this](const mc_rtc::Configuration & data)
+                                                {
+                                                  variant_ = data("oneof");
+                                                  callback(data);
+                                                },
+                                                mc_rtc::gui::FormOneOfInput(
+                                                    "oneof", true, [this]() -> const variant_t & { return variant_; },
+                                                    mc_rtc::gui::FormCheckbox("bool", true, false),
+                                                    mc_rtc::gui::FormNumberInput("number", true, 42.42),
+                                                    mc_rtc::gui::FormStringInput("string", true, "empty"))));
   }
 
   void callback(const mc_rtc::Configuration & data)
@@ -77,6 +89,8 @@ struct AdvancedFormServer : public TestServer
 
   std::vector<std::string> str_vector_ = {"a", "b", "c", "d"};
   Eigen::Vector3d point_ = Eigen::Vector3d::Ones();
+  using variant_t = std::variant<bool, double, std::string>;
+  variant_t variant_ = std::string("hello");
 };
 
 int main()

--- a/tests/gui_AdvancedForm.cpp
+++ b/tests/gui_AdvancedForm.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015-2023 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#include "gui_TestServer.h"
+
+struct AdvancedFormServer : public TestServer
+{
+  AdvancedFormServer()
+  {
+    builder.addElement({}, mc_rtc::gui::Form(
+                               "Send data", [this](const mc_rtc::Configuration & data) { callback(data); },
+                               mc_rtc::gui::FormPoint3DInput("Point3D", true, Eigen::Vector3d::Zero()),
+                               mc_rtc::gui::FormRotationInput("Rotation", true, {Eigen::Vector3d(1, 0, 0)}),
+                               mc_rtc::gui::FormTransformInput("Transform", true, {Eigen::Vector3d(0, 0, 1)})));
+  }
+
+  void callback(const mc_rtc::Configuration & data)
+  {
+    mc_rtc::log::info("Data from callback:\n{}", data.dump(true, true));
+  }
+};
+
+int main()
+{
+  AdvancedFormServer server;
+  server.loop();
+  return 0;
+}

--- a/tests/gui_SampleClient.cpp
+++ b/tests/gui_SampleClient.cpp
@@ -25,35 +25,35 @@ std::string cat2str(const std::vector<std::string> & cat)
 
 } // namespace
 
-struct DummyControllerClient : public mc_control::ControllerClient
+struct SampleControllerClient : public mc_control::ControllerClient
 {
-  DummyControllerClient();
+  SampleControllerClient();
 
   void join();
 
   void category(const std::vector<std::string> & category, const std::string & name) override;
 };
 
-DummyControllerClient::DummyControllerClient()
+SampleControllerClient::SampleControllerClient()
 : mc_control::ControllerClient("ipc:///tmp/mc_rtc_pub.ipc", "ipc:///tmp/mc_rtc_rep.ipc")
 {
   start();
 }
 
-void DummyControllerClient::join()
+void SampleControllerClient::join()
 {
   while(run_) { std::this_thread::sleep_for(std::chrono::seconds(1)); }
   stop();
 }
 
-void DummyControllerClient::category(const std::vector<std::string> & category, const std::string & name)
+void SampleControllerClient::category(const std::vector<std::string> & category, const std::string & name)
 {
   mc_rtc::log::info("Create new category {} in {}", name, cat2str(category));
 }
 
 int main()
 {
-  DummyControllerClient client;
+  SampleControllerClient client;
   client.join();
   return 0;
 }

--- a/tests/gui_TestServer.h
+++ b/tests/gui_TestServer.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2023 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_control/ControllerServer.h>
+
+#include <mc_rtc/gui.h>
+
+#include <chrono>
+#include <thread>
+
+#ifndef M_PI
+#  include <boost/math/constants/constants.hpp>
+#  define M_PI boost::math::constants::pi<double>()
+#endif
+
+struct TestServer
+{
+  virtual void publish()
+  {
+    server.handle_requests(builder);
+    server.publish(builder);
+    t_ += 0.005;
+  }
+
+  mc_control::ControllerServer server{0.005, 0.05, {"ipc:///tmp/mc_rtc_pub.ipc"}, {"ipc:///tmp/mc_rtc_rep.ipc"}};
+  mc_rtc::gui::StateBuilder builder;
+  double t_ = 0.0;
+
+  void loop()
+  {
+    while(1)
+    {
+      auto now = std::chrono::high_resolution_clock::now();
+      publish();
+      std::this_thread::sleep_until(now + std::chrono::milliseconds(5));
+    }
+  }
+};


### PR DESCRIPTION
Add multiple elements to form more complex forms in mc_rtc GUI.

This is the second of three PR introducing Schema-like structures in mc_rtc

This PR adds the following elements to form:
- `FormPoint3DInput`, `FormTransformInput` and `FormRotationInput` allow interactive 3D elements in a Form
- `FormObjectInput` allows to nest a form inside a form
- `FormGenericArrayInput` allows to create an array of arbitrary objects into a form
- `FormOneOfInput` lets you create a form that nest one of the specified form (the target is to support `variant` integration in a form)

These features are supported in a branch of mc_rtc-imgui and mc_rtc_ros and I will open PR once this gets merged