### PR TITLE
[StabilizerTask] Fix disabling when the robot is in the air

### DIFF
--- a/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
+++ b/include/mc_tasks/lipm_stabilizer/StabilizerTask.h
@@ -834,6 +834,7 @@ protected:
    * @param solver Solver to which this task has been added
    */
   void configure_(mc_solver::QPSolver & solver);
+  void disable_();
 
   /** Ensures that the configuration is valid */
   void checkConfiguration(const StabilizerConfiguration & config);
@@ -953,6 +954,8 @@ protected:
   mc_filter::ExponentialMovingAverage<Eigen::Vector3d> dcmIntegrator_;
   mc_filter::LowPassCompose<Eigen::Vector3d> dcmDerivator_;
   bool inTheAir_ = false; /**< Is the robot in the air? */
+  bool wasInTheAir_ = false; /**< Whether the robot was in the air at the previous iteration */
+  bool wasEnabled_ = true; /**< Whether the stabilizer was enabled before the robot was in the air */
   Eigen::Vector3d dfForceError_ = Eigen::Vector3d::Zero(); /**< Force error in foot force difference control */
   Eigen::Vector3d dfError_ = Eigen::Vector3d::Zero(); /**< Height error in foot force difference control */
   double dt_ = 0.005; /**< Controller cycle in [s] */


### PR DESCRIPTION
This PR properly disables the stabilizer when the robot is in the air by ensuring that all feedback gains are set to zero when lifting occurs and resets them to their pre-lifting values when the robot is back on the ground.

Please note however that in case of erroneous lift-off detection, this might have some side effects as the derivators and integrators are reset (current existing behaviour). However I don't think we ever had erroneous detection of whether the robot is in the air, so it's not a big concern.