### PR TITLE
[Collisions] Allow to select unactive joints

### DIFF
--- a/doc/_data/schemas/mc_rbdyn/Collision.json
+++ b/doc/_data/schemas/mc_rbdyn/Collision.json
@@ -5,8 +5,10 @@
   {
     "body1": { "type": "string", "description": "First convex body used, wildcards can be used" },
     "body2": { "type": "string", "description": "Second convex body used, wildcards can be used" },
-    "r1Joints": { "type": "array", "items": { "type": "string" }, "description": "Active joints used to avoid the collision (default: all)" },
-    "r2Joints": { "type": "array", "items": { "type": "string" }, "description": "Active joints used to avoid the collision (default: all)" },
+    "r1ActiveJoints": { "type": "array", "items": { "type": "string" }, "description": "Active joints used to avoid the collision (default: all)" },
+    "r2ActiveJoints": { "type": "array", "items": { "type": "string" }, "description": "Active joints used to avoid the collision (default: all)" },
+    "r1UnactiveJoints": { "type": "array", "items": { "type": "string" }, "description": "Joints not used to avoid the collision (default: none). Has no effect if r1ActiveJoints isn't empty." },
+    "r2UnactiveJoints": { "type": "array", "items": { "type": "string" }, "description": "Joints not used to avoid the collision (default: none). Has no effect if r2ActiveJoints isn't empty." },
     "iDist": { "type": "number", "default": 0.05, "description": "Interaction distance" },
     "sDist": { "type": "number", "default": 0.01, "description": "Safety distance" },
     "damping": { "type": "number", "default": 0.0, "description": "Damping, 0 enables automatic computation" }

--- a/include/mc_rbdyn/Collision.h
+++ b/include/mc_rbdyn/Collision.h
@@ -24,9 +24,12 @@ struct MC_RBDYN_DLLAPI Collision
             double i,
             double s,
             double d,
-            const std::vector<std::string> & r1Joints = {},
-            const std::vector<std::string> & r2Joints = {})
-  : body1(b1), body2(b2), iDist(i), sDist(s), damping(d), r1Joints(r1Joints), r2Joints(r2Joints)
+            const std::vector<std::string> & r1ActiveJoints = {},
+            const std::vector<std::string> & r2ActiveJoints = {},
+            const std::vector<std::string> & r1UnactiveJoints = {},
+            const std::vector<std::string> & r2UnactiveJoints = {})
+  : body1(b1), body2(b2), iDist(i), sDist(s), damping(d), r1ActiveJoints(r1ActiveJoints),
+    r2ActiveJoints(r2ActiveJoints), r1UnactiveJoints(r1UnactiveJoints), r2UnactiveJoints(r2UnactiveJoints)
   {
   }
   std::string body1; /** First body in the constraint */
@@ -34,8 +37,10 @@ struct MC_RBDYN_DLLAPI Collision
   double iDist; /** Interaction distance */
   double sDist; /** Security distance */
   double damping; /** Damping (0 is automatic */
-  std::vector<std::string> r1Joints; /** Selected joints in the first robot (empty = all joints) */
-  std::vector<std::string> r2Joints; /** Selected joints in the second robot, ignored if r1 == r2 */
+  std::vector<std::string> r1ActiveJoints; /** Selected joints in the first robot (empty = all joints selected) */
+  std::vector<std::string> r2ActiveJoints; /** Selected joints in the second robot, ignored if r1 == r2 */
+  std::vector<std::string> r1UnactiveJoints; /** Unselected joints in the first robot (empty = no joints unselected) */
+  std::vector<std::string> r2UnactiveJoints; /** Unselected joints in the second robot, ignored if r1 == r2 */
   inline bool isNone() { return body1 == "NONE" && body2 == "NONE"; }
 
   bool operator==(const Collision & rhs) const;

--- a/src/mc_solver/utils/jointsToSelector.h
+++ b/src/mc_solver/utils/jointsToSelector.h
@@ -5,6 +5,15 @@
 namespace mc_solver
 {
 
+/**
+ * @brief Returns a joint selector for the given list of active/unactive joints
+ *
+ * @tparam Select If true, the selector will be set to 1 (active) for the given joints, 0 (unactive) otherwise
+ * @tparam Select If false, the selector will be set to 0 (unactive) for the given joints, 1 (active) otherwise
+ *
+ * @return Eigen::VectorXd A joint selector consisting of a vector of size robot.mb().nrDof() with 1 for active joints,
+ * 0 otherwise or an empty vector when all joints are active.
+ */
 template<bool Select = true>
 static inline Eigen::VectorXd jointsToSelector(const mc_rbdyn::Robot & robot, const std::vector<std::string> & joints)
 {


### PR DESCRIPTION
This PR adds the ability to select unactive joints in a collision constraint. Without this we do not have the ability to disable all joints of a robot in a collision constraint, and more often than not it's more natural to specify which joints we want to disable.

This:
- Renames `r1Joints/r2Joints` to `r1ActiveJoints/r2ActiveJoints` and deprecates use of the former
- Introduces `r1UnactiveJoints/r2UnactiveJoints`
- If both `activeJoints` and `unactiveJoints` are present, `activeJoints` takes precedence:
  - `r1ActiveJoints: []` and `r2ActiveJoints: []` -> all joints active
  - `r1ActiveJoints: [J1, J2]` and `r2ActiveJoints: anything` -> J1 and J2 active
  - `r1ActiveJoitns: []` and `r2ActiveJoints: [J1, J2]` -> J1 and J2 unactive

```yaml
- type: collision
  r1: hrp4
  r2: human
  collisions:
    - body1: L_ELBOW_P_LINK
      body2: TorsoLink
      iDist: 0.03
      sDist: 0.001
      r2UnactiveJoints: &unactiveJoints
        [Root, base, Torso_0, Torso_1, Torso_2, Head_0, Head_1, Head_2, LArm_0, LArm_1, LArm_2, LElbow, LForearm, LWrist_0, LWrist_1, LHand, LHandThumbLink1, LHandThumbLink2, LHandThumbLink3, LHandIndexLink1, LHandIndexLink2, LHandIndexLink3, LHandMiddleLink1, LHandMiddleLink2, LHandMiddleLink3, LHandRingLink1, LHandRingLink2, LHandRingLink3, LHandBabyLink1, LHandBabyLink2, LHandBabyLink3, RArm_0, RArm_1, RArm_2, RElbow, RForearm, RWrist_0, RWrist_1, RHand, RHandThumbLink1, RHandThumbLink2, RHandThumbLink3, RHandIndexLink1, RHandIndexLink2, RHandIndexLink3, RHandMiddleLink1, RHandMiddleLink2, RHandMiddleLink3, RHandRingLink1, RHandRingLink2, RHandRingLink3, RHandBabyLink1, RHandBabyLink2, RHandBabyLink3, LLeg_0, LLeg_1, LLeg_2, LShin_0, LAnkle_0, LAnkle_1, RLeg_0, RLeg_1, RLeg_2, RShin_0, RAnkle_0, RAnkle_1]
    - body1: L_WRIST_Y_LINK
      body2: TorsoLink
      iDist: 0.03
      sDist: 0.001
      damping: 0
      r2UnactiveJoints: *unactiveJoints
```

Slightly annoying, with this way of describing it we do not have a direct way of disabling all joints short of listing them all in YAML.