### PR TITLE
Add mc_rtc::Schema (BETA)

### DIFF
--- a/.github/workflows/build-others.yml
+++ b/.github/workflows/build-others.yml
@@ -27,6 +27,10 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: recursive
+    - name: Free-up space
+      run: |
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/local/lib/android
     - name: Build within Docker
       run: |
         echo "::group::Setup Dockerfile"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,8 @@ jobs:
       if: matrix.os == 'ubuntu-18.04' || matrix.os == 'ubuntu-20.04'
       run: |
         set -e
+        sudo rm -rf /opt/hostedtoolcache/CodeQL
+        sudo rm -rf /usr/local/lib/android
         echo "LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/x86_64-linux-gnu/:${LD_LIBRARY_PATH}" >> $GITHUB_ENV
     - name: macOS cleanup
       run: |

--- a/doc/_data/tutorials.yml
+++ b/doc/_data/tutorials.yml
@@ -32,6 +32,8 @@
       id: ros
     -
       id: global-plugins
+    -
+      id: schema
 -
   id: tools
   tutorials:

--- a/doc/_i18n/en.yml
+++ b/doc/_i18n/en.yml
@@ -108,6 +108,8 @@ tutorials:
       title: ROS integration
     global-plugins:
       title: Using global plugins
+    schema:
+      title: Schema structures integrated to the framework
   tools:
     title: Framework tools
     desc: These tutorials introduce useful tools developed around mc_rtc

--- a/doc/_i18n/en/tutorials/usage/schema.md
+++ b/doc/_i18n/en/tutorials/usage/schema.md
@@ -1,0 +1,242 @@
+## Introducing `mc_rtc::Schema`
+
+JSON Schema is a [specification](https://json-schema.org/) that allows to document the expected data format to go from a JSON object to a given data structure.
+
+It is used in [mc_rtc](https://jrl-umi3218.github.io/mc_rtc/json.html) to document the expected data for loading objects -- e.g. tasks or constraints -- into the framework.
+
+As you write code within mc_rtc you will likely encounter a scenarion where you load a number of parameters from an {% include link_tutorial.html category="usage" tutorial="mc_rtc_configuration" %} object.
+
+In addition to loading this configuration object into your data structure, you will also likely be interested in:
+
+- Saving the current state of the object to an `mc_rtc::Configuration` file -- and then to disk;
+- Allow to edit the parameters online;
+- Document the configuration format;
+
+Writing all this code by hand is possible but tedious and error-prone, especially when adding or removing fields from the structure.
+
+This is where `mc_rtc::Schema` comes in. Its objective is to allow you to write a simple structure that behaves like a simple structure but comes packed with extra features.
+
+## Our first schema-based structure
+
+The following example is a simple schema structure that illustrates the basic usage of the feature:
+
+```cpp
+#include <mc_rtc/Schema.h>
+
+struct SimpleSchema
+{
+  MC_RTC_NEW_SCHEMA(SimpleSchema)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__)
+  MEMBER(bool, useFeature, "Use magic feature")
+  MEMBER(double, weight, "Task weight")
+  MEMBER(std::vector<std::string>, names, "Some names")
+  MEMBER(sva::ForceVecd, wrench, "Target wrench")
+  MEMBER(sva::PTransformd, pt, "Some transform")
+#undef MEMBER
+};
+```
+
+<h5 class="no_toc">Note for MSVC users</h5>
+
+If you intend the above code to be used with the Microsoft Visual C++ Compiler (MSVC), the `MEMBER` definition should be changed to:
+
+```cpp
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__))
+```
+
+Or avoid the `MEMBER` helper all-together.
+
+This works around a pre-processor issue in MSVC.
+
+### Usage
+
+The structure that we defined this way is used a regular C++ structure:
+
+```cpp
+void do_foo(const sva::ForceVecd &);
+
+// The structure can be default constructed (more on the defaults later)
+SimpleSchema simple;
+// Access a member as a simple structure
+do_foo(simple.wrench);
+// The members are of the type you specified so this is also possible
+do_foo(simple.pt * simple.wrench);
+```
+
+However, this structure also has a number of extra functionalities built-in:
+
+```cpp
+// Load from an mc_rtc::Configuration value
+simple.load(config);
+// Save to an mc_rtc::Configuration object
+simple.save(config);
+// We can also take advantage of mc_rtc::Configuration user defined conversions
+config.add("simple", simple);
+SimpleSchema simple2 = config("simple");
+// Print to the console
+mc_rtc::log::info("simple:\n{}", simple.dump(true, true));
+// Add a form to the GUI that will edit simple in place
+simple.addToGUI(*controller.gui(), {"Form category"}, "Form name",
+                [this]() {
+                  // The simple object has been updated with new values at this point
+                  on_simple_update();
+                });
+```
+
+You can also use aggregate initialization or [designated initialization](https://en.cppreference.com/w/cpp/language/aggregate_initialization#Designated_initializers) (from C++20) to initialize the structure:
+
+```cpp
+SimpleSchema simple{true, 42.42, {"a", "b"}, wrench, pt};
+```
+
+Finally the structure we created here has the same size as the simpler structure we could have created by hand.
+
+## The `MC_RTC_SCHEMA_MEMBER` macro
+
+In the previous example, we have used the `MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER` macro. It is actually a wrapper around the more general `MC_RTC_SCHEMA_MEMBER` macro which has the following siganture:
+
+```cpp
+MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, FLAGS, DEFAULT, ...)
+```
+
+The parameters have the following usage:
+
+- `T` is the type of the Schema object where this member appears;
+- `TYPE` is the type of the member variable;
+- `NAME` is the name of the member variable;
+- `DESCRIPTION` is a documentation string for the member variable, it is also used in the generated Form;
+- `FLAGS` is used to add additional information about the member, most notably whether the member is required or not;
+- `DEFAULT` is the default value used for this member;
+- `...`/`NAMES` these extra parameters are used for two purposes:
+  - if `TYPE` is `std::string` this can be used to provide valid values;
+  - if `TYPE` is `std::variant<T...>` this is used to assign meaningful names to the variant altneratives;
+
+### About `TYPE`
+
+The intent is for any `TYPE` to be usable -- at least for the load/save scenario, not all types may be supported for the form-based edition.
+
+If a given `TYPE` is not supported you will get a compilation error, please report the issue to mc_rtc developpers.
+
+As of now, most types that can be loaded/saved through an `mc_rtc::Configuration` object are supported as well as schema-based types and `std::vector` of such types.
+
+The following is an example using such types:
+
+```cpp
+struct ComposeSchema
+{
+  MC_RTC_NEW_SCHEMA(ComposeSchema)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ComposeSchema, __VA_ARGS__))
+  MEMBER(int, integer, "Integer value")
+  MEMBER(SimpleSchema, simple, "Simple schema")
+  MEMBER(std::vector<SimpleSchema>, many, "Multiple simple schema")
+#undef MEMBER
+};
+```
+
+### About `FLAGS`
+
+There is current two flags:
+
+- `mc_rtc::schema::Required`
+- `mc_rtc::schema::Interactive`
+
+#### `mc_rtc::schema::Required`
+
+When a member is required:
+
+- the member must be present in the configuration;
+- the member must correctly de-serialize to its type;
+
+Otherwise the member is only read if it is present in the configuration.
+
+Note: members are always saved into a Configuration object, whether they are required or not
+
+#### `mc_rtc::schema::Interactive`
+
+The schema can treat the following types as interactive:
+
+- `Eigen::Vector3d`
+- `sva::PTransformd`
+
+If members of these types are added to a form then interactive form elements will be used.
+
+However, it does not always make sense. For example, a 3D gain could be represented with an `Eigen::Vector3d` and there is no point to use a 3D marker to edit this value.
+
+You can control this behavior by setting the interactive flag accordingly. In all macros, except the basic `MC_RTC_SCHEMA_MEMBER`, the flag is set by default.
+
+#### Example
+
+The following example illustrates the use of these flags in the `MC_RTC_SCHEMA_MEMBER` macro call:
+
+```cpp
+struct InteractiveSchema
+{
+  MC_RTC_NEW_SCHEMA(InteractiveSchema)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_MEMBER(InteractiveSchema, __VA_ARGS__))
+  MEMBER(Eigen::Vector3d,
+         point,
+         "3D point",
+         mc_rtc::schema::Required | mc_rtc::schema::Interactive,
+         Eigen::Vector3d::Zero())
+  MEMBER(Eigen::Vector3d, gain, "3D gain", mc_rtc::schema::Required, Eigen::Vector3d::Ones())
+  MEMBER(Eigen::Vector3d, gainOpt, "3D optional gain", mc_rtc::schema::None, Eigen::Vector3d::Zero())
+#undef MEMBER
+};
+```
+
+### About `DEFAULT`
+
+This lets you specify the default value of the member. Anything that would be valid on the right-hand side of the assignment operator is ok here.
+
+If you are using a `_DEFAULT_` macro, this is `mc_rtc::Default<T>` which is:
+
+- `0` for arithmetic types (thus `false` for `bool`)
+- Zero for Eigen vectors
+- Identity for Eigen square matrix
+- Identity for `sva::PTransformd`
+- Zero for `sva::ForceVecd`, `sva::MotionVecd`, `sva::ImpedanceVecd`, `sva::AdmittanceVecd`
+- Empty string for `std::string`
+- `mc_rtc::Default<T>` for `std::variant<T, Others...>`
+- Default values for a schema-based structure
+
+### About `NAMES`
+
+These extra parameter has two possible use-case:
+
+- a list of possible values when `TYPE` is `std::string`
+- a description of the types when `TYPE` is `std::variant<T...>`
+
+#### Example
+
+In this example we have a gain represented as variant. It can be a `double` scalar or an `Eigen::Vector3d`. The `mc_rtc::schema::Choices` is passed to the `MEMBER` macro and those names will be used when displaying the choice in the GUI.
+
+```cpp
+struct SimpleVariant
+{
+  MC_RTC_NEW_SCHEMA(SimpleVariant)
+  using gain_t = std::variant<double, Eigen::Vector3d>;
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleVariant, __VA_ARGS__))
+  MEMBER(gain_t, stiffness, "Task stiffness", mc_rtc::schema::Choices({"scalar", "dimensional"}))
+#undef MEMBER
+};
+```
+
+## The `MC_RTC_NEW_SCHEMA` and `MC_RTC_SCHEMA` macros
+
+In all examples so far we have seen usage of `MC_RTC_NEW_SCHEMA`. As the name suggests, this macro is used to introduce a new schema declaration.
+
+It takes a single argument which is the name of the structure we are creating.
+
+However, it is sometimes useful to extend a schema with additional members. In such cases one should use the `MC_RTC_SCHEMA` macro instead:
+
+```cpp
+struct ExtendedSchema : public SimpleSchema
+{
+  MC_RTC_SCHEMA(ExtendedSchema, SimpleSchema)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ExtendedSchema, __VA_ARGS__))
+  MEMBER(double, extendedGain, "Gain for the extended algorithm")
+#undef MEMBER
+};
+```
+
+This macro simply takes the schema name as well as the base class the schema is using.

--- a/doc/_i18n/jp.yml
+++ b/doc/_i18n/jp.yml
@@ -109,6 +109,8 @@ tutorials:
       title: ROS統合
     global-plugins:
       title: グローバルプラグインの利用
+    schema:
+      title: フレームワークに統合されたスキーマ構造
   tools:
     title: ツール
     desc: これらのチュートリアルはmc_rtc関連の便利なツールを紹介します。

--- a/doc/_i18n/jp/tutorials/usage/schema.md
+++ b/doc/_i18n/jp/tutorials/usage/schema.md
@@ -1,0 +1,224 @@
+## `mc_rtc::Schema` の紹介
+
+[JSON Schema](https://json-schema.org/)は、JSONオブジェクトから指定されたデータ構造への期待されるデータ形式を文書化する仕様です。
+
+[mc_rtc](https://jrl-umi3218.github.io/mc_rtc/json.html)では、オブジェクトをフレームワークにロードする際の期待されるデータを文書化するために使用されます。
+
+mc_rtc内でコードを記述する際に、おそらく{% include link_tutorial.html category="usage" tutorial="mc_rtc_configuration" %}オブジェクトから多くのパラメータをロードするシナリオに遭遇するでしょう。
+
+この構成オブジェクトをデータ構造にロードするだけでなく、オブジェクトの現在の状態を`mc_rtc::Configuration`ファイルに保存し、それをディスクに保存すること、パラメータをオンラインで編集できるようにすること、構成形式を文書化することにも関心を持つでしょう。
+
+すべてのコードを手動で記述することは可能ですが、特に構造からフィールドを追加または削除する場合は面倒でエラーが発生しやすいです。
+
+これが`mc_rtc::Schema`が登場する場所です。その目標は、シンプルな構造のように振る舞いながらも、追加の機能を備えた構造を記述できるようにすることです。
+
+## 私たちの最初のスキーマベースの構造
+
+```cpp
+#include <mc_rtc/Schema.h>
+
+struct SimpleSchema
+{
+  MC_RTC_NEW_SCHEMA(SimpleSchema)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__)
+  MEMBER(bool, useFeature, "魔法の機能を使用する")
+  MEMBER(double, weight, "タスクの重み")
+  MEMBER(std::vector<std::string>, names, "いくつかの名前")
+  MEMBER(sva::ForceVecd, wrench, "目標トルク")
+  MEMBER(sva::PTransformd, pt, "いくつかの変換")
+#undef MEMBER
+};
+```
+
+<h5 class="no_toc">MSVCユーザー向けの注意</h5>
+
+上記のコードをMicrosoft Visual C++ Compiler（MSVC）で使用する場合、`MEMBER`の定義を次のように変更する必要があります：
+
+```cpp
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__))
+```
+
+あるいは、`MEMBER`ヘルパーを完全に回避することもできます。
+
+これは、MSVCのプリプロセッサの問題を回避するためのものです。
+
+### 使用法
+
+この方法で定義した構造は通常のC++構造体として使用されます：
+
+```cpp
+void do_foo(const sva::ForceVecd &);
+
+// この構造体はデフォルトで構築できます（デフォルトについては後で説明します）
+SimpleSchema simple;
+// メンバーをシンプルな構造体としてアクセスできます
+do_foo(simple.wrench);
+// メンバーは指定した型のものなので、次のようにもできます
+do_foo(simple.pt * simple.wrench);
+```
+
+ただし、この構造には追加の機能が組み込まれています：
+
+```cpp
+// mc_rtc::Configuration値からロード
+simple.load(config);
+// mc_rtc::Configurationオブジェクトに保存
+simple.save(config);
+// mc_rtc::Configurationのユーザー定義変換も利用できます
+config.add("simple", simple);
+SimpleSchema simple2 = config("simple");
+// コンソールに出力
+mc_rtc::log::info("simple:\n{}", simple.dump(true, true));
+// simpleをインプレースで編集するGUIフォームを追加
+simple.addToGUI(*controller.gui(), {"フォームカテゴリ"}, "フォーム名",
+                [this]() {
+                  // この時点でsimpleオブジェクトは新しい値で更新されています
+                  on_simple_update();
+                });
+```
+
+また、集成初期化または[指定された初期化](https://en.cppreference.com/w/cpp/language/aggregate_initialization#Designated_initializers)（C++20から）を使用して構造を初期化することもできます：
+
+```cpp
+SimpleSchema simple{true, 42.42, {"a", "b"}, wrench, pt};
+```
+
+最後に、ここで作成した構造体は、手動で作成した単純な構造体と同じサイズです。
+
+## `MC_RTC_SCHEMA_MEMBER` マクロ
+
+前の例では、`MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER` マクロを使用しました。実際には、より一般的な `MC_RTC_SCHEMA_MEMBER` マクロがあり、そのシグネチャは次のようになっています：
+
+```cpp
+MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, FLAGS, DEFAULT, ...)
+```
+
+パラメータの使用方法は次のとおりです：
+
+- `T`はこのメンバーが表示されるスキーマオブジェクトの型です。
+- `TYPE`はメンバー変数の型です。
+- `NAME`はメンバー変数の名前です。
+- `DESCRIPTION`はメンバー変数のドキュメント文字列であり、生成されたフォームでも使用されます。
+- `FLAGS`はメンバーに関する追加情報を追加するために使用され、メンバーが必要かどうかなどを特に示します。
+- `DEFAULT`はこのメンバーのデフォルト値を指定します。
+- `...` / `NAMES`はこれらの追加のパラメータで、2つの目的に使用されます：
+  - `TYPE`が`std::string`の場合、有効な値を提供するために使用できます。
+  - `TYPE`が`std::variant<T...>`の場合、変数の代替名を割り当てるために使用されます。
+
+### `TYPE`について
+
+`TYPE`は、少なくともロード/保存シナリオではすべての`TYPE`を使用できることが意図されています。フォームベースの編集についてはすべての型がサポートされるわけではありません。特定の`TYPE`がサポートされていない場合、コンパイルエラーが発生しますので、問題をmc_rtcの開発者に報告してください。現在、`mc_rtc::Configuration`オブジェクトを介してロード/保存できるほとんどの型、スキーマベースの型、およびそのような型の`std::vector`がサポートされています。次の例は、このような型を使用する例です：
+
+```cpp
+struct ComposeSchema
+{
+  MC_RTC_NEW_SCHEMA(ComposeSchema)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ComposeSchema, __VA_ARGS__))
+  MEMBER(int, integer, "整数値")
+  MEMBER(SimpleSchema, simple, "シンプルなスキーマ")
+  MEMBER(std::vector<SimpleSchema>, many, "複数のシンプルスキーマ")
+#undef MEMBER
+};
+```
+
+### `FLAGS`について
+
+現在、2つのフラグがあります：
+
+- `mc_rtc::schema::Required`
+- `mc_rtc::schema::Interactive`
+
+#### `mc_rtc::schema::Required`
+
+メンバーが必要な場合：
+
+- メンバーは設定で存在している必要があります。
+- メンバーは正しくその型にデシリアライズされる必要があります。
+
+それ以外の場合、メンバーは設定で存在する場合にのみ読み込まれます。メンバーは常にConfigurationオブジェクトに保存されますが、必要かどうかにかかわらずです。
+
+#### `mc_rtc::schema::Interactive`
+
+スキーマは次の型を対話型として扱うことができます：
+
+- `Eigen::Vector3d`
+- `sva::PTransformd`
+
+これらの型のメンバーがフォームに追加されると、対話型フォーム要素が使用されます。ただし、これが常に意味があるわけではありません。たとえば、3Dゲインは`Eigen::Vector3d`で表すことができ、この値を編集するために3Dマーカーを使用する必要はありません。
+
+この動作を制御するには、対応する対話型フラグを設定します。基本的な`MC_RTC_SCHEMA_MEMBER`以外のすべてのマクロでは、フラグがデフォルトで設定されています。
+
+#### 例
+
+次の例は、`MC_RTC_SCHEMA_MEMBER`マクロの呼び出しでこれらのフラグを使用する方法を示しています：
+
+```cpp
+struct InteractiveSchema
+{
+  MC_RTC_NEW_SCHEMA(InteractiveSchema)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_MEMBER(InteractiveSchema, __VA_ARGS__))
+  MEMBER(Eigen::Vector3d,
+         point,
+         "3Dポイント",
+         mc_rtc::schema::Required | mc_rtc::schema::Interactive,
+         Eigen::Vector3d::Zero())
+  MEMBER(Eigen::Vector3d, gain, "3Dゲイン", mc_rtc::schema::Required, Eigen::Vector3d::Ones())
+  MEMBER(Eigen::Vector3d, gainOpt, "3Dオプショナルゲイン", mc_rtc::schema::None, Eigen::Vector3d::Zero())
+#undef MEMBER
+};
+```
+
+### `DEFAULT`について
+
+これにより、メンバーのデフォルト値を指定できます。代入演算子の右側で有効な値であれば、何でも構いません。_DEFAULT_`マクロを使用している場合、これは`mc_rtc::Default<T>`です。これは次のようになります：
+
+- 算術型の場合は`0`（したがって`bool`の場合は`false`）
+- Eigenベクトルの場合はゼロ
+- Eigen正方行列の場合は単位行列
+- `sva::PTransformd`の場合は単位変換行列
+- `sva::ForceVecd`、`sva::MotionVecd`、`sva::ImpedanceVecd`、`sva::AdmittanceVecd`の場合はゼロ
+- `std::string`の場合は空の文字列
+- `std::variant<T>`の場合は`mc_rtc::Default<T>`です
+- スキーマベースの構造の場合はデフォルト値
+
+### `NAMES`について
+
+これらの追加パラメータには2つの可能な使用例があります：
+
+- `TYPE`が`std::string`の場合、有効な値のリストを提供する場合
+- `TYPE`が`std::variant<T...>`の場合、バリアントの代替名を割り当てる場合
+
+#### 例
+
+この例では、バリアントとして表されるゲインを持っています。これは`double`スカラーまたは`Eigen::Vector3d`である可能性があります。`mc_rtc::schema::Choices`が`MEMBER`マクロに渡され、これらの名前がGUIで選択肢を表示する際に使用されます：
+
+```cpp
+struct SimpleVariant
+{
+  MC_RTC_NEW_SCHEMA(SimpleVariant)
+  using gain_t = std::variant<double, Eigen::Vector3d>;
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleVariant, __VA_ARGS__))
+  MEMBER(gain_t, stiffness, "タスク剛性", mc_rtc::schema::Choices({"スカラー", "次元"}))
+#undef MEMBER
+};
+```
+
+## `MC_RTC_NEW_SCHEMA` および `MC_RTC_SCHEMA` マクロ
+
+これまでのすべての例で、`MC_RTC_NEW_SCHEMA`を使用してスキーマ宣言を導入しました。その名前が示すように、このマクロは新しいスキーマ宣言を導入するために使用されます。
+
+このマクロは、作成している構造体の名前を単一の引数として受け取ります。
+
+ただし、スキーマを追加のメンバーで拡張する場合、`MC_RTC_SCHEMA`マクロを代わりに使用することがあります：
+
+```cpp
+struct ExtendedSchema : public SimpleSchema
+{
+  MC_RTC_SCHEMA(ExtendedSchema, SimpleSchema)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ExtendedSchema, __VA_ARGS__))
+  MEMBER(double, extendedGain, "拡張アルゴリズムのゲイン")
+#undef MEMBER
+};
+```
+
+このようにして、スキーマを拡張することができます。

--- a/doc/tutorials/usage/schema.md
+++ b/doc/tutorials/usage/schema.md
@@ -1,0 +1,6 @@
+---
+layout: tutorials
+toc: true
+---
+
+{% translate_file tutorials/usage/schema.md %}

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -1,0 +1,207 @@
+#pragma once
+
+#include <mc_rtc/Configuration.h>
+#include <mc_rtc/gui/Form.h>
+#include <mc_rtc/gui/StateBuilder.h>
+
+namespace mc_rtc::schema
+{
+
+namespace details
+{
+
+/** Helper to pass otherwise non deducible template parameters to a constructor */
+template<auto ptr>
+struct MemberPointerWrapper
+{
+};
+
+/** Helper when a Schema value has a finite number of choices */
+template<typename T, bool HasChoices>
+struct Choices
+{
+  Choices() = default;
+  Choices(const std::vector<std::string> & choices) : choices(choices) {}
+  std::vector<T> choices;
+};
+
+template<typename T>
+struct Choices<T, false>
+{
+  Choices() = default;
+};
+
+/** Helper to get a default value for a given type */
+template<typename T, typename Enable = void>
+struct Default
+{
+  static_assert(!std::is_same_v<T, T>, "Must be specialized");
+};
+
+template<typename T>
+struct Default<T, std::enable_if_t<std::is_arithmetic_v<T>>>
+{
+  inline static constexpr T value = 0;
+};
+
+template<typename Scalar, int N, int _Options, int _MaxRows, int _MaxCols>
+struct Default<Eigen::Matrix<Scalar, N, 1, _Options, _MaxRows, _MaxCols>, std::enable_if_t<(N > 0)>>
+{
+  inline static const Eigen::Matrix<Scalar, N, 1, _Options, _MaxRows, _MaxCols> value =
+      Eigen::Matrix<Scalar, N, 1, _Options, _MaxRows, _MaxCols>::Zero();
+};
+
+template<typename Scalar, int N, int _Options, int _MaxRows, int _MaxCols>
+struct Default<Eigen::Matrix<Scalar, N, N, _Options, _MaxRows, _MaxCols>, std::enable_if_t<(N > 1)>>
+{
+  inline static const Eigen::Matrix<Scalar, N, N, _Options, _MaxRows, _MaxCols> value =
+      Eigen::Matrix<Scalar, N, N, _Options, _MaxRows, _MaxCols>::Identity();
+};
+
+template<>
+struct Default<sva::PTransformd>
+{
+  inline static const sva::PTransformd value = sva::PTransformd::Identity();
+};
+
+template<>
+struct Default<sva::MotionVecd>
+{
+  inline static const sva::MotionVecd value = sva::MotionVecd::Zero();
+};
+
+template<>
+struct Default<sva::ForceVecd>
+{
+  inline static const sva::ForceVecd value = sva::ForceVecd::Zero();
+};
+
+template<>
+struct Default<sva::ImpedanceVecd>
+{
+  inline static const sva::ImpedanceVecd value = sva::ImpedanceVecd::Zero();
+};
+
+template<>
+struct Default<sva::AdmittanceVecd>
+{
+  inline static const sva::AdmittanceVecd value = sva::AdmittanceVecd::Zero();
+};
+
+template<>
+struct Default<std::string>
+{
+  inline static const std::string value = "";
+};
+
+} // namespace details
+
+/** Operations implemented by an object that can be represented with a Schema */
+struct MC_RTC_UTILS_DLLAPI Operations
+{
+  /** Save to a configuration object */
+  std::function<void(const void * self, Configuration & out)> save = [](const void *, Configuration &) {};
+
+  /** Load from a configuration object */
+  std::function<void(void * self, const Configuration & in)> load = [](void *, const Configuration &) {};
+
+  using StandardForm = gui::details::FormImpl<std::function<void(const Configuration &)>>;
+
+  /** Build a Form to load the object */
+  std::function<void(const void * self, StandardForm & form)> buildForm = [](const void *, StandardForm &) {};
+
+  /** Load from a Form */
+  std::function<void(void * self, const Configuration & in)> loadForm = [](void *, const Configuration &) {};
+
+  /** FIXME Add a saveSchema function */
+
+  /** FIXME Add logging operation?*/
+};
+
+/** A simple value in a schema
+ *
+ * This comprises of:
+ * - a value of type \tparam T
+ * - an indentifier/name given at construction
+ * - a description given at construction
+ */
+template<typename T>
+struct alignas(T) Value
+{
+  /** Create the value
+   *
+   * \tparam Schema Schema this value belongs to
+   *
+   * \tparam ptr Member pointer in the Schema object
+   *
+   * \tparam IsRequired If true the value is required in the form
+   *
+   * \tparam HasChoices If true, we expect choices to be provided for the value instead of an open form
+   *
+   * \param ops Operations that we should setup
+   *
+   * \param name Name of the value
+   *
+   * \param description Description for the value
+   *
+   * \param default_ Default value
+   *
+   * \param required Pass the IsRequired value
+   *
+   * \param combo Possible choices when \tparam HasChoices is true
+   */
+  template<typename Schema, Value<T> Schema::*ptr, bool IsRequired = true, bool HasChoices = false>
+  Value(Operations & ops,
+        details::MemberPointerWrapper<ptr>,
+        const std::string & name,
+        const std::string & description,
+        const T & default_ = details::Default<T>::value,
+        const std::bool_constant<IsRequired> & = {},
+        const details::Choices<T, HasChoices> & choices = {})
+  : value_(default_)
+  {
+    ops.save = [save = ops.save, name](const void * self, mc_rtc::Configuration & out)
+    {
+      save(self, out);
+      out.add(name, (static_cast<const Schema *>(self)->*ptr).operator const T &());
+    };
+    ops.load = [load = ops.load, name](void * self, const mc_rtc::Configuration & in)
+    {
+      load(self, in);
+      (static_cast<Schema *>(self)->*ptr).operator T &() = in(name).operator T();
+    };
+    ops.loadForm = [loadForm = ops.loadForm, description](void * self, const mc_rtc::Configuration & in)
+    {
+      loadForm(self, in);
+      T & value = static_cast<Schema *>(self)->*ptr;
+      if(IsRequired || in.has(description)) { value = in(description).operator T(); }
+    };
+    ops.buildForm =
+        [buildForm = ops.buildForm, description, choices](const void * self, Operations::StandardForm & form)
+    {
+      buildForm(self, form);
+      const T & value = static_cast<Schema *>(self)->*ptr;
+      auto get_value = [&value]() -> const T & { return value; };
+      if constexpr(std::is_same_v<T, bool>)
+      {
+        form.addElement(mc_rtc::gui::FormCheckbox(description, IsRequired, get_value));
+      }
+      else if constexpr(std::is_integral_v<T>)
+      {
+        form.addElement(mc_rtc::gui::FormIntegerInput(description, IsRequired, get_value));
+      }
+      else if constexpr(std::is_floating_point_v<T>)
+      {
+        form.addElement(mc_rtc::gui::FormNumberInput(description, IsRequired, get_value));
+      }
+    };
+  }
+
+  inline operator T &() noexcept { return value_; }
+
+  inline operator const T &() const noexcept { return value_; }
+
+  T value_;
+};
+
+} // namespace mc_rtc::schema

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -341,7 +341,7 @@ struct alignas(T) Value
    *
    * \param combo Possible choices when \tparam HasChoices is true
    */
-  template<typename Schema, Value<T> Schema::*ptr, ValueFlag Flags = ValueFlag::All, bool HasChoices = false>
+  template<typename Schema, T Schema::*ptr, ValueFlag Flags = ValueFlag::All, bool HasChoices = false>
   Value(Operations & ops,
         details::MemberPointerWrapper<ptr>,
         const std::string & name,
@@ -425,8 +425,6 @@ struct alignas(T) Value
     };
   }
 
-  inline operator T &() noexcept { return value_; }
-
   inline operator const T &() const noexcept { return value_; }
 
   T value_;
@@ -483,13 +481,11 @@ struct Schema : public Operations
 };
 
 /** Declare a Schema<T> member of type TYPE, specify REQUIRED and DEFAULT value */
-#define SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, REQUIRED, DEFAULT, ...)                                            \
-  mc_rtc::schema::Value<TYPE> NAME##_                                                                                \
-  {                                                                                                                  \
-    *this, mc_rtc::schema::details::MemberPointerWrapper<&T::NAME##_>{}, #NAME, DESCRIPTION, DEFAULT,                \
-        std::integral_constant<mc_rtc::schema::ValueFlag,                                                            \
-                               mc_rtc::schema::ValueFlag::All & static_cast<mc_rtc::schema::ValueFlag>(REQUIRED)>{}, \
-        ##__VA_ARGS__                                                                                                \
+#define SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, REQUIRED, DEFAULT, ...)                          \
+  TYPE NAME = mc_rtc::schema::Value<TYPE>                                                          \
+  {                                                                                                \
+    *this, mc_rtc::schema::details::MemberPointerWrapper<&T::NAME>{}, #NAME, DESCRIPTION, DEFAULT, \
+        std::integral_constant<mc_rtc::schema::ValueFlag, REQUIRED>{}, ##__VA_ARGS__               \
   }
 
 /** Declare a required Schema<T> member of type TYPE, only specify DEFAULT */

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -182,8 +182,8 @@ void addValueToForm(const T & value,
   }
   else if constexpr(details::is_std_vector_v<T>)
   {
-    // FIXME We need a way to provide the existing elements here
-    mc_rtc::gui::FormGenericArrayInput input(description, IsRequired);
+    auto get_value = [&value]() -> const T & { return value; };
+    mc_rtc::gui::FormGenericArrayInput input(description, IsRequired, get_value);
     using value_type = typename T::value_type;
     static value_type default_{};
     addValueToForm<value_type, true>(default_, description, {}, input);

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -264,8 +264,6 @@ struct MC_RTC_UTILS_DLLAPI Operations
                      const std::integral_constant<ValueFlag, Flags> & = {},
                      const details::Choices<HasChoices> & choices = {})
   {
-    constexpr bool IsRequired = HasFeature(Flags, ValueFlag::Required);
-    constexpr bool IsInteractive = HasFeature(Flags, ValueFlag::Interactive);
     values_count += 1;
     save = [save = save, name](const void * self, mc_rtc::Configuration & out)
     {
@@ -282,6 +280,7 @@ struct MC_RTC_UTILS_DLLAPI Operations
     };
     load = [load = load, name](void * self, const mc_rtc::Configuration & in)
     {
+      constexpr bool IsRequired = HasFeature(Flags, ValueFlag::Required);
       load(self, in);
       T & value = static_cast<Schema *>(self)->*ptr;
       if(in.has(name)) { value = in(name).operator T(); }
@@ -289,6 +288,7 @@ struct MC_RTC_UTILS_DLLAPI Operations
     };
     formToStd = [formToStd = formToStd, name, description](const Configuration & in, Configuration & out)
     {
+      constexpr bool IsRequired = HasFeature(Flags, ValueFlag::Required);
       formToStd(in, out);
       if(IsRequired || in.has(description))
       {
@@ -313,6 +313,8 @@ struct MC_RTC_UTILS_DLLAPI Operations
     };
     buildForm = [buildForm = buildForm, description, choices](const void * self, Operations::FormElements & form)
     {
+      constexpr bool IsRequired = HasFeature(Flags, ValueFlag::Required);
+      constexpr bool IsInteractive = HasFeature(Flags, ValueFlag::Interactive);
       buildForm(self, form);
       const T & value = static_cast<const Schema *>(self)->*ptr;
       details::addValueToForm<T, IsRequired, IsInteractive>(value, description, choices, form);

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -277,7 +277,7 @@ struct alignas(T) Value
         auto out_ = out.array(name, value.size());
         for(const auto & v : value)
         {
-          auto obj_ = out.object();
+          auto obj_ = out_.object();
           v.save(obj_);
         }
       }

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -4,6 +4,8 @@
 #include <mc_rtc/gui/Form.h>
 #include <mc_rtc/gui/StateBuilder.h>
 
+#include <variant>
+
 namespace mc_rtc::schema
 {
 
@@ -139,6 +141,11 @@ template<>
 struct Default<std::string>
 {
   inline static const std::string value = "";
+};
+
+template<typename T, typename... Others>
+struct Default<std::variant<T, Others...>> : public Default<T>
+{
 };
 
 } // namespace details

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -210,7 +210,7 @@ inline constexpr bool HasFeature(ValueFlag flag, ValueFlag feature) noexcept
  * - MC_RTC_SCHEMA_MEMBER_*(SchemaT, ...) to declare members inside a schema-enable struct of type SchemaT
  *
  */
-struct MC_RTC_UTILS_DLLAPI Operations
+struct Operations
 {
   /** Name of members in the schema */
   size_t values_count = 0;

--- a/include/mc_rtc/SchemaMacros.h
+++ b/include/mc_rtc/SchemaMacros.h
@@ -1,3 +1,5 @@
+#define MC_RTC_PP_ID(X) X
+
 #define MC_RTC_SCHEMA(SchemaT, BaseT)                                                                        \
   /** Tag to detect Schema objects */                                                                        \
   using is_schema_t = std::true_type;                                                                        \
@@ -103,20 +105,22 @@ public:
 
 /** Declare a required Schema<T> member of type TYPE, only specify DEFAULT */
 #define MC_RTC_SCHEMA_REQUIRED_MEMBER(T, TYPE, NAME, DESCRIPTION, DEFAULT, ...) \
-  MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::All, DEFAULT, ##__VA_ARGS__)
+  MC_RTC_PP_ID(MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::All, DEFAULT, ##__VA_ARGS__))
 
 /** Declare an optional Schema<T> member of type TYPE, only specify DEFAULT */
-#define MC_RTC_SCHEMA_OPTIONAL_MEMBER(T, TYPE, NAME, DESCRIPTION, DEFAULT, ...) \
-  MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::Interactive, DEFAULT, ##__VA_ARGS__)
+#define MC_RTC_SCHEMA_OPTIONAL_MEMBER(T, TYPE, NAME, DESCRIPTION, DEFAULT, ...)                                  \
+  MC_RTC_PP_ID(MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::Interactive, DEFAULT, \
+                                    ##__VA_ARGS__))
 
 /** Declare a Schema<T> member of type TYPE with a default value, only specify REQUIRED */
 #define MC_RTC_SCHEMA_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, REQUIRED, ...) \
-  MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, REQUIRED, mc_rtc::Default<TYPE>::value, ##__VA_ARGS__)
+  MC_RTC_PP_ID(MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, REQUIRED, mc_rtc::Default<TYPE>::value, ##__VA_ARGS__))
 
 /** Declare a required Schema<T> member of type TYPE with a default value */
 #define MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, ...) \
-  MC_RTC_SCHEMA_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::All, ##__VA_ARGS__)
+  MC_RTC_PP_ID(MC_RTC_SCHEMA_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::All, ##__VA_ARGS__))
 
 /** Declare an optional Schema<T> member of type TYPE with a default value */
 #define MC_RTC_SCHEMA_OPTIONAL_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, ...) \
-  MC_RTC_SCHEMA_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::Interactive, ##__VA_ARGS__)
+  MC_RTC_PP_ID(                                                                \
+      MC_RTC_SCHEMA_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::Interactive, ##__VA_ARGS__))

--- a/include/mc_rtc/SchemaMacros.h
+++ b/include/mc_rtc/SchemaMacros.h
@@ -1,0 +1,122 @@
+#define MC_RTC_SCHEMA(SchemaT, BaseT)                                                                        \
+  /** Tag to detect Schema objects */                                                                        \
+  using is_schema_t = std::true_type;                                                                        \
+                                                                                                             \
+protected:                                                                                                   \
+  inline static mc_rtc::schema::Operations ops_;                                                             \
+                                                                                                             \
+  inline static size_t schema_size() noexcept                                                                \
+  {                                                                                                          \
+    return ops_.values_count + BaseT::ops_.values_count;                                                     \
+  }                                                                                                          \
+  inline void write_impl(mc_rtc::MessagePackBuilder & builder) const                                         \
+  {                                                                                                          \
+    BaseT::ops_.write(this, builder);                                                                        \
+    ops_.write(this, builder);                                                                               \
+  }                                                                                                          \
+                                                                                                             \
+public:                                                                                                      \
+  inline void save(mc_rtc::Configuration & out) const                                                        \
+  {                                                                                                          \
+    BaseT::ops_.save(this, out);                                                                             \
+    ops_.save(this, out);                                                                                    \
+  }                                                                                                          \
+  inline mc_rtc::Configuration toConfiguration() const                                                       \
+  {                                                                                                          \
+    mc_rtc::Configuration out;                                                                               \
+    save(out);                                                                                               \
+    return out;                                                                                              \
+  }                                                                                                          \
+  inline void write(mc_rtc::MessagePackBuilder & builder) const                                              \
+  {                                                                                                          \
+    builder.start_map(schema_size());                                                                        \
+    write_impl(builder);                                                                                     \
+    builder.finish_map();                                                                                    \
+  }                                                                                                          \
+  inline std::string dump(bool pretty, bool yaml) const                                                      \
+  {                                                                                                          \
+    mc_rtc::Configuration out;                                                                               \
+    save(out);                                                                                               \
+    return out.dump(pretty, yaml);                                                                           \
+  }                                                                                                          \
+  inline void load(const mc_rtc::Configuration & in)                                                         \
+  {                                                                                                          \
+    BaseT::ops_.load(this, in);                                                                              \
+    ops_.load(this, in);                                                                                     \
+  }                                                                                                          \
+  inline static SchemaT fromConfiguration(const mc_rtc::Configuration & in)                                  \
+  {                                                                                                          \
+    SchemaT out;                                                                                             \
+    out.load(in);                                                                                            \
+    return out;                                                                                              \
+  }                                                                                                          \
+  inline void buildForm(mc_rtc::schema::Operations::FormElements & form) const                               \
+  {                                                                                                          \
+    BaseT::ops_.buildForm(this, form);                                                                       \
+    ops_.buildForm(this, form);                                                                              \
+  }                                                                                                          \
+  static inline void formToStd(const mc_rtc::Configuration & in, mc_rtc::Configuration & out)                \
+  {                                                                                                          \
+    BaseT::ops_.formToStd(in, out);                                                                          \
+    ops_.formToStd(in, out);                                                                                 \
+  }                                                                                                          \
+  template<typename Callback = std::function<void()>>                                                        \
+  inline void addToGUI(                                                                                      \
+      mc_rtc ::gui::StateBuilder & gui, const std::vector<std::string> & category, const std::string & name, \
+      Callback callback = []() {})                                                                           \
+  {                                                                                                          \
+    auto form = mc_rtc::gui::Form(name,                                                                      \
+                                  [this, callback](const mc_rtc::Configuration & in)                         \
+                                  {                                                                          \
+                                    mc_rtc::Configuration cfg;                                               \
+                                    formToStd(in, cfg);                                                      \
+                                    /** FIXME If callback takes SchemaT do a copy **/                        \
+                                    load(cfg);                                                               \
+                                    callback();                                                              \
+                                  });                                                                        \
+    buildForm(form);                                                                                         \
+    gui.addElement(category, form);                                                                          \
+  }                                                                                                          \
+  inline bool operator==(const SchemaT & rhs) const                                                          \
+  {                                                                                                          \
+    return BaseT::ops_.areEqual(this, &rhs) && ops_.areEqual(this, &rhs);                                    \
+  }                                                                                                          \
+  inline bool operator!=(const SchemaT & rhs) const                                                          \
+  {                                                                                                          \
+    return !(*this == rhs);                                                                                  \
+  }
+
+#define MC_RTC_NEW_SCHEMA(SchemaT) MC_RTC_SCHEMA(SchemaT, mc_rtc::schema::details::EmptySchema)
+
+/** Declare a T member of type TYPE, specify REQUIRED and DEFAULT value */
+#define MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, REQUIRED, DEFAULT, ...)                           \
+public:                                                                                                    \
+  TYPE NAME = mc_rtc::schema::details::get_default(                                                        \
+      DEFAULT, std::integral_constant<mc_rtc::schema::ValueFlag, REQUIRED>{}, ##__VA_ARGS__);              \
+                                                                                                           \
+private:                                                                                                   \
+  inline static const bool NAME##_registered_ =                                                            \
+      T::ops_.registerValue(mc_rtc::schema::details::MemberPointerWrapper<&T::NAME>{}, #NAME, DESCRIPTION, \
+                            std::integral_constant<mc_rtc::schema::ValueFlag, REQUIRED>{}, ##__VA_ARGS__); \
+                                                                                                           \
+public:
+
+/** Declare a required Schema<T> member of type TYPE, only specify DEFAULT */
+#define MC_RTC_SCHEMA_REQUIRED_MEMBER(T, TYPE, NAME, DESCRIPTION, DEFAULT, ...) \
+  MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::All, DEFAULT, ##__VA_ARGS__)
+
+/** Declare an optional Schema<T> member of type TYPE, only specify DEFAULT */
+#define MC_RTC_SCHEMA_OPTIONAL_MEMBER(T, TYPE, NAME, DESCRIPTION, DEFAULT, ...) \
+  MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::Interactive, DEFAULT, ##__VA_ARGS__)
+
+/** Declare a Schema<T> member of type TYPE with a default value, only specify REQUIRED */
+#define MC_RTC_SCHEMA_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, REQUIRED, ...) \
+  MC_RTC_SCHEMA_MEMBER(T, TYPE, NAME, DESCRIPTION, REQUIRED, mc_rtc::Default<TYPE>::value, ##__VA_ARGS__)
+
+/** Declare a required Schema<T> member of type TYPE with a default value */
+#define MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, ...) \
+  MC_RTC_SCHEMA_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::All, ##__VA_ARGS__)
+
+/** Declare an optional Schema<T> member of type TYPE with a default value */
+#define MC_RTC_SCHEMA_OPTIONAL_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, ...) \
+  MC_RTC_SCHEMA_DEFAULT_MEMBER(T, TYPE, NAME, DESCRIPTION, mc_rtc::schema::ValueFlag::Interactive, ##__VA_ARGS__)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -241,6 +241,11 @@ target_include_directories(gui_AdvancedForm PRIVATE ${CONFIG_HEADER_INCLUDE_DIR}
 set_target_properties(gui_AdvancedForm PROPERTIES FOLDER tests/GUI)
 target_link_libraries(gui_AdvancedForm PUBLIC mc_control)
 
+add_executable(gui_Schema gui_Schema.cpp)
+target_include_directories(gui_Schema PRIVATE ${CONFIG_HEADER_INCLUDE_DIR})
+set_target_properties(gui_Schema PROPERTIES FOLDER tests/GUI)
+target_link_libraries(gui_Schema PUBLIC mc_control)
+
 # ######################################################################################
 # -- Filters test -- #
 # ######################################################################################

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,7 @@ macro(mc_rtc_test NAME)
 endmacro()
 
 mc_rtc_test(testConfiguration mc_rtc_utils mc_rbdyn)
+mc_rtc_test(testSchema mc_rtc_utils mc_rbdyn)
 mc_rtc_test(testGUIStateBuilder mc_rtc_gui)
 mc_rtc_test(testJsonIO mc_rtc_utils mc_rbdyn)
 mc_rtc_test(testConstraintSetLoader mc_solver)

--- a/tests/gui_Schema.cpp
+++ b/tests/gui_Schema.cpp
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2015-2023 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#include "gui_TestServer.h"
+
+#include <mc_rtc/Schema.h>
+
+struct SimpleSchema : public mc_rtc::schema::Schema<SimpleSchema>
+{
+#define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__)
+  MEMBER(bool, useFeature, "Use magic feature");
+  MEMBER(double, weight, "Task weight");
+#undef MEMBER
+};
+
+struct ComposeSchema : public mc_rtc::schema::Schema<ComposeSchema>
+{
+#define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(ComposeSchema, __VA_ARGS__)
+  MEMBER(int, integer, "Integer value");
+  MEMBER(SimpleSchema, simple, "Simple schema");
+#undef MEMBER
+};
+
+struct SchemaServer : public TestServer
+{
+  SchemaServer()
+  {
+    simple_.addToGUI(builder, {"Simple"}, "Update simple", [this]() { simple_updated(); });
+    compose_.addToGUI(builder, {"Compose"}, "Update compose", [this]() { compose_updated(); });
+  }
+
+  SimpleSchema simple_;
+  ComposeSchema compose_;
+
+  void simple_updated() { mc_rtc::log::info("simple_ updated:\n{}", simple_.dump(true, true)); }
+  void compose_updated() { mc_rtc::log::info("compose_ updated:\n{}", compose_.dump(true, true)); }
+};
+
+int main()
+{
+  SchemaServer server;
+  server.loop();
+  return 0;
+}

--- a/tests/gui_Schema.cpp
+++ b/tests/gui_Schema.cpp
@@ -34,6 +34,14 @@ struct InteractiveSchema : public mc_rtc::schema::Schema<InteractiveSchema>
 #undef MEMBER
 };
 
+struct SimpleVariant : public mc_rtc::schema::Schema<SimpleVariant>
+{
+  using gain_t = std::variant<double, Eigen::Vector3d>;
+#define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleVariant, __VA_ARGS__)
+  MEMBER(gain_t, stiffness, "Task stiffness");
+#undef MEMBER
+};
+
 struct SchemaServer : public TestServer
 {
   SchemaServer()
@@ -41,15 +49,18 @@ struct SchemaServer : public TestServer
     simple_.addToGUI(builder, {"Simple"}, "Update simple", [this]() { simple_updated(); });
     compose_.addToGUI(builder, {"Compose"}, "Update compose", [this]() { compose_updated(); });
     interactive_.addToGUI(builder, {"Interactive"}, "Update interactive", [this]() { interactive_updated(); });
+    simple_variant_.addToGUI(builder, {"Simple variant"}, "Update simple", [this]() { simple_variant_updated(); });
   }
 
   SimpleSchema simple_;
   ComposeSchema compose_;
   InteractiveSchema interactive_;
+  SimpleVariant simple_variant_;
 
   void simple_updated() { mc_rtc::log::info("simple_ updated:\n{}", simple_.dump(true, true)); }
   void compose_updated() { mc_rtc::log::info("compose_ updated:\n{}", compose_.dump(true, true)); }
   void interactive_updated() { mc_rtc::log::info("interactive_ updated:\n{}", interactive_.dump(true, true)); }
+  void simple_variant_updated() { mc_rtc::log::info("simple_variant_ updated:\n{}", simple_variant_.dump(true, true)); }
 };
 
 int main()

--- a/tests/gui_Schema.cpp
+++ b/tests/gui_Schema.cpp
@@ -26,11 +26,14 @@ struct ComposeSchema : public mc_rtc::schema::Schema<ComposeSchema>
 
 struct InteractiveSchema : public mc_rtc::schema::Schema<InteractiveSchema>
 {
-  using ValueFlag = mc_rtc::schema::ValueFlag;
 #define MEMBER(...) SCHEMA_MEMBER(InteractiveSchema, __VA_ARGS__)
-  MEMBER(Eigen::Vector3d, point, "3D point", ValueFlag::Required | ValueFlag::Interactive, Eigen::Vector3d::Zero());
-  MEMBER(Eigen::Vector3d, gain, "3D gain", ValueFlag::Required, Eigen::Vector3d::Zero());
-  MEMBER(Eigen::Vector3d, gainOpt, "3D optional gain", ValueFlag::None, Eigen::Vector3d::Zero());
+  MEMBER(Eigen::Vector3d,
+         point,
+         "3D point",
+         mc_rtc::schema::Required | mc_rtc::schema::Interactive,
+         Eigen::Vector3d::Zero());
+  MEMBER(Eigen::Vector3d, gain, "3D gain", mc_rtc::schema::Required, Eigen::Vector3d::Zero());
+  MEMBER(Eigen::Vector3d, gainOpt, "3D optional gain", mc_rtc::schema::None, Eigen::Vector3d::Zero());
 #undef MEMBER
 };
 
@@ -38,7 +41,7 @@ struct SimpleVariant : public mc_rtc::schema::Schema<SimpleVariant>
 {
   using gain_t = std::variant<double, Eigen::Vector3d>;
 #define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleVariant, __VA_ARGS__)
-  MEMBER(gain_t, stiffness, "Task stiffness");
+  MEMBER(gain_t, stiffness, "Task stiffness", mc_rtc::schema::Choices({"scalar", "dimensional"}));
 #undef MEMBER
 };
 

--- a/tests/gui_Schema.cpp
+++ b/tests/gui_Schema.cpp
@@ -11,6 +11,7 @@ struct SimpleSchema : public mc_rtc::schema::Schema<SimpleSchema>
 #define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__)
   MEMBER(bool, useFeature, "Use magic feature");
   MEMBER(double, weight, "Task weight");
+  MEMBER(std::vector<std::string>, names, "Some names");
 #undef MEMBER
 };
 

--- a/tests/gui_Schema.cpp
+++ b/tests/gui_Schema.cpp
@@ -6,33 +6,163 @@
 
 #include "samples_Schema.h"
 
-struct ComposeSchema : public mc_rtc::schema::Schema<ComposeSchema>
+struct ComposeSchema
 {
-#define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(ComposeSchema, __VA_ARGS__)
-  MEMBER(int, integer, "Integer value");
-  MEMBER(SimpleSchema, simple, "Simple schema");
-  MEMBER(std::vector<SimpleSchema>, many, "Multiple simple schema");
+  MC_RTC_NEW_SCHEMA(ComposeSchema)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ComposeSchema, __VA_ARGS__)
+  MEMBER(int, integer, "Integer value")
+  MEMBER(SimpleSchema, simple, "Simple schema")
+  MEMBER(std::vector<SimpleSchema>, many, "Multiple simple schema")
 #undef MEMBER
 };
 
-struct InteractiveSchema : public mc_rtc::schema::Schema<InteractiveSchema>
+struct InteractiveSchema
 {
-#define MEMBER(...) SCHEMA_MEMBER(InteractiveSchema, __VA_ARGS__)
+  MC_RTC_NEW_SCHEMA(InteractiveSchema)
+#define MEMBER(...) MC_RTC_SCHEMA_MEMBER(InteractiveSchema, __VA_ARGS__)
   MEMBER(Eigen::Vector3d,
          point,
          "3D point",
          mc_rtc::schema::Required | mc_rtc::schema::Interactive,
-         Eigen::Vector3d::Zero());
-  MEMBER(Eigen::Vector3d, gain, "3D gain", mc_rtc::schema::Required, Eigen::Vector3d::Zero());
-  MEMBER(Eigen::Vector3d, gainOpt, "3D optional gain", mc_rtc::schema::None, Eigen::Vector3d::Zero());
+         Eigen::Vector3d::Zero())
+  MEMBER(Eigen::Vector3d, gain, "3D gain", mc_rtc::schema::Required, Eigen::Vector3d::Zero())
+  MEMBER(Eigen::Vector3d, gainOpt, "3D optional gain", mc_rtc::schema::None, Eigen::Vector3d::Zero())
 #undef MEMBER
 };
 
-struct SimpleVariant : public mc_rtc::schema::Schema<SimpleVariant>
+struct SimpleVariant
 {
+  MC_RTC_NEW_SCHEMA(SimpleVariant)
   using gain_t = std::variant<double, Eigen::Vector3d>;
-#define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleVariant, __VA_ARGS__)
-  MEMBER(gain_t, stiffness, "Task stiffness", mc_rtc::schema::Choices({"scalar", "dimensional"}));
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleVariant, __VA_ARGS__)
+  MEMBER(gain_t, stiffness, "Task stiffness", mc_rtc::schema::Choices({"scalar", "dimensional"}))
+#undef MEMBER
+};
+
+struct ChildSchema : public SimpleSchema
+{
+  MC_RTC_SCHEMA(ChildSchema, SimpleSchema)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ChildSchema, __VA_ARGS__)
+  MEMBER(double, gain, "Some gain")
+#undef MEMBER
+};
+
+struct MCCContactConstraint
+{
+  MC_RTC_NEW_SCHEMA(MCCContactConstraint)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCContactConstraint, __VA_ARGS__)
+  MEMBER(std::string, type, "Type of contact constraint", mc_rtc::schema::Choices({"Empty", "Surface", "Grasp"}))
+  MEMBER(double, fricCoeff, "Contact friction coefficient")
+#undef MEMBER
+};
+
+struct MCCSwingCommandConfig
+{
+  MC_RTC_NEW_SCHEMA(MCCSwingCommandConfig)
+#define MEMBER(...) MC_RTC_SCHEMA_OPTIONAL_DEFAULT_MEMBER(MCCSwingCommandConfig, __VA_ARGS__)
+  MEMBER(Eigen::Vector3d, approachOffset, "Offset for approach")
+  MEMBER(Eigen::Vector3d, withdrawOffset, "Offset for withdraw")
+#undef MEMBER
+};
+
+struct MCCSwingCommand
+{
+  MC_RTC_NEW_SCHEMA(MCCSwingCommand)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCSwingCommand, __VA_ARGS__)
+  MEMBER(std::string, type, "Type of motion", mc_rtc::schema::Choices({"Add", "Remove"}))
+  MEMBER(double, startTime, "Start time")
+  MEMBER(double, endTime, "End time")
+  MEMBER(MCCSwingCommandConfig, config, "Configuration for swing command")
+#undef MEMBER
+};
+
+struct MCCContactCommand
+{
+  MC_RTC_NEW_SCHEMA(MCCContactCommand)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCContactCommand, __VA_ARGS__)
+  MEMBER(double, time, "Time to enable contact")
+  MEMBER(MCCContactConstraint, constraint, "Contact constraint")
+#undef MEMBER
+};
+
+struct MCCGripperCommandConfig
+{
+  MC_RTC_NEW_SCHEMA(MCCGripperCommandConfig)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCGripperCommandConfig, __VA_ARGS__)
+  MEMBER(double, opening, "Target opening")
+#undef MEMBER
+};
+
+struct MCCGripperCommand
+{
+  MC_RTC_NEW_SCHEMA(MCCGripperCommand)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCGripperCommand, __VA_ARGS__)
+  MEMBER(double, time, "Time to trigger gripper")
+  MEMBER(std::string, name, "Gripper's name")
+  MEMBER(MCCGripperCommandConfig, config, "Gripper's motion configuration")
+#undef MEMBER
+};
+
+struct MCCStepCommand
+{
+  MC_RTC_NEW_SCHEMA(MCCStepCommand)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCStepCommand, __VA_ARGS__)
+  MEMBER(std::string, limb, "Contact limb")
+  MEMBER(sva::PTransformd, pose, "Contact position")
+#undef MEMBER
+#define MEMBER(...) MC_RTC_SCHEMA_OPTIONAL_DEFAULT_MEMBER(MCCStepCommand, __VA_ARGS__)
+  MEMBER(std::string, type, "Type of motion", mc_rtc::schema::Choices({"Add", "Remove"}))
+  MEMBER(double, startTime, "Start time")
+  MEMBER(double, endTime, "End time")
+  MEMBER(MCCContactConstraint, constraint, "Contact constraint")
+  MEMBER(MCCSwingCommand, swingCommand, "Swing command")
+  MEMBER(std::vector<MCCContactCommand>, contactCommandList, "List of contact commands")
+  MEMBER(std::vector<MCCGripperCommand>, gripperCommandList, "List of gripper commands")
+#undef MEMBER
+};
+
+struct MCCNominalCentroidalPose
+{
+  MC_RTC_NEW_SCHEMA(MCCNominalCentroidalPose)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCNominalCentroidalPose, __VA_ARGS__)
+  MEMBER(double, time, "Time to trigger")
+  MEMBER(sva::PTransformd, pose, "Centroidal pose")
+#undef MEMBER
+};
+
+struct MCCCollision
+{
+  MC_RTC_NEW_SCHEMA(MCCCollision)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCCollision, __VA_ARGS__)
+  MEMBER(std::string, body1, "Body in r1")
+  MEMBER(std::string, body2, "Body in r2")
+#undef MEMBER
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_MEMBER(MCCCollision, __VA_ARGS__)
+  MEMBER(double, iDist, "Interaction distance", 0.05)
+  MEMBER(double, sDist, "Safety distance", 0.01)
+#undef MEMBER
+};
+
+struct MCCCollisionConfig
+{
+  MC_RTC_NEW_SCHEMA(MCCCollisionConfig)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCCollisionConfig, __VA_ARGS__)
+  MEMBER(double, time, "Time to trigger")
+  MEMBER(std::string, type, "Type of operation", mc_rtc::schema::Choices({"Add", "Remove"}))
+  MEMBER(std::string, r1, "First robot")
+  MEMBER(std::string, r2, "First robot")
+  MEMBER(std::vector<MCCCollision>, collisions, "Collisions")
+#undef MEMBER
+};
+
+struct MultiContactMotionConfiguration
+{
+  MC_RTC_NEW_SCHEMA(MultiContactMotionConfiguration)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MultiContactMotionConfiguration, __VA_ARGS__)
+  MEMBER(std::string, baseTime, "How time should be interpreted", mc_rtc::schema::Choices({"Relative", "Absolute"}))
+  MEMBER(std::vector<MCCStepCommand>, stepCommandList, "Multi-contact steps")
+  MEMBER(std::vector<MCCNominalCentroidalPose>, nominalCentroidalPoseList, "List of nominal centroidal poses")
+  MEMBER(std::vector<MCCCollisionConfig>, collisionConfigList, "List of collision in the motion")
 #undef MEMBER
 };
 

--- a/tests/gui_Schema.cpp
+++ b/tests/gui_Schema.cpp
@@ -20,6 +20,7 @@ struct ComposeSchema : public mc_rtc::schema::Schema<ComposeSchema>
 #define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(ComposeSchema, __VA_ARGS__)
   MEMBER(int, integer, "Integer value");
   MEMBER(SimpleSchema, simple, "Simple schema");
+  MEMBER(std::vector<SimpleSchema>, many, "Multiple simple schema");
 #undef MEMBER
 };
 

--- a/tests/gui_Schema.cpp
+++ b/tests/gui_Schema.cpp
@@ -4,16 +4,7 @@
 
 #include "gui_TestServer.h"
 
-#include <mc_rtc/Schema.h>
-
-struct SimpleSchema : public mc_rtc::schema::Schema<SimpleSchema>
-{
-#define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__)
-  MEMBER(bool, useFeature, "Use magic feature");
-  MEMBER(double, weight, "Task weight");
-  MEMBER(std::vector<std::string>, names, "Some names");
-#undef MEMBER
-};
+#include "samples_Schema.h"
 
 struct ComposeSchema : public mc_rtc::schema::Schema<ComposeSchema>
 {

--- a/tests/gui_Schema.cpp
+++ b/tests/gui_Schema.cpp
@@ -9,7 +9,7 @@
 struct ComposeSchema
 {
   MC_RTC_NEW_SCHEMA(ComposeSchema)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ComposeSchema, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ComposeSchema, __VA_ARGS__))
   MEMBER(int, integer, "Integer value")
   MEMBER(SimpleSchema, simple, "Simple schema")
   MEMBER(std::vector<SimpleSchema>, many, "Multiple simple schema")
@@ -19,7 +19,7 @@ struct ComposeSchema
 struct InteractiveSchema
 {
   MC_RTC_NEW_SCHEMA(InteractiveSchema)
-#define MEMBER(...) MC_RTC_SCHEMA_MEMBER(InteractiveSchema, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_MEMBER(InteractiveSchema, __VA_ARGS__))
   MEMBER(Eigen::Vector3d,
          point,
          "3D point",
@@ -34,7 +34,7 @@ struct SimpleVariant
 {
   MC_RTC_NEW_SCHEMA(SimpleVariant)
   using gain_t = std::variant<double, Eigen::Vector3d>;
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleVariant, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleVariant, __VA_ARGS__))
   MEMBER(gain_t, stiffness, "Task stiffness", mc_rtc::schema::Choices({"scalar", "dimensional"}))
 #undef MEMBER
 };
@@ -42,7 +42,7 @@ struct SimpleVariant
 struct ChildSchema : public SimpleSchema
 {
   MC_RTC_SCHEMA(ChildSchema, SimpleSchema)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ChildSchema, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ChildSchema, __VA_ARGS__))
   MEMBER(double, gain, "Some gain")
 #undef MEMBER
 };
@@ -50,7 +50,7 @@ struct ChildSchema : public SimpleSchema
 struct MCCContactConstraint
 {
   MC_RTC_NEW_SCHEMA(MCCContactConstraint)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCContactConstraint, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCContactConstraint, __VA_ARGS__))
   MEMBER(std::string, type, "Type of contact constraint", mc_rtc::schema::Choices({"Empty", "Surface", "Grasp"}))
   MEMBER(double, fricCoeff, "Contact friction coefficient")
 #undef MEMBER
@@ -59,7 +59,7 @@ struct MCCContactConstraint
 struct MCCSwingCommandConfig
 {
   MC_RTC_NEW_SCHEMA(MCCSwingCommandConfig)
-#define MEMBER(...) MC_RTC_SCHEMA_OPTIONAL_DEFAULT_MEMBER(MCCSwingCommandConfig, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_OPTIONAL_DEFAULT_MEMBER(MCCSwingCommandConfig, __VA_ARGS__))
   MEMBER(Eigen::Vector3d, approachOffset, "Offset for approach")
   MEMBER(Eigen::Vector3d, withdrawOffset, "Offset for withdraw")
 #undef MEMBER
@@ -68,7 +68,7 @@ struct MCCSwingCommandConfig
 struct MCCSwingCommand
 {
   MC_RTC_NEW_SCHEMA(MCCSwingCommand)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCSwingCommand, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCSwingCommand, __VA_ARGS__))
   MEMBER(std::string, type, "Type of motion", mc_rtc::schema::Choices({"Add", "Remove"}))
   MEMBER(double, startTime, "Start time")
   MEMBER(double, endTime, "End time")
@@ -79,7 +79,7 @@ struct MCCSwingCommand
 struct MCCContactCommand
 {
   MC_RTC_NEW_SCHEMA(MCCContactCommand)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCContactCommand, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCContactCommand, __VA_ARGS__))
   MEMBER(double, time, "Time to enable contact")
   MEMBER(MCCContactConstraint, constraint, "Contact constraint")
 #undef MEMBER
@@ -88,7 +88,7 @@ struct MCCContactCommand
 struct MCCGripperCommandConfig
 {
   MC_RTC_NEW_SCHEMA(MCCGripperCommandConfig)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCGripperCommandConfig, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCGripperCommandConfig, __VA_ARGS__))
   MEMBER(double, opening, "Target opening")
 #undef MEMBER
 };
@@ -96,7 +96,7 @@ struct MCCGripperCommandConfig
 struct MCCGripperCommand
 {
   MC_RTC_NEW_SCHEMA(MCCGripperCommand)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCGripperCommand, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCGripperCommand, __VA_ARGS__))
   MEMBER(double, time, "Time to trigger gripper")
   MEMBER(std::string, name, "Gripper's name")
   MEMBER(MCCGripperCommandConfig, config, "Gripper's motion configuration")
@@ -106,11 +106,11 @@ struct MCCGripperCommand
 struct MCCStepCommand
 {
   MC_RTC_NEW_SCHEMA(MCCStepCommand)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCStepCommand, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCStepCommand, __VA_ARGS__))
   MEMBER(std::string, limb, "Contact limb")
   MEMBER(sva::PTransformd, pose, "Contact position")
 #undef MEMBER
-#define MEMBER(...) MC_RTC_SCHEMA_OPTIONAL_DEFAULT_MEMBER(MCCStepCommand, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_OPTIONAL_DEFAULT_MEMBER(MCCStepCommand, __VA_ARGS__))
   MEMBER(std::string, type, "Type of motion", mc_rtc::schema::Choices({"Add", "Remove"}))
   MEMBER(double, startTime, "Start time")
   MEMBER(double, endTime, "End time")
@@ -124,7 +124,7 @@ struct MCCStepCommand
 struct MCCNominalCentroidalPose
 {
   MC_RTC_NEW_SCHEMA(MCCNominalCentroidalPose)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCNominalCentroidalPose, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCNominalCentroidalPose, __VA_ARGS__))
   MEMBER(double, time, "Time to trigger")
   MEMBER(sva::PTransformd, pose, "Centroidal pose")
 #undef MEMBER
@@ -133,11 +133,11 @@ struct MCCNominalCentroidalPose
 struct MCCCollision
 {
   MC_RTC_NEW_SCHEMA(MCCCollision)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCCollision, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCCollision, __VA_ARGS__))
   MEMBER(std::string, body1, "Body in r1")
   MEMBER(std::string, body2, "Body in r2")
 #undef MEMBER
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_MEMBER(MCCCollision, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_MEMBER(MCCCollision, __VA_ARGS__))
   MEMBER(double, iDist, "Interaction distance", 0.05)
   MEMBER(double, sDist, "Safety distance", 0.01)
 #undef MEMBER
@@ -146,7 +146,7 @@ struct MCCCollision
 struct MCCCollisionConfig
 {
   MC_RTC_NEW_SCHEMA(MCCCollisionConfig)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCCollisionConfig, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MCCCollisionConfig, __VA_ARGS__))
   MEMBER(double, time, "Time to trigger")
   MEMBER(std::string, type, "Type of operation", mc_rtc::schema::Choices({"Add", "Remove"}))
   MEMBER(std::string, r1, "First robot")
@@ -158,7 +158,7 @@ struct MCCCollisionConfig
 struct MultiContactMotionConfiguration
 {
   MC_RTC_NEW_SCHEMA(MultiContactMotionConfiguration)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MultiContactMotionConfiguration, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(MultiContactMotionConfiguration, __VA_ARGS__))
   MEMBER(std::string, baseTime, "How time should be interpreted", mc_rtc::schema::Choices({"Relative", "Absolute"}))
   MEMBER(std::vector<MCCStepCommand>, stepCommandList, "Multi-contact steps")
   MEMBER(std::vector<MCCNominalCentroidalPose>, nominalCentroidalPoseList, "List of nominal centroidal poses")

--- a/tests/gui_Schema.cpp
+++ b/tests/gui_Schema.cpp
@@ -24,19 +24,32 @@ struct ComposeSchema : public mc_rtc::schema::Schema<ComposeSchema>
 #undef MEMBER
 };
 
+struct InteractiveSchema : public mc_rtc::schema::Schema<InteractiveSchema>
+{
+  using ValueFlag = mc_rtc::schema::ValueFlag;
+#define MEMBER(...) SCHEMA_MEMBER(InteractiveSchema, __VA_ARGS__)
+  MEMBER(Eigen::Vector3d, point, "3D point", ValueFlag::Required | ValueFlag::Interactive, Eigen::Vector3d::Zero());
+  MEMBER(Eigen::Vector3d, gain, "3D gain", ValueFlag::Required, Eigen::Vector3d::Zero());
+  MEMBER(Eigen::Vector3d, gainOpt, "3D optional gain", ValueFlag::None, Eigen::Vector3d::Zero());
+#undef MEMBER
+};
+
 struct SchemaServer : public TestServer
 {
   SchemaServer()
   {
     simple_.addToGUI(builder, {"Simple"}, "Update simple", [this]() { simple_updated(); });
     compose_.addToGUI(builder, {"Compose"}, "Update compose", [this]() { compose_updated(); });
+    interactive_.addToGUI(builder, {"Interactive"}, "Update interactive", [this]() { interactive_updated(); });
   }
 
   SimpleSchema simple_;
   ComposeSchema compose_;
+  InteractiveSchema interactive_;
 
   void simple_updated() { mc_rtc::log::info("simple_ updated:\n{}", simple_.dump(true, true)); }
   void compose_updated() { mc_rtc::log::info("compose_ updated:\n{}", compose_.dump(true, true)); }
+  void interactive_updated() { mc_rtc::log::info("interactive_ updated:\n{}", interactive_.dump(true, true)); }
 };
 
 int main()

--- a/tests/samples_Schema.h
+++ b/tests/samples_Schema.h
@@ -7,7 +7,7 @@
 struct SimpleSchema
 {
   MC_RTC_NEW_SCHEMA(SimpleSchema)
-#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__))
   MEMBER(bool, useFeature, "Use magic feature")
   MEMBER(double, weight, "Task weight")
   MEMBER(std::vector<std::string>, names, "Some names")

--- a/tests/samples_Schema.h
+++ b/tests/samples_Schema.h
@@ -1,0 +1,16 @@
+#pragma once
+
+/** Contains some sample schemas to share among tests */
+
+#include <mc_rtc/Schema.h>
+
+struct SimpleSchema : public mc_rtc::schema::Schema<SimpleSchema>
+{
+#define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__)
+  MEMBER(bool, useFeature, "Use magic feature");
+  MEMBER(double, weight, "Task weight");
+  MEMBER(std::vector<std::string>, names, "Some names");
+  MEMBER(sva::ForceVecd, wrench, "Target wrench");
+  MEMBER(sva::PTransformd, pt, "Some transform");
+#undef MEMBER
+};

--- a/tests/samples_Schema.h
+++ b/tests/samples_Schema.h
@@ -4,13 +4,14 @@
 
 #include <mc_rtc/Schema.h>
 
-struct SimpleSchema : public mc_rtc::schema::Schema<SimpleSchema>
+struct SimpleSchema
 {
-#define MEMBER(...) SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__)
-  MEMBER(bool, useFeature, "Use magic feature");
-  MEMBER(double, weight, "Task weight");
-  MEMBER(std::vector<std::string>, names, "Some names");
-  MEMBER(sva::ForceVecd, wrench, "Target wrench");
-  MEMBER(sva::PTransformd, pt, "Some transform");
+  MC_RTC_NEW_SCHEMA(SimpleSchema)
+#define MEMBER(...) MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(SimpleSchema, __VA_ARGS__)
+  MEMBER(bool, useFeature, "Use magic feature")
+  MEMBER(double, weight, "Task weight")
+  MEMBER(std::vector<std::string>, names, "Some names")
+  MEMBER(sva::ForceVecd, wrench, "Target wrench")
+  MEMBER(sva::PTransformd, pt, "Some transform")
 #undef MEMBER
 };

--- a/tests/testSchema.cpp
+++ b/tests/testSchema.cpp
@@ -1,4 +1,4 @@
-#include <mc_rtc/Schema.h>
+#include "samples_Schema.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -30,4 +30,11 @@ BOOST_AUTO_TEST_CASE(TestDefault)
   static_assert(Default<std::variant<double, Eigen::Vector3d>>::value == 0.0);
   using test_variant_t = std::variant<Eigen::Vector3d, double>;
   BOOST_REQUIRE(Default<test_variant_t>::value == Eigen::Vector3d::Zero());
+}
+
+BOOST_AUTO_TEST_CASE(TestSimpleSchema)
+{
+  SimpleSchema default_;
+  SimpleSchema other_;
+  BOOST_REQUIRE(default_ == other_);
 }

--- a/tests/testSchema.cpp
+++ b/tests/testSchema.cpp
@@ -26,4 +26,8 @@ BOOST_AUTO_TEST_CASE(TestDefault)
   BOOST_REQUIRE(Default<sva::ForceVecd>::value == sva::ForceVecd::Zero());
   BOOST_REQUIRE(Default<sva::ImpedanceVecd>::value == sva::ImpedanceVecd::Zero());
   BOOST_REQUIRE(Default<sva::AdmittanceVecd>::value == sva::AdmittanceVecd::Zero());
+  // Variants' default is the default of the first type
+  static_assert(Default<std::variant<double, Eigen::Vector3d>>::value == 0.0);
+  using test_variant_t = std::variant<Eigen::Vector3d, double>;
+  BOOST_REQUIRE(Default<test_variant_t>::value == Eigen::Vector3d::Zero());
 }

--- a/tests/testSchema.cpp
+++ b/tests/testSchema.cpp
@@ -5,7 +5,7 @@
 
 BOOST_AUTO_TEST_CASE(TestDefault)
 {
-  using namespace mc_rtc::schema::details;
+  using namespace mc_rtc;
   // Arithmetic types default to zero
   static_assert(Default<int>::value == 0);
   static_assert(Default<uint64_t>::value == 0);

--- a/tests/testSchema.cpp
+++ b/tests/testSchema.cpp
@@ -1,4 +1,5 @@
 #include "samples_Schema.h"
+#include "utils.h"
 
 #include <boost/test/unit_test.hpp>
 
@@ -37,4 +38,15 @@ BOOST_AUTO_TEST_CASE(TestSimpleSchema)
   SimpleSchema default_;
   SimpleSchema other_;
   BOOST_REQUIRE(default_ == other_);
+  {
+    default_.useFeature = true;
+    default_.weight = 42.42;
+    default_.names = {"a", "b", "c"};
+    default_.wrench = random_fv();
+    default_.pt = random_pt();
+    mc_rtc::Configuration cfg;
+    default_.save(cfg);
+    other_.load(cfg);
+    BOOST_REQUIRE(default_ == other_);
+  }
 }

--- a/tests/testSchema.cpp
+++ b/tests/testSchema.cpp
@@ -49,4 +49,12 @@ BOOST_AUTO_TEST_CASE(TestSimpleSchema)
     other_.load(cfg);
     BOOST_REQUIRE(default_ == other_);
   }
+  {
+    SimpleSchema new_{true, 42.42, default_.names, default_.wrench, default_.pt};
+    BOOST_REQUIRE(new_ == default_);
+  }
+  {
+    SimpleSchema copy_{default_};
+    BOOST_REQUIRE(copy_ == default_);
+  }
 }

--- a/tests/testSchema.cpp
+++ b/tests/testSchema.cpp
@@ -1,0 +1,29 @@
+#include <mc_rtc/Schema.h>
+
+#include <boost/test/unit_test.hpp>
+
+BOOST_AUTO_TEST_CASE(TestDefault)
+{
+  using namespace mc_rtc::schema::details;
+  // Arithmetic types default to zero
+  static_assert(Default<int>::value == 0);
+  static_assert(Default<uint64_t>::value == 0);
+  static_assert(Default<float>::value == 0.0f);
+  static_assert(Default<double>::value == 0.0);
+  // Vectors default to Zero
+  BOOST_REQUIRE(Default<Eigen::Vector3d>::value == Eigen::Vector3d::Zero());
+  BOOST_REQUIRE(Default<Eigen::Vector6d>::value == Eigen::Vector6d::Zero());
+  using Vector9f = Eigen::Matrix<float, 9, 1>;
+  BOOST_REQUIRE(Default<Vector9f>::value == Vector9f::Zero());
+  // Square matrixes default to identity
+  BOOST_REQUIRE(Default<Eigen::Matrix3d>::value == Eigen::Matrix3d::Identity());
+  BOOST_REQUIRE(Default<Eigen::Matrix3i>::value == Eigen::Matrix3i::Identity());
+  // String defaults to empty
+  BOOST_REQUIRE(Default<std::string>::value == std::string(""));
+  // SpaceVecAlg objects default to reasonable values
+  BOOST_REQUIRE(Default<sva::PTransformd>::value == sva::PTransformd::Identity());
+  BOOST_REQUIRE(Default<sva::MotionVecd>::value == sva::MotionVecd::Zero());
+  BOOST_REQUIRE(Default<sva::ForceVecd>::value == sva::ForceVecd::Zero());
+  BOOST_REQUIRE(Default<sva::ImpedanceVecd>::value == sva::ImpedanceVecd::Zero());
+  BOOST_REQUIRE(Default<sva::AdmittanceVecd>::value == sva::AdmittanceVecd::Zero());
+}


### PR DESCRIPTION
This PR adds support for defining Schema-like structures within mc_rtc.

The motivation and the implementation are documented in the doc joined to this PR.

I'm introducing it in this state to:
1. Allow us to start using it in some projects
2. Use it internally in mc_rtc

It is likely the feature will evolve a bit after merging as it gets more practical use.