### PR TITLE
[mc_control] call teardownIdleState after starting execution when fsm::Controller::reset was called

### DIFF
--- a/src/mc_control/fsm/Controller.cpp
+++ b/src/mc_control/fsm/Controller.cpp
@@ -130,6 +130,7 @@ void Controller::reset(const ControllerResetData & data)
     gui_->data().add("states", all_states);
   }
   startIdleState();
+  running_ = false;
 }
 
 void Controller::resetPostures()


### PR DESCRIPTION
Problem:
The weight of the PostureTask is changed to 10000 by startIdleState when `fsm::Controller::reset` is called.
However, if `running_` is true when `fsm::Controller::reset` is called, the weight remains 10000 after starting execution of states because `teardownIdleState` will not be called in `fsm::Controller::run` while `running_` remains true.
This will cause inconsistency of the motion after changing controllers.

Solution:
Set `running_=false` in `fsm::Controller::reset` to call `teardownIdleState` in `fsm::Controller::run` after starting a state.