### PR TITLE
[Schema] Add support for std::map

### DIFF
--- a/doc/_i18n/en/tutorials/usage/schema.md
+++ b/doc/_i18n/en/tutorials/usage/schema.md
@@ -60,12 +60,11 @@ This occurs because the pre-processor splits the arguments as follows:
 To avoid this you can explicitly alias the type
 
 ```cpp
-using MapType = std::map<std::string, double>
+using MapType = std::map<std::string, double>;
 MEMBER(MapType, jointValues, "Map of joint names and values")
 ```
 
 If this is not an option, you may use `BOOST_IDENTIY_TYPE` instead.
-
 
 
 <h6 class="no_toc">Note for MSVC users</h6>

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -323,7 +323,7 @@ struct Operations
           auto out_ = out.add(name);
           T::formToStd(in(description), out_);
         }
-        else if constexpr(details::is_std_vector_schema_v<T> or details::is_std_map_schema_v<T>)
+        else if constexpr(details::is_std_vector_schema_v<T> || details::is_std_map_schema_v<T>)
         {
           using SchemaT = typename T::value_type;
           std::vector<Configuration> in_ = in(description);

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -67,6 +67,28 @@ inline constexpr bool is_std_vector_schema_v = []()
   else { return false; }
 }();
 
+/** Type-trait to detect an std::map */
+template<typename T>
+struct is_std_map : std::false_type
+{
+};
+
+template<typename... Args>
+struct is_std_map<std::map<Args...>> : std::true_type
+{
+};
+
+template<typename T>
+inline constexpr bool is_std_map_v = is_std_map<T>::value;
+
+/** Type-trait to detect an std::map<Key, ValueT> where ValueT is a Schema-based type */
+template<typename T>
+inline constexpr bool is_std_map_schema_v = []()
+{
+  if constexpr(is_std_map_v<T>) { return is_schema_v<typename T::value_type>; }
+  else { return false; }
+}();
+
 template<typename T, bool IsRequired, bool IsInteractive, bool HasChoices = false, bool IsStatic = false>
 void addValueToForm(const T & value,
                     const std::string & description,
@@ -118,6 +140,10 @@ void addValueToForm(const T & value,
     static value_type default_{};
     addValueToForm<value_type, true, IsInteractive>(default_, description, {}, input);
     form.addElement(input);
+  }
+  else if constexpr(details::is_std_map_v<T>)
+  {
+    // We currently do not support map in forms
   }
   else if constexpr(gui::details::is_variant_v<T>)
   {
@@ -297,7 +323,7 @@ struct Operations
           auto out_ = out.add(name);
           T::formToStd(in(description), out_);
         }
-        else if constexpr(details::is_std_vector_schema_v<T>)
+        else if constexpr(details::is_std_vector_schema_v<T> or details::is_std_map_schema_v<T>)
         {
           using SchemaT = typename T::value_type;
           std::vector<Configuration> in_ = in(description);
@@ -383,6 +409,11 @@ struct Default<T, std::enable_if_t<schema::details::is_std_vector_v<T>>>
   inline static const T value = {};
 };
 
+template<typename T>
+struct Default<T, typename std::enable_if_t<schema::details::is_std_map_v<T>>>
+{
+  inline static const T value = {};
+};
 } // namespace mc_rtc
 
 #include <mc_rtc/SchemaMacros.h>

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -73,8 +73,8 @@ struct is_std_map : std::false_type
 {
 };
 
-template<typename... Args>
-struct is_std_map<std::map<Args...>> : std::true_type
+template<typename T>
+struct is_std_map<std::map<std::string, T>> : std::true_type
 {
 };
 
@@ -323,7 +323,7 @@ struct Operations
           auto out_ = out.add(name);
           T::formToStd(in(description), out_);
         }
-        else if constexpr(details::is_std_vector_schema_v<T> || details::is_std_map_schema_v<T>)
+        else if constexpr(details::is_std_vector_schema_v<T>)
         {
           using SchemaT = typename T::value_type;
           std::vector<Configuration> in_ = in(description);
@@ -334,6 +334,7 @@ struct Operations
             SchemaT::formToStd(in_[i], out_i);
           }
         }
+        else if constexpr(details::is_std_map_schema_v<T>) {}
         else { out.add(name, in(description)); }
       }
     };

--- a/tests/samples_Schema.h
+++ b/tests/samples_Schema.h
@@ -11,6 +11,8 @@ struct SimpleSchema
   MEMBER(bool, useFeature, "Use magic feature")
   MEMBER(double, weight, "Task weight")
   MEMBER(std::vector<std::string>, names, "Some names")
+  using MapType = std::map<std::string, double>;
+  MEMBER(MapType, jointValues, "Some joint values")
   MEMBER(sva::ForceVecd, wrench, "Target wrench")
   MEMBER(sva::PTransformd, pt, "Some transform")
 #undef MEMBER

--- a/tests/testSchema.cpp
+++ b/tests/testSchema.cpp
@@ -31,6 +31,10 @@ BOOST_AUTO_TEST_CASE(TestDefault)
   static_assert(Default<std::variant<double, Eigen::Vector3d>>::value == 0.0);
   using test_variant_t = std::variant<Eigen::Vector3d, double>;
   BOOST_REQUIRE(Default<test_variant_t>::value == Eigen::Vector3d::Zero());
+  BOOST_REQUIRE(Default<std::vector<double>>::value == std::vector<double>{});
+  auto map_value = Default<std::map<std::string, double>>::value;
+  auto expected_map_value = std::map<std::string, double>{};
+  BOOST_REQUIRE(map_value == expected_map_value);
 }
 
 BOOST_AUTO_TEST_CASE(TestSimpleSchema)
@@ -42,6 +46,7 @@ BOOST_AUTO_TEST_CASE(TestSimpleSchema)
     default_.useFeature = true;
     default_.weight = 42.42;
     default_.names = {"a", "b", "c"};
+    default_.jointValues = {{"a", 0.0}, {"b", 1.0}, {"c", 2.0}};
     default_.wrench = random_fv();
     default_.pt = random_pt();
     mc_rtc::Configuration cfg;
@@ -50,7 +55,7 @@ BOOST_AUTO_TEST_CASE(TestSimpleSchema)
     BOOST_REQUIRE(default_ == other_);
   }
   {
-    SimpleSchema new_{true, 42.42, default_.names, default_.wrench, default_.pt};
+    SimpleSchema new_{true, 42.42, default_.names, default_.jointValues, default_.wrench, default_.pt};
     BOOST_REQUIRE(new_ == default_);
   }
   {


### PR DESCRIPTION
Add support for `std::map` in `mc_rtc::Schema`.