### PR TITLE
Improve Replay accuracy

### DIFF
--- a/include/mc_rbdyn/ForceSensor.h
+++ b/include/mc_rbdyn/ForceSensor.h
@@ -5,16 +5,12 @@
 #pragma once
 
 #include <mc_rbdyn/Device.h>
+#include <mc_rbdyn/ForceSensorCalibData.h>
 
 namespace mc_rbdyn
 {
 
 struct Robot;
-
-namespace detail
-{
-struct ForceSensorCalibData;
-}
 
 /** This struct is intended to hold static information about a force sensor
  * and the current reading of said sensor. If the appropriate data is
@@ -114,6 +110,8 @@ public:
    * @{
    */
 
+  void loadCalibrator(const detail::ForceSensorCalibData & data) noexcept;
+
   /** Load data from a file, using a gravity vector. The file should
    * contain 13 parameters in that order: mass (1), rpy for X_f_ds (3),
    * position for X_p_vb (3), wrench offset (6).
@@ -153,6 +151,9 @@ public:
   /** Return the sensor offset */
   const sva::ForceVecd & offset() const;
 
+  /** Access the calibration object */
+  inline const detail::ForceSensorCalibData & calib() const noexcept { return calibration_; }
+
   /** @} */
   /* End of Calibration group */
 
@@ -161,7 +162,7 @@ public:
 private:
   sva::ForceVecd wrench_;
 
-  std::shared_ptr<detail::ForceSensorCalibData> calibration_;
+  detail::ForceSensorCalibData calibration_;
 };
 
 inline bool operator==(const mc_rbdyn::ForceSensor & lhs, const mc_rbdyn::ForceSensor & rhs)

--- a/include/mc_rbdyn/ForceSensorCalibData.h
+++ b/include/mc_rbdyn/ForceSensorCalibData.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <mc_rtc/Schema.h>
+
+namespace mc_rbdyn::detail
+{
+
+struct ForceSensorCalibData
+{
+  MC_RTC_NEW_SCHEMA(ForceSensorCalibData)
+#define MEMBER(...) MC_RTC_PP_ID(MC_RTC_SCHEMA_REQUIRED_DEFAULT_MEMBER(ForceSensorCalibData, __VA_ARGS__))
+  MEMBER(double, mass, "Mass of the link generating the wrench")
+  MEMBER(sva::ForceVecd, worldForce, "Constant gravity wrench applied on the force sensor in the world frame")
+  MEMBER(sva::PTransformd, X_f_ds, "Local rotation between the model force sensor and the real one")
+  MEMBER(sva::PTransformd, X_p_vb, "Transform from the parent body to the virtual link CoM")
+  MEMBER(sva::ForceVecd, offset, "Force/torque offset")
+#undef MEMBER
+
+  /** Restore the calibrator default values such that it always returns zero
+   * contribution
+   */
+  void reset();
+
+  /** Load data from a file, using a gravity vector. The file
+   * should contain 13 parameters in that order: mass (1),
+   * rpy for X_f_ds (3), position for X_p_vb (3), wrench
+   * offset (6).
+   *
+   * If the file does not exist, default calibration parameters that do nothing
+   * will be used. If the file exists but its parameters are invalid, an exception will be thrown.
+   *
+   * @throws std::invalid_argument if the file is ill-formed.
+   **/
+  void loadData(const std::string & filename, const Eigen::Vector3d & gravity);
+
+  /** Return the gravity wrench applied on the force sensor in the sensor
+   * frame, i.e. the external force $f_{ext}$ is:
+   * $f_{ext} = f_{mes} - wfToSensor$.
+   * @param X_0_p the transform in the world frame of the parent body of the sensor
+   * @param X_p_f the transform from the parent body to the sensor itself
+   */
+  sva::ForceVecd wfToSensor(const sva::PTransformd & X_0_p, const sva::PTransformd & X_p_f) const noexcept;
+};
+
+} // namespace mc_rbdyn::detail

--- a/include/mc_rtc/SchemaMacros.h
+++ b/include/mc_rtc/SchemaMacros.h
@@ -1,4 +1,4 @@
-#define MC_RTC_PP_ID(X) X
+#include <mc_rtc/macros/pp_id.h>
 
 #define MC_RTC_SCHEMA(SchemaT, BaseT)                                                                        \
   /** Tag to detect Schema objects */                                                                        \

--- a/include/mc_rtc/log/Logger.h
+++ b/include/mc_rtc/log/Logger.h
@@ -111,6 +111,8 @@ public:
     std::map<std::string, sva::PTransformd> init;
     /** Initial configuration of robots in the world */
     std::map<std::string, std::vector<std::vector<double>>> init_q;
+    /** Calibration used for the force sensors */
+    std::map<std::string, std::map<std::string, mc_rtc::Configuration>> calibs;
   };
 
 public:

--- a/include/mc_rtc/log/Logger.h
+++ b/include/mc_rtc/log/Logger.h
@@ -109,6 +109,8 @@ public:
     std::vector<std::string> main_robot_module;
     /** Initial position of robots in the world */
     std::map<std::string, sva::PTransformd> init;
+    /** Initial configuration of robots in the world */
+    std::map<std::string, std::vector<std::vector<double>>> init_q;
   };
 
 public:

--- a/include/mc_rtc/macros/pp_id.h
+++ b/include/mc_rtc/macros/pp_id.h
@@ -1,0 +1,8 @@
+/*
+ * Copyright 2015-2023 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+/** Preprocessor identity, used to force expansion (mainly to work around MSVC "feature") */
+#define MC_RTC_PP_ID(x) x

--- a/include/mc_rtc/pragma.h
+++ b/include/mc_rtc/pragma.h
@@ -5,9 +5,7 @@
 #pragma once
 
 #include <mc_rtc/macros/deprecated.h>
-
-/** Preprocessor identity, used to force expansion (mainly to work around MSVC "feature" */
-#define MC_RTC_PP_ID(x) x
+#include <mc_rtc/macros/pp_id.h>
 
 /** Transform a expression to string*/
 #define MC_RTC_STRINGIFY_(x) #x

--- a/src/mc_control/Ticker.cpp
+++ b/src/mc_control/Ticker.cpp
@@ -181,6 +181,19 @@ Ticker::Ticker(const Configuration & config) : config_(config), gc_(get_gc_confi
     }
     // Do the initialization
     auto [encoders, attitudes] = get_initial_state(*log_, gc_.robots(), gc_.controller().robot().name());
+    if(log_->meta())
+    {
+      const auto & calibs = log_->meta()->calibs;
+      for(const auto & [r, fs_calibs] : calibs)
+      {
+        auto & robot = gc_.robots().robot(r);
+        for(const auto & [fs_name, calib] : fs_calibs)
+        {
+          auto & fs = const_cast<mc_rbdyn::ForceSensor &>(robot.forceSensor(fs_name));
+          fs.loadCalibrator(mc_rbdyn::detail::ForceSensorCalibData::fromConfiguration(calib));
+        }
+      }
+    }
     gc_.init(encoders, attitudes);
   }
   else { gc_.init(); }

--- a/src/mc_control/Ticker.cpp
+++ b/src/mc_control/Ticker.cpp
@@ -181,19 +181,6 @@ Ticker::Ticker(const Configuration & config) : config_(config), gc_(get_gc_confi
     }
     // Do the initialization
     auto [encoders, attitudes] = get_initial_state(*log_, gc_.robots(), gc_.controller().robot().name());
-    if(log_->meta())
-    {
-      const auto & calibs = log_->meta()->calibs;
-      for(const auto & [r, fs_calibs] : calibs)
-      {
-        auto & robot = gc_.robots().robot(r);
-        for(const auto & [fs_name, calib] : fs_calibs)
-        {
-          auto & fs = const_cast<mc_rbdyn::ForceSensor &>(robot.forceSensor(fs_name));
-          fs.loadCalibrator(mc_rbdyn::detail::ForceSensorCalibData::fromConfiguration(calib));
-        }
-      }
-    }
     gc_.init(encoders, attitudes);
   }
   else { gc_.init(); }

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -1048,10 +1048,12 @@ void MCGlobalController::setup_log()
   meta.main_robot_module = controller_->robot().module().parameters();
   meta.init.clear();
   meta.init_q.clear();
+  meta.calibs.clear();
   for(const auto & r : controller_->robots())
   {
     meta.init[r.name()] = r.posW();
     meta.init_q[r.name()] = r.mbc().q;
+    for(const auto & fs : r.forceSensors()) { meta.calibs[r.name()][fs.name()] = fs.calib().toConfiguration(); }
   }
   if(setup_logger_.count(current_ctrl)) { return; }
   // Copy controller pointer to avoid lambda issue

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -1047,7 +1047,12 @@ void MCGlobalController::setup_log()
   meta.main_robot = controller_->robot().name();
   meta.main_robot_module = controller_->robot().module().parameters();
   meta.init.clear();
-  for(const auto & r : controller_->robots()) { meta.init[r.name()] = r.posW(); }
+  meta.init_q.clear();
+  for(const auto & r : controller_->robots())
+  {
+    meta.init[r.name()] = r.posW();
+    meta.init_q[r.name()] = r.mbc().q;
+  }
   if(setup_logger_.count(current_ctrl)) { return; }
   // Copy controller pointer to avoid lambda issue
   MCController * controller = controller_;

--- a/src/mc_rbdyn/ForceSensor.cpp
+++ b/src/mc_rbdyn/ForceSensor.cpp
@@ -16,126 +16,79 @@ namespace mc_rbdyn
 
 namespace detail
 {
-/** Structure used to hold the calibration data. This structure is *NOT*
- * intended to be constructed directly, see @ForceSensorsCalibrator for usage.
- * It is composed of 13 parameters (real numbers) that should be loaded
- * from a calibration file. **/
-struct ForceSensorCalibData
-{
-public:
-  /** Default constructor, always returns zero contribution */
-  ForceSensorCalibData() {}
 
-  /** Restore the calibrator default values such that it always returns zero
-   * contribution
-   */
-  void reset()
-  {
-    mass_ = 0.0;
-    worldForce_ = sva::ForceVecd(Eigen::Vector6d::Zero());
-    X_f_ds_ = sva::PTransformd::Identity();
-    X_p_vb_ = sva::PTransformd::Identity();
-    offset_ = sva::ForceVecd(Eigen::Vector6d::Zero());
-  }
-
-  /** Load data from a file, using a gravity vector. The file
-   * should contain 13 parameters in that order: mass (1),
-   * rpy for X_f_ds (3), position for X_p_vb (3), wrench
-   * offset (6).
-   *
-   * If the file does not exist, default calibration parameters that do nothing
-   * will be used. If the file exists but its parameters are invalid, an exception will be thrown.
-   *
-   * @throws std::invalid_argument if the file is ill-formed.
-   **/
-  void loadData(const std::string & filename, const Eigen::Vector3d & gravity)
-  {
-    constexpr int nr_params = 13;
-    std::ifstream strm(filename);
-    if(!strm.is_open())
-    {
-      mc_rtc::log::error("Could not open {}", filename);
-      return;
-    }
-
-    // Vector 13d
-    Eigen::Matrix<double, nr_params, 1> X;
-    double temp;
-    for(int i = 0; i < nr_params; ++i)
-    {
-      strm >> temp;
-      if(!strm.good())
-      {
-        mc_rtc::log::error_and_throw<std::invalid_argument>("[ForceSensorCalibData] Invalid calibration file {}. {}",
-                                                            filename, dataRequirements());
-      }
-      if(strm.eof())
-      {
-        mc_rtc::log::error_and_throw<std::invalid_argument>(
-            "[ForceSensorCalibData] Calibration file {} is too short. {}", filename, dataRequirements());
-      }
-      X(i) = temp;
-    }
-
-    mass_ = X(0);
-    worldForce_ = sva::ForceVecd(Eigen::Vector3d(0., 0., 0.), -X(0) * gravity);
-    X_f_ds_ = mc_rbdyn::rpyToPT(X.segment<3>(1));
-    X_p_vb_ = sva::PTransformd(Eigen::Matrix3d::Identity(), X.segment<3>(4));
-    offset_ = sva::ForceVecd(X.segment<6>(7));
-  }
-
-  static std::string dataRequirements()
-  {
-    return R"(The file should contain 13 parameters in that order:
+static std::string CalibDataRequirements =
+    R"(The file should contain 13 parameters in that order:
     - mass (1)
     - rpy of local rotation between the model force sensor and real one (3)
     - translation from the parent body to the virtual link CoM (3)
     - wrench offset (6).)";
-  }
 
-  /** Return the gravity wrench applied on the force sensor in the sensor
-   * frame, i.e. the external force $f_{ext}$ is:
-   * $f_{ext} = f_{mes} - wfToSensor$.
-   * @param X_0_p the transform in the world frame of the parent body of the sensor
-   * @param X_p_f the transform from the parent body to the sensor itself
-   */
-  inline sva::ForceVecd wfToSensor(const sva::PTransformd & X_0_p, const sva::PTransformd & X_p_f) const
+void ForceSensorCalibData::reset()
+{
+  mass = 0.0;
+  worldForce = sva::ForceVecd(Eigen::Vector6d::Zero());
+  X_f_ds = sva::PTransformd::Identity();
+  X_p_vb = sva::PTransformd::Identity();
+  offset = sva::ForceVecd(Eigen::Vector6d::Zero());
+}
+
+void ForceSensorCalibData::loadData(const std::string & filename, const Eigen::Vector3d & gravity)
+{
+  constexpr int nr_params = 13;
+  std::ifstream strm(filename);
+  if(!strm.is_open())
   {
-    sva::PTransformd X_0_ds = X_f_ds_ * X_p_f * X_0_p;
-    sva::PTransformd X_0_vb(X_0_ds.inv().rotation(), (X_p_vb_ * X_0_p * X_0_ds.inv()).translation());
-    return offset_ + X_0_vb.transMul(worldForce_);
+    mc_rtc::log::error("Could not open {}", filename);
+    return;
   }
 
-  /** Return X_f_ds, the pure rotation transform from the position given by
-   * the URDF and the one estimated by calibration
-   */
-  inline const sva::PTransformd & X_f_ds() const { return X_f_ds_; }
+  // Vector 13d
+  Eigen::Matrix<double, nr_params, 1> X;
+  double temp;
+  for(int i = 0; i < nr_params; ++i)
+  {
+    strm >> temp;
+    if(!strm.good())
+    {
+      mc_rtc::log::error_and_throw<std::invalid_argument>("[ForceSensorCalibData] Invalid calibration file {}. {}",
+                                                          filename, CalibDataRequirements);
+    }
+    if(strm.eof())
+    {
+      mc_rtc::log::error_and_throw<std::invalid_argument>("[ForceSensorCalibData] Calibration file {} is too short. {}",
+                                                          filename, CalibDataRequirements);
+    }
+    X(i) = temp;
+  }
 
-  /** Return the mass of the link generating the wrench */
-  inline double mass() const { return mass_; }
+  mass = X(0);
+  worldForce = sva::ForceVecd(Eigen::Vector3d(0., 0., 0.), -X(0) * gravity);
+  X_f_ds = mc_rbdyn::rpyToPT(X.segment<3>(1));
+  X_p_vb = sva::PTransformd(Eigen::Matrix3d::Identity(), X.segment<3>(4));
+  offset = sva::ForceVecd(X.segment<6>(7));
+}
 
-  inline const sva::ForceVecd & offset() const { return offset_; }
+/** Return the gravity wrench applied on the force sensor in the sensor
+ * frame, i.e. the external force $f_{ext}$ is:
+ * $f_{ext} = f_{mes} - wfToSensor$.
+ * @param X_0_p the transform in the world frame of the parent body of the sensor
+ * @param X_p_f the transform from the parent body to the sensor itself
+ */
+sva::ForceVecd ForceSensorCalibData::wfToSensor(const sva::PTransformd & X_0_p,
+                                                const sva::PTransformd & X_p_f) const noexcept
+{
+  sva::PTransformd X_0_ds = X_f_ds * X_p_f * X_0_p;
+  sva::PTransformd X_0_vb(X_0_ds.inv().rotation(), (X_p_vb * X_0_p * X_0_ds.inv()).translation());
+  return offset + X_0_vb.transMul(worldForce);
+}
 
-private:
-  /** Mass of the link generating the wrench */
-  double mass_ = 0.0;
-  /** Constant gravity wrench applied on the force sensor
-   * in the world frame: $\{0, mg \} */
-  sva::ForceVecd worldForce_ = sva::ForceVecd(Eigen::Vector6d::Zero());
-  /** Local rotation between the model force sensor and real one */
-  sva::PTransformd X_f_ds_ = sva::PTransformd::Identity();
-  /** Transform from the parent body to the virtual link CoM */
-  sva::PTransformd X_p_vb_ = sva::PTransformd::Identity();
-  /** Force/torque offset */
-  sva::ForceVecd offset_ = sva::ForceVecd(Eigen::Vector6d::Zero());
-};
 } // namespace detail
 
 ForceSensor::ForceSensor() : ForceSensor("", "", sva::PTransformd::Identity()) {}
 
 ForceSensor::ForceSensor(const std::string & name, const std::string & parentBodyName, const sva::PTransformd & X_p_f)
-: Device(name, parentBodyName, X_p_f), wrench_(Eigen::Vector6d::Zero()),
-  calibration_(std::make_shared<detail::ForceSensorCalibData>())
+: Device(name, parentBodyName, X_p_f), wrench_(Eigen::Vector6d::Zero())
 {
   type_ = "ForceSensor";
 }
@@ -143,7 +96,7 @@ ForceSensor::ForceSensor(const std::string & name, const std::string & parentBod
 ForceSensor::ForceSensor(const ForceSensor & fs) : ForceSensor(fs.name_, fs.parentBody(), fs.X_p_f())
 {
   wrench_ = fs.wrench_;
-  *calibration_ = *fs.calibration_;
+  calibration_ = fs.calibration_;
 }
 
 ForceSensor & ForceSensor::operator=(const ForceSensor & fs)
@@ -152,12 +105,17 @@ ForceSensor & ForceSensor::operator=(const ForceSensor & fs)
   name_ = fs.name_;
   parent_ = fs.parent_;
   X_p_s_ = fs.X_p_s_;
-  *calibration_ = *fs.calibration_;
+  calibration_ = fs.calibration_;
   wrench_ = fs.wrench_;
   return *this;
 }
 
 ForceSensor::~ForceSensor() noexcept = default;
+
+void ForceSensor::loadCalibrator(const detail::ForceSensorCalibData & data) noexcept
+{
+  calibration_ = data;
+}
 
 void ForceSensor::loadCalibrator(const std::string & calib_file, const Eigen::Vector3d & gravity)
 {
@@ -166,22 +124,22 @@ void ForceSensor::loadCalibrator(const std::string & calib_file, const Eigen::Ve
     mc_rtc::log::warning("No calibration file {} found for force sensor {}", calib_file, name());
     return;
   }
-  else { calibration_->loadData(calib_file, gravity); }
+  calibration_.loadData(calib_file, gravity);
 }
 
 void ForceSensor::copyCalibrator(const mc_rbdyn::ForceSensor & other)
 {
-  calibration_ = std::make_shared<detail::ForceSensorCalibData>(*other.calibration_);
+  calibration_ = other.calibration_;
 }
 
 void ForceSensor::resetCalibrator()
 {
-  calibration_->reset();
+  calibration_.reset();
 }
 
 const sva::PTransformd & ForceSensor::X_fsmodel_fsactual() const
 {
-  return calibration_->X_f_ds();
+  return calibration_.X_f_ds;
 }
 
 const sva::PTransformd ForceSensor::X_fsactual_parent() const
@@ -191,18 +149,18 @@ const sva::PTransformd ForceSensor::X_fsactual_parent() const
 
 double ForceSensor::mass() const
 {
-  return calibration_->mass();
+  return calibration_.mass;
 }
 
 const sva::ForceVecd & ForceSensor::offset() const
 {
-  return calibration_->offset();
+  return calibration_.offset;
 }
 
 sva::ForceVecd ForceSensor::wrenchWithoutGravity(const mc_rbdyn::Robot & robot) const
 {
   sva::PTransformd X_0_p = robot.mbc().bodyPosW[robot.bodyIndexByName(parent_)];
-  auto w = wrench_ - calibration_->wfToSensor(X_0_p, X_p_s_);
+  auto w = wrench_ - calibration_.wfToSensor(X_0_p, X_p_s_);
   return w;
 }
 

--- a/src/mc_rtc/Logger.cpp
+++ b/src/mc_rtc/Logger.cpp
@@ -297,12 +297,13 @@ void Logger::log()
       }
       else if constexpr(std::is_same_v<T, StartEvent>)
       {
-        builder.start_array(5);
+        builder.start_array(6);
         builder.write(static_cast<uint8_t>(3));
         builder.write(meta_.timestep);
         builder.write(meta_.main_robot);
         builder.write(meta_.main_robot_module);
         builder.write(meta_.init);
+        builder.write(meta_.init_q);
         builder.finish_array();
       }
       else { static_assert(!std::is_same_v<T, T>, "non-exhaustive visitor"); }

--- a/src/mc_rtc/Logger.cpp
+++ b/src/mc_rtc/Logger.cpp
@@ -297,13 +297,14 @@ void Logger::log()
       }
       else if constexpr(std::is_same_v<T, StartEvent>)
       {
-        builder.start_array(6);
+        builder.start_array(7);
         builder.write(static_cast<uint8_t>(3));
         builder.write(meta_.timestep);
         builder.write(meta_.main_robot);
         builder.write(meta_.main_robot_module);
         builder.write(meta_.init);
         builder.write(meta_.init_q);
+        builder.write(meta_.calibs);
         builder.finish_array();
       }
       else { static_assert(!std::is_same_v<T, T>, "non-exhaustive visitor"); }

--- a/src/mc_rtc/internals/LogEntry.h
+++ b/src/mc_rtc/internals/LogEntry.h
@@ -511,9 +511,9 @@ struct LogEntry : mpack_tree_t
           else if(event_t == 3)
           {
             // StartEvent event
-            if(event_size != 5)
+            if(event_size < 5)
             {
-              log::error("Start event should have five entries");
+              log::error("Start event should have at least five entries");
               valid_ = false;
               return;
             }
@@ -523,6 +523,7 @@ struct LogEntry : mpack_tree_t
             meta.main_robot = data[2].operator std::string();
             meta.main_robot_module = data[3];
             meta.init = data[4];
+            if(data.size() > 5) { meta.init_q = data[5]; }
             metaOut = meta;
           }
           else

--- a/src/mc_rtc/internals/LogEntry.h
+++ b/src/mc_rtc/internals/LogEntry.h
@@ -524,6 +524,7 @@ struct LogEntry : mpack_tree_t
             meta.main_robot_module = data[3];
             meta.init = data[4];
             if(data.size() > 5) { meta.init_q = data[5]; }
+            if(data.size() > 6) { meta.calibs = data[6]; }
             metaOut = meta;
           }
           else

--- a/tests/controllers/replay/CMakeLists.txt
+++ b/tests/controllers/replay/CMakeLists.txt
@@ -28,6 +28,9 @@ set_target_properties(
              LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/TestReplayController
              RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/TestReplayController
 )
+target_include_directories(TestReplayController PRIVATE ${CMAKE_SOURCE_DIR}/tests)
+set(CONFIG_HEADER_INCLUDE_DIR "${CMAKE_BINARY_DIR}/tests/include/$<CONFIG>")
+target_include_directories(TestReplayController PRIVATE ${CONFIG_HEADER_INCLUDE_DIR})
 
 add_global_controller_test_run(
   TestReplayController_Record ${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/mc_rtc.yaml 50

--- a/tests/controllers/replay/TestReplayController_Play.in.yaml
+++ b/tests/controllers/replay/TestReplayController_Play.in.yaml
@@ -1,6 +1,6 @@
 Plugins: [Replay]
 Replay:
-  with-inputs: false
+  with-inputs: true
   with-gui-inputs: false
   with-outputs: false
   with-datastore-config: "@CMAKE_CURRENT_SOURCE_DIR@/datastore-replay.yaml"


### PR DESCRIPTION
This PR introduces two changes to improve Replay accuracy and ease of use

1. Log the initial configuration
==

In some interfaces, in particular mc_openrtm, the initial configuration may be different from the initial values of the encoder. This can lead to some discrepancies in the replay. (usually small but in practice this hinders the search for failing conditions)

2. Log the force sensors' calibrations
==

This simplifies the usage of the Replay significantly as the Replay will now use the same force sensors' calibration parameters that were used during recording.