### PR TITLE
[JointSensor] include motor status property

### DIFF
--- a/include/mc_control/mc_global_controller.h
+++ b/include/mc_control/mc_global_controller.h
@@ -600,6 +600,42 @@ public:
    * \throws If the specified robot does not exist
    */
   void setJointMotorCurrents(const std::string & robotName, const std::map<std::string, double> & currents);
+
+  /*! \brief Motor status provided by the JointSensor for the main robot (sets control+real)
+   *
+   * \param joint name of the joint to which sensor is attached
+   * \param status motor ON/OFF status
+   * \throws If the robot does not have any JointSensor at joint
+   */
+  void setJointMotorStatus(const std::string & joint, bool status);
+
+  /*! \brief Motor status provided by the JointSensor for the specified robot (sets control+real)
+   *
+   * \param robotName Name of the robot to which the sensor values will be assigned.
+   * A robot with that name must exist in both robots() and realRobots() instances.
+   * \param joint name of the joint to which sensor is attached
+   * \param status motor ON/OFF status
+   * \throws If the robot does not have any JointSensor at joint
+   * \throws If the specified robot does not exist
+   */
+  void setJointMotorStatus(const std::string & robotName, const std::string & joint, bool status);
+
+  /*! \brief Motor status provided by multiple JointSensors for the main robot (sets control+real)
+   *
+   * \param statuses map of joint name to motor status
+   * \throws If any of the joint sensors do not exist
+   */
+  void setJointMotorStatuses(const std::map<std::string, bool> & statuses);
+
+  /*! \brief Motor status provided by multiple JointSensors for the specified robot (sets control+real)
+   *
+   * \param robotName Name of the robot to which the sensor values will be assigned.
+   * A robot with that name must exist in both robots() and realRobots() instances.
+   * \param statuses map of joint name to motor status
+   * \throws If any of the joint sensors do not exist
+   * \throws If the specified robot does not exist
+   */
+  void setJointMotorStatuses(const std::string & robotName, const std::map<std::string, bool> & statuses);
   /** @} */
 
 protected:

--- a/include/mc_rbdyn/JointSensor.h
+++ b/include/mc_rbdyn/JointSensor.h
@@ -55,6 +55,12 @@ struct MC_RBDYN_DLLAPI JointSensor
   /** Set the sensor's current reading (Ampere) */
   inline void motorCurrent(double motor_current) noexcept { motor_current_ = motor_current; }
 
+  /** Return the sensor's motor ON/OFF reading, ON (true) if not provided */
+  inline bool motorStatus() const noexcept { return motor_status_; }
+
+  /** Set the sensor's motor ON/OFF reading */
+  inline void motorStatus(bool motor_status) noexcept { motor_status_ = motor_status; }
+
 protected:
   /** Name of joint to which sensor is attached */
   std::string joint_;
@@ -66,6 +72,8 @@ private:
   double driver_temperature_ = std::numeric_limits<double>::quiet_NaN();
   /* Motor current (Ampere) */
   double motor_current_ = std::numeric_limits<double>::quiet_NaN();
+  /* Motor status (ON/OFF) */
+  bool motor_status_ = true;
 };
 
 inline bool operator==(const JointSensor & lhs, const JointSensor & rhs)

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -535,6 +535,8 @@ void MCController::addRobotToLog(const mc_rbdyn::Robot & r)
                          [this, name, jnt]() { return robot(name).jointJointSensor(jnt).driverTemperature(); });
     logger().addLogEntry(entry_str("JointSensor_" + jnt + "_motorCurrent"),
                          [this, name, jnt]() { return robot(name).jointJointSensor(jnt).motorCurrent(); });
+    logger().addLogEntry(entry_str("JointSensor_" + jnt + "_motorStatus"),
+                         [this, name, jnt]() { return robot(name).jointJointSensor(jnt).motorStatus(); });
   }
 }
 
@@ -576,6 +578,7 @@ void MCController::removeRobot(const std::string & name)
       logger().removeLogEntry(entry_str("JointSensor_" + js.joint() + "_motorTemperature"));
       logger().removeLogEntry(entry_str("JointSensor_" + js.joint() + "_driverTemperature"));
       logger().removeLogEntry(entry_str("JointSensor_" + js.joint() + "_motorCurrent"));
+      logger().removeLogEntry(entry_str("JointSensor_" + js.joint() + "_motorStatus"));
     }
     converters_.erase(converters_.begin() + robot.robotIndex());
   }

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -708,6 +708,31 @@ void MCGlobalController::setJointMotorCurrents(const std::string & robotName,
   for(const auto & c : currents) { sensors[robot.data()->jointJointSensors.at(c.first)].motorCurrent(c.second); }
 }
 
+void MCGlobalController::setJointMotorStatus(const std::string & joint, bool status)
+{
+  setJointMotorStatus(controller_->robot().name(), joint, status);
+}
+
+void MCGlobalController::setJointMotorStatus(const std::string & robotName, const std::string & joint, bool status)
+{
+  auto & robot = controller().robot(robotName);
+  auto & sensors = robot.data()->jointSensors;
+  sensors[robot.data()->jointJointSensors.at(joint)].motorStatus(status);
+}
+
+void MCGlobalController::setJointMotorStatuses(const std::map<std::string, bool> & statuses)
+{
+  setJointMotorStatuses(controller_->robot().name(), statuses);
+}
+
+void MCGlobalController::setJointMotorStatuses(const std::string & robotName,
+                                               const std::map<std::string, bool> & statuses)
+{
+  auto & robot = controller().robot(robotName);
+  auto & sensors = robot.data()->jointSensors;
+  for(const auto & s : statuses) { sensors[robot.data()->jointJointSensors.at(s.first)].motorStatus(s.second); }
+}
+
 bool MCGlobalController::run()
 {
   /** Always pick a steady clock */
@@ -743,6 +768,7 @@ bool MCGlobalController::run()
         js.motorTemperature(controller_->robot().jointJointSensor(js.joint()).motorTemperature());
         js.driverTemperature(controller_->robot().jointJointSensor(js.joint()).driverTemperature());
         js.motorCurrent(controller_->robot().jointJointSensor(js.joint()).motorCurrent());
+        js.motorStatus(controller_->robot().jointJointSensor(js.joint()).motorStatus());
       }
       next_controller_->realRobot().mbc() = controller_->realRobot().mbc();
     }


### PR DESCRIPTION
- Can be used to act on servo off or motor alarm situations. 
- Set to `true` by default