### PR TITLE
[MCControler] Update main robot name

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,8 @@ repos:
           src/mc_control/samples/ExternalForces/etc/ExternalForces.in.yaml|
           src/mc_control/samples/LIPMStabilizer/etc/LIPMStabilizer.in.yaml|
           src/mc_control/fsm/states/data/StabilizerStanding.yaml|
-          tests/controllers/TestPythonState.in.yaml
+          tests/controllers/TestPythonState.in.yaml|
+          tests/global_controller_configuration/mc_rtc.in.yaml
       )$
   - id: debug-statements
   - id: destroyed-symlinks

--- a/doc/_i18n/en.yml
+++ b/doc/_i18n/en.yml
@@ -178,3 +178,4 @@ tutorials:
       title: Supporting MC_RTC_BUILD_STATIC in your code
     debug-lssol-output-6:
       title: Debugging LSSOL output 6
+or: or

--- a/doc/_i18n/en/tutorials/introduction/configuration.html
+++ b/doc/_i18n/en/tutorials/introduction/configuration.html
@@ -30,7 +30,13 @@
       </th>
       <td colspan="2">These entries cover most needs you might have</td>
     </tr>
-    {% include mc_rtc_configuration_row.html entry="MainRobot" desc="This entry dictates the main robot used by all controllers. Most interface cannot infer the correct module to use based on the simulation environment so this is the user's responsibility to make sure the two match." example="MainRobot: JVRC1" %}
+{% capture MainRobot_example2 %}
+# Support renaming the robot
+MainRobot:
+  name: MyRobot
+  module: JVRC1
+{% endcapture %}
+    {% include mc_rtc_configuration_row.html entry="MainRobot" desc="This entry dictates the main robot used by all controllers. Most interface cannot infer the correct module to use based on the simulation environment so this is the user's responsibility to make sure the two match." example="MainRobot: JVRC1" example2=MainRobot_example2%}
     <tr>
       <th scope="row">Enabled</th>
       <td>Provides a list of enabled controllers. See the <a href="{{site.baseurl}}/tutorials/samples/list-of-samples.html">list of all available sample controllers</a>.</td>

--- a/doc/_i18n/jp.yml
+++ b/doc/_i18n/jp.yml
@@ -179,3 +179,4 @@ tutorials:
       title: MC_RTC_BUILD_STATICをプログラムでサポートする方法
     debug-lssol-output-6:
       title: LSSOL output 6のデバッグ
+or: または

--- a/doc/_i18n/jp/tutorials/introduction/configuration.html
+++ b/doc/_i18n/jp/tutorials/introduction/configuration.html
@@ -30,7 +30,13 @@
       </th>
       <td colspan="2">このエントリは、通常考えられるほとんどのニーズをカバーします。</td>
     </tr>
-    {% include mc_rtc_configuration_row.html entry="MainRobot" desc="このエントリは、すべてのコントローラーで使用されるメインロボットを指定します。ほとんどのインターフェイスは、どのモジュールを使用すべきかをシミュレーション環境に基づいて推測することはできません。そのため、シミュレーション環境に応じてユーザーがモジュールを指定する必要があります。" example="MainRobot: JVRC1" %}
+{% capture MainRobot_example2 %}
+# ロボット名の変更をサポート
+MainRobot:
+  name: MyRobot
+  module: JVRC1
+{% endcapture %}
+    {% include mc_rtc_configuration_row.html entry="MainRobot" desc="このエントリは、すべてのコントローラーで使用されるメインロボットを指定します。ほとんどのインターフェイスは、どのモジュールを使用すべきかをシミュレーション環境に基づいて推測することはできません。そのため、シミュレーション環境に応じてユーザーがモジュールを指定する必要があります。" example="MainRobot: JVRC1" example2=MainRobot_example2 %}
     <tr>
       <th scope="row">Enabled</th>
       <td>有効なコントローラーのリストを提供します。<a href="{{site.baseurl}}/tutorials/samples/list-of-samples.html">利用可能なサンプルコントローラーのリスト</a>を参照してください。</a>.</td>

--- a/doc/_includes/mc_rtc_configuration_row.html
+++ b/doc/_includes/mc_rtc_configuration_row.html
@@ -1,5 +1,11 @@
 <tr>
   <th scope="row">{{include.entry}}</th>
   <td>{{include.desc}}</td>
-  <td>{% highlight yaml %}{{include.example}}{% endhighlight %}</td>
+  <td>
+    {% highlight yaml %}{{include.example}}{% endhighlight %}
+    {% if include.example2 %}
+      <p>{% t or %}</p>
+      {% highlight yaml %}{{include.example2}}{% endhighlight %}
+    {% endif %}
+  </td>
 </tr>

--- a/include/mc_control/mc_global_controller.h
+++ b/include/mc_control/mc_global_controller.h
@@ -883,8 +883,12 @@ public:
      * \param conf Configuration file that should be loaded
      *
      * \param Main robot module, if null use the MainRobot entry in conf to initialize it
+     *
+     * \param conf_only If true, only load the specified configuration file
      */
-    GlobalConfiguration(const std::string & conf, std::shared_ptr<mc_rbdyn::RobotModule> rm = nullptr);
+    GlobalConfiguration(const std::string & conf,
+                        std::shared_ptr<mc_rbdyn::RobotModule> rm = nullptr,
+                        bool conf_only = false);
 
     inline bool enabled(const std::string & ctrl);
 

--- a/include/mc_control/mc_global_controller.h
+++ b/include/mc_control/mc_global_controller.h
@@ -898,7 +898,7 @@ public:
     std::string init_attitude_sensor = "";
 
     std::vector<std::string> robot_module_paths = {};
-    std::shared_ptr<mc_rbdyn::RobotModule> main_robot_module;
+    std::shared_ptr<mc_rbdyn::RobotModule> main_robot_module = nullptr;
 
     std::vector<std::string> observer_module_paths = {};
 

--- a/include/mc_control/mc_global_controller.h
+++ b/include/mc_control/mc_global_controller.h
@@ -15,9 +15,6 @@
 #include <mc_rtc/log/Logger.h>
 
 #include <array>
-#include <fstream>
-#include <sstream>
-#include <thread>
 
 namespace mc_control
 {
@@ -878,7 +875,6 @@ public:
    */
   bool running = false;
 
-public:
   /*! \brief Store the controller configuration */
   struct MC_CONTROL_DLLAPI GlobalConfiguration
   {
@@ -895,21 +891,21 @@ public:
     bool verbose_loader = true;
 
     bool init_attitude_from_sensor = false;
-    std::string init_attitude_sensor = "";
+    std::string init_attitude_sensor;
 
-    std::vector<std::string> robot_module_paths = {};
-    std::shared_ptr<mc_rbdyn::RobotModule> main_robot_module = nullptr;
+    std::vector<std::string> robot_module_paths;
+    std::shared_ptr<mc_rbdyn::RobotModule> main_robot_module;
 
-    std::vector<std::string> observer_module_paths = {};
+    std::vector<std::string> observer_module_paths;
 
-    std::vector<std::string> global_plugin_paths = {};
-    std::vector<std::string> global_plugins = {};
-    std::vector<std::string> global_plugins_autoload = {};
+    std::vector<std::string> global_plugin_paths;
+    std::vector<std::string> global_plugins;
+    std::vector<std::string> global_plugins_autoload;
     std::unordered_map<std::string, mc_rtc::Configuration> global_plugin_configs;
 
-    std::vector<std::string> controller_module_paths = {};
-    std::vector<std::string> enabled_controllers = {};
-    std::string initial_controller = "";
+    std::vector<std::string> controller_module_paths;
+    std::vector<std::string> enabled_controllers;
+    std::string initial_controller;
     std::unordered_map<std::string, mc_rtc::Configuration> controllers_configs;
     double timestep = 0.002;
     bool include_halfsit_controller = true;
@@ -921,8 +917,8 @@ public:
 
     bool enable_gui_server = true;
     double gui_timestep = 0.05;
-    std::vector<std::string> gui_server_pub_uris{};
-    std::vector<std::string> gui_server_rep_uris{};
+    std::vector<std::string> gui_server_pub_uris;
+    std::vector<std::string> gui_server_rep_uris;
 
     Configuration config;
 
@@ -936,8 +932,8 @@ public:
 private:
   using duration_ms = std::chrono::duration<double, std::milli>;
   GlobalConfiguration config;
-  std::string current_ctrl = "";
-  std::string next_ctrl = "";
+  std::string current_ctrl;
+  std::string next_ctrl;
   MCController * controller_ = nullptr;
   MCController * next_controller_ = nullptr;
   std::unique_ptr<mc_rtc::ObjectLoader<MCController>> controller_loader_;
@@ -945,7 +941,7 @@ private:
   std::vector<mc_observers::ObserverPtr> observers_;
   std::map<std::string, mc_observers::ObserverPtr> observersByName_;
 
-  std::unique_ptr<mc_control::ControllerServer> server_ = nullptr;
+  std::unique_ptr<mc_control::ControllerServer> server_;
 
   std::unique_ptr<mc_rtc::ObjectLoader<GlobalPlugin>> plugin_loader_;
   struct PluginHandle
@@ -981,7 +977,7 @@ private:
   void start_log();
   void setup_log();
   void setup_plugin_log();
-  std::map<std::string, bool> setup_logger_ = {};
+  std::map<std::string, bool> setup_logger_;
 
   /** Timers and performance measure */
   duration_ms global_run_dt{0};

--- a/include/mc_rbdyn/RobotLoader.h
+++ b/include/mc_rbdyn/RobotLoader.h
@@ -132,6 +132,7 @@ public:
     std::lock_guard<std::mutex> guard{mtx};
     init(true);
     robot_loader->clear();
+    aliases.clear();
   }
 
   /** Check if a robot is available

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -130,11 +130,7 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   qpsolver->gui(gui_);
   qpsolver->controller(this);
 
-  std::string main_robot_name = robot_modules[0]->name;
-  if(config.has("MainRobot"))
-  {
-    if(config("MainRobot").has("name")) { config("MainRobot")("name", main_robot_name); }
-  }
+  std::string main_robot_name = config.find<std::string>("MainRobot", "name").value_or(robot_modules[0]->name);
   loadRobot(robot_modules[0], main_robot_name);
   for(auto it = std::next(robot_modules.cbegin()); it != robot_modules.end(); ++it)
   {

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -115,7 +115,7 @@ static inline std::shared_ptr<mc_solver::QPSolver> make_solver(double dt, MCCont
   }
 }
 
-MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModule>> & robots_modules,
+MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModule>> & robot_modules,
                            double dt,
                            const mc_rtc::Configuration & config,
                            ControllerParameters params)
@@ -130,14 +130,15 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   qpsolver->gui(gui_);
   qpsolver->controller(this);
 
-  std::string main_robot_name = robots_modules[0]->name;
+  std::string main_robot_name = robot_modules[0]->name;
   if(config.has("MainRobot"))
   {
     if(config("MainRobot").has("name")) { config("MainRobot")("name", main_robot_name); }
   }
-  loadRobot(robots_modules[0], main_robot_name);
-  for(auto rm : std::vector<mc_rbdyn::RobotModulePtr>(robots_modules.begin() + 1, robots_modules.end()))
+  loadRobot(robot_modules[0], main_robot_name);
+  for(auto it = std::next(robot_modules.cbegin()); it != robot_modules.end(); ++it)
   {
+    const auto & rm = *it;
     loadRobot(rm, rm->name);
   }
   /* Load robot-specific configuration depending on parameters */

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -129,7 +129,24 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   qpsolver->logger(logger_);
   qpsolver->gui(gui_);
   qpsolver->controller(this);
-  for(auto rm : robots_modules) { loadRobot(rm, rm->name); }
+
+  std::string main_robot_name = robots_modules[0]->name;
+  if(config.has("MainRobot"))
+  {
+    std::string main_robot_name_config;
+    if(config("MainRobot").size() == 0) { config("MainRobot", main_robot_name_config); }
+    else
+    {
+      std::vector<std::string> params = config("MainRobot");
+      main_robot_name_config = params[0];
+    }
+    if(!mc_rbdyn::RobotLoader::has_robot(main_robot_name_config)) { main_robot_name = main_robot_name_config; }
+  }
+  loadRobot(robots_modules[0], main_robot_name);
+  for(auto rm : std::vector<mc_rbdyn::RobotModulePtr>(robots_modules.begin() + 1, robots_modules.end()))
+  {
+    loadRobot(rm, rm->name);
+  }
   /* Load robot-specific configuration depending on parameters */
   auto load_robot_config_into = config;
   if(params.load_robot_config_)

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -199,7 +199,7 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   dynamicsConstraint.reset(new mc_solver::DynamicsConstraint(robots(), 0, dt, damper, 0.5));
   kinematicsConstraint.reset(new mc_solver::KinematicsConstraint(robots(), 0, dt, damper, 0.5));
   selfCollisionConstraint.reset(new mc_solver::CollisionsConstraint(robots(), 0, 0, dt));
-  selfCollisionConstraint->addCollisions(solver(), robots_modules[0]->minimalSelfCollisions());
+  selfCollisionConstraint->addCollisions(solver(), robot_modules[0]->minimalSelfCollisions());
   compoundJointConstraint.reset(new mc_solver::CompoundJointConstraint(robots(), 0, timeStep));
   postureTask = std::make_shared<mc_tasks::PostureTask>(solver(), 0, 10.0, 5.0);
   /** Load additional robots from the configuration */

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -133,14 +133,7 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   std::string main_robot_name = robots_modules[0]->name;
   if(config.has("MainRobot"))
   {
-    std::string main_robot_name_config;
-    if(config("MainRobot").size() == 0) { config("MainRobot", main_robot_name_config); }
-    else
-    {
-      std::vector<std::string> params = config("MainRobot");
-      main_robot_name_config = params[0];
-    }
-    if(!mc_rbdyn::RobotLoader::has_robot(main_robot_name_config)) { main_robot_name = main_robot_name_config; }
+    if(config("MainRobot").has("name")) { config("MainRobot")("name", main_robot_name); }
   }
   loadRobot(robots_modules[0], main_robot_name);
   for(auto rm : std::vector<mc_rbdyn::RobotModulePtr>(robots_modules.begin() + 1, robots_modules.end()))

--- a/src/mc_control/Ticker.cpp
+++ b/src/mc_control/Ticker.cpp
@@ -4,6 +4,8 @@
 
 #include <mc_control/Ticker.h>
 
+#include <thread>
+
 #include <boost/filesystem.hpp>
 namespace bfs = boost::filesystem;
 

--- a/src/mc_control/mc_global_controller.cpp
+++ b/src/mc_control/mc_global_controller.cpp
@@ -26,8 +26,6 @@
 
 #include <algorithm>
 #include <cstdlib>
-#include <fstream>
-#include <iomanip>
 
 namespace mc_control
 {
@@ -35,12 +33,12 @@ namespace mc_control
 MCGlobalController::PluginHandle::~PluginHandle() {}
 
 MCGlobalController::MCGlobalController(const std::string & conf, std::shared_ptr<mc_rbdyn::RobotModule> rm)
-: MCGlobalController(GlobalConfiguration(conf, rm))
+: MCGlobalController(GlobalConfiguration(conf, std::move(rm)))
 {
 }
 
 MCGlobalController::MCGlobalController(const GlobalConfiguration & conf)
-: config(conf), current_ctrl(""), next_ctrl(""), controller_(nullptr), next_controller_(nullptr)
+: config(conf), controller_(nullptr), next_controller_(nullptr)
 {
   // Display configuration information
   if(conf.enable_gui_server)

--- a/src/mc_control/mc_global_controller_configuration.cpp
+++ b/src/mc_control/mc_global_controller_configuration.cpp
@@ -20,28 +20,32 @@ namespace mc_control
 {
 
 MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string & conf,
-                                                             std::shared_ptr<mc_rbdyn::RobotModule> rm)
+                                                             std::shared_ptr<mc_rbdyn::RobotModule> rm,
+                                                             bool conf_only)
 {
-  // Load default configuration file
-  std::string globalPath(mc_rtc::CONF_PATH);
-  if(bfs::exists(globalPath))
+  if(!conf_only)
   {
-    mc_rtc::log::info("Loading default global configuration {}", globalPath);
-    config.load(globalPath);
-  }
+    // Load default configuration file
+    std::string globalPath(mc_rtc::CONF_PATH);
+    if(bfs::exists(globalPath))
+    {
+      mc_rtc::log::info("Loading default global configuration {}", globalPath);
+      config.load(globalPath);
+    }
 
 #ifndef WIN32
-  auto config_path = bfs::path(std::getenv("HOME")) / ".config/mc_rtc/mc_rtc.conf";
+    auto config_path = bfs::path(std::getenv("HOME")) / ".config/mc_rtc/mc_rtc.conf";
 #else
-  // Should work for Windows Vista and up
-  auto config_path = bfs::path(std::getenv("APPDATA")) / "mc_rtc/mc_rtc.conf";
+    // Should work for Windows Vista and up
+    auto config_path = bfs::path(std::getenv("APPDATA")) / "mc_rtc/mc_rtc.conf";
 #endif
-  // Load user's local configuration if it exists
-  if(!bfs::exists(config_path)) { config_path.replace_extension(".yaml"); }
-  if(bfs::exists(config_path))
-  {
-    mc_rtc::log::info("Loading additional global configuration {}", config_path.string());
-    config.load(config_path.string());
+    // Load user's local configuration if it exists
+    if(!bfs::exists(config_path)) { config_path.replace_extension(".yaml"); }
+    if(bfs::exists(config_path))
+    {
+      mc_rtc::log::info("Loading additional global configuration {}", config_path.string());
+      config.load(config_path.string());
+    }
   }
   // Load extra configuration
   if(bfs::exists(conf))
@@ -49,6 +53,7 @@ MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string &
     mc_rtc::log::info("Loading additional global configuration {}", conf);
     config.load(conf);
   }
+  else if(conf_only) { mc_rtc::log::error_and_throw("Required to load {} only but this is not available", conf); }
 
   ///////////////////////
   //  General options  //

--- a/src/mc_control/mc_global_controller_configuration.cpp
+++ b/src/mc_control/mc_global_controller_configuration.cpp
@@ -86,7 +86,12 @@ MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string &
       auto main_robot_cfg = config.find("MainRobot");
       if(!main_robot_cfg) { return {"JVRC1"}; }
       if(main_robot_cfg->isArray()) { return main_robot_cfg->operator std::vector<std::string>(); }
-      if(main_robot_cfg->isObject()) { return (*main_robot_cfg)("module").operator std::vector<std::string>(); }
+      if(main_robot_cfg->isObject())
+      {
+        auto module_cfg = (*main_robot_cfg)("module");
+        if(module_cfg.isArray()) { return module_cfg.operator std::vector<std::string>(); }
+        return {module_cfg.operator std::string()};
+      }
       return {main_robot_cfg->operator std::string()};
     }();
     if(!mc_rbdyn::RobotLoader::has_robot(main_robot_params[0]))

--- a/src/mc_control/mc_global_controller_configuration.cpp
+++ b/src/mc_control/mc_global_controller_configuration.cpp
@@ -198,7 +198,6 @@ MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string &
   else { mc_rtc::log::error_and_throw("Enabled entry in mc_rtc must contain at least one controller name"); }
   config("Default", initial_controller);
   config("IncludeHalfSitController", include_halfsit_controller);
-  load_controllers_configs();
 
   ////////////////////
   // Initialization //

--- a/src/mc_control/mc_global_controller_configuration.cpp
+++ b/src/mc_control/mc_global_controller_configuration.cpp
@@ -52,21 +52,6 @@ MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string &
   config("VerboseLoader", verbose_loader);
   config("Timestep", timestep);
 
-  ///////////////////
-  //  Controllers  //
-  ///////////////////
-  config("ControllerModulePaths", controller_module_paths);
-  if(!config("ClearControllerModulePath", false))
-  {
-    controller_module_paths.insert(controller_module_paths.begin(), mc_rtc::MC_CONTROLLER_INSTALL_PREFIX);
-  }
-  enabled_controllers = mc_rtc::fromVectorOrElement<std::string>(config, "Enabled", {});
-  if(enabled_controllers.size()) { initial_controller = enabled_controllers[0]; }
-  else { mc_rtc::log::error_and_throw("Enabled entry in mc_rtc must contain at least one controller name"); }
-  config("Default", initial_controller);
-  config("IncludeHalfSitController", include_halfsit_controller);
-  load_controllers_configs();
-
   //////////////
   //  Robots  //
   //////////////
@@ -89,7 +74,12 @@ MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string &
   {
     if(!config.has("MainRobot") || config("MainRobot").size() == 0)
     {
-      std::string robot_name = config("MainRobot", std::string{"JVRC1"});
+      std::string robot_name = "JVRC1";
+      if(config.has("MainRobot"))
+      {
+        if(config("MainRobot").has("module")) { config("MainRobot")("module", robot_name); }
+        else { config("MainRobot", robot_name); }
+      }
       if(mc_rbdyn::RobotLoader::has_robot(robot_name))
       {
         try
@@ -102,22 +92,6 @@ MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string &
         }
       }
       else
-      {
-        for(auto & c : controllers_configs)
-        {
-          if(c.second.has("robots"))
-          {
-            auto controller_robots_config = c.second("robots");
-            if(controller_robots_config.has(robot_name))
-            {
-              const std::string rm = controller_robots_config(robot_name)("module");
-              main_robot_module = mc_rbdyn::RobotLoader::get_robot_module(rm);
-            }
-            break;
-          }
-        }
-      }
-      if(main_robot_module == nullptr)
       {
         mc_rtc::log::error_and_throw("Trying to use {} as main robot but this robot cannot be loaded", robot_name);
       }
@@ -146,22 +120,6 @@ MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string &
         }
       }
       else
-      {
-        for(auto & c : controllers_configs)
-        {
-          if(c.second.has("robots"))
-          {
-            auto controller_robots_config = c.second("robots");
-            if(controller_robots_config.has(params[0]))
-            {
-              const std::string rm = controller_robots_config(params[0])("module");
-              main_robot_module = mc_rbdyn::RobotLoader::get_robot_module(rm);
-            }
-            break;
-          }
-        }
-      }
-      if(main_robot_module == nullptr)
       {
         mc_rtc::log::error_and_throw("Trying to use {} as main robot but this robot cannot be loaded", params[0]);
       }
@@ -226,6 +184,21 @@ MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string &
       global_plugins.push_back(p);
     }
   }
+
+  ///////////////////
+  //  Controllers  //
+  ///////////////////
+  config("ControllerModulePaths", controller_module_paths);
+  if(!config("ClearControllerModulePath", false))
+  {
+    controller_module_paths.insert(controller_module_paths.begin(), mc_rtc::MC_CONTROLLER_INSTALL_PREFIX);
+  }
+  enabled_controllers = mc_rtc::fromVectorOrElement<std::string>(config, "Enabled", {});
+  if(enabled_controllers.size()) { initial_controller = enabled_controllers[0]; }
+  else { mc_rtc::log::error_and_throw("Enabled entry in mc_rtc must contain at least one controller name"); }
+  config("Default", initial_controller);
+  config("IncludeHalfSitController", include_halfsit_controller);
+  load_controllers_configs();
 
   ////////////////////
   // Initialization //

--- a/src/mc_rbdyn/RobotLoader.cpp
+++ b/src/mc_rbdyn/RobotLoader.cpp
@@ -98,12 +98,15 @@ void RobotLoader::init(bool skip_default_path)
       if(!skip_default_path) { default_path.push_back(mc_rtc::MC_ROBOTS_INSTALL_PREFIX); }
       robot_loader.reset(new mc_rtc::ObjectLoader<RobotModule>("MC_RTC_ROBOT_MODULE", default_path, verbose_));
       for(const auto & p : default_path) { handle_aliases_dir(bfs::path(p) / "aliases"); }
+      if(!skip_default_path)
+      {
 #ifndef WIN32
-      handle_aliases_dir(bfs::path(std::getenv("HOME")) / ".config/mc_rtc/aliases/");
+        handle_aliases_dir(bfs::path(std::getenv("HOME")) / ".config/mc_rtc/aliases/");
 #else
-      // Should work for Windows Vista and up
-      handle_aliases_dir(bfs::path(std::getenv("APPDATA")) / "mc_rtc/aliases/");
+        // Should work for Windows Vista and up
+        handle_aliases_dir(bfs::path(std::getenv("APPDATA")) / "mc_rtc/aliases/");
 #endif
+      }
     }
     catch(const mc_rtc::LoaderException & exc)
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -252,3 +252,5 @@ target_link_libraries(gui_Schema PUBLIC mc_control)
 mc_rtc_test(test_filters mc_filter SpaceVecAlg::SpaceVecAlg)
 
 mc_rtc_test(test_interpolation mc_control)
+
+add_subdirectory(global_controller_configuration)

--- a/tests/global_controller_configuration/CMakeLists.txt
+++ b/tests/global_controller_configuration/CMakeLists.txt
@@ -1,0 +1,56 @@
+set(ROBOT_MODULE_PATH "${CMAKE_BINARY_DIR}/src/mc_robots")
+if(CMAKE_CONFIGURATION_TYPES)
+  set(ROBOT_MODULE_PATH "${ROBOT_MODULE_PATH}/$<CONFIG>")
+endif()
+
+function(make_configuration VAR_OUT MAIN_ROBOT)
+  set(CFG_CMAKE_OUT "${CMAKE_CURRENT_BINARY_DIR}/${VAR_OUT}/etc/mc_rtc.cmake.yaml")
+  set(CFG_OUT "${CMAKE_CURRENT_BINARY_DIR}/${VAR_OUT}/etc/$<CONFIG>/mc_rtc.yaml")
+  configure_file(mc_rtc.in.yaml "${CFG_CMAKE_OUT}" @ONLY)
+  file(
+    GENERATE
+    OUTPUT "${CFG_OUT}"
+    INPUT "${CFG_CMAKE_OUT}"
+  )
+  set(${VAR_OUT}
+      "${CFG_OUT}"
+      PARENT_SCOPE
+  )
+endfunction()
+
+make_configuration(MAIN_ROBOT_SIMPLE_CFG "JVRC1")
+make_configuration(MAIN_ROBOT_SIMPLE_VECTOR_CFG "[JVRC1]")
+make_configuration(MAIN_ROBOT_OBJECT_CFG "{module: JVRC1, name: JVRC1}")
+make_configuration(MAIN_ROBOT_OBJECT_VECTOR_CFG "{module: [JVRC1], name: JVRC1}")
+
+set(CPP_CMAKE_OUT
+    "${CMAKE_CURRENT_BINARY_DIR}/testGlobalControllerConfiguration.cmake.cpp"
+)
+set(CPP_OUT
+    "${CMAKE_CURRENT_BINARY_DIR}/$<CONFIG>/testGlobalControllerConfiguration.cpp"
+)
+configure_file(testGlobalControllerConfiguration.in.cpp "${CPP_CMAKE_OUT}" @ONLY)
+file(
+  GENERATE
+  OUTPUT "${CPP_OUT}"
+  INPUT "${CPP_CMAKE_OUT}"
+)
+
+add_executable(testGlobalControllerConfiguration "${CPP_OUT}")
+target_link_libraries(
+  testGlobalControllerConfiguration
+  PUBLIC mc_rtc::mc_control Boost::unit_test_framework Boost::disable_autolinking
+)
+if(NOT Boost_USE_STATIC_LIBS)
+  target_link_libraries(testGlobalControllerConfiguration PUBLIC Boost::dynamic_linking)
+endif()
+target_compile_definitions(
+  testGlobalControllerConfiguration PRIVATE -DBOOST_TEST_DYN_LINK -DBOOST_TEST_MAIN
+)
+set_target_properties(
+  testGlobalControllerConfiguration PROPERTIES FOLDER tests/framework
+)
+add_test(NAME testGlobalControllerConfiguration
+         COMMAND testGlobalControllerConfiguration
+)
+generate_msvc_dot_user_file(testGlobalControllerConfiguration)

--- a/tests/global_controller_configuration/mc_rtc.in.yaml
+++ b/tests/global_controller_configuration/mc_rtc.in.yaml
@@ -1,0 +1,12 @@
+MainRobot: @MAIN_ROBOT@
+ClearRobotModulePath: true
+RobotModulePaths: ["@ROBOT_MODULE_PATH@"]
+
+ClearControllerModulePath: true
+Enabled: [Posture]
+
+ClearObserverModulePath: true
+ObserverPipelines: {}
+
+ClearGlobalPluginPath: true
+Plugins: []

--- a/tests/global_controller_configuration/testGlobalControllerConfiguration.in.cpp
+++ b/tests/global_controller_configuration/testGlobalControllerConfiguration.in.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2015-2024 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#include <mc_control/mc_global_controller.h>
+
+#include <mc_rbdyn/RobotLoader.h>
+
+#include <boost/test/unit_test.hpp>
+
+/** Make sure the robot loader has nothing available when we start a test case */
+struct TestGlobalControllerConfigurationFixture
+{
+  TestGlobalControllerConfigurationFixture()
+  {
+    mc_rtc::Loader::debug_suffix = "";
+    mc_rbdyn::RobotLoader::clear();
+    std::cout << "AVAILABLE ROBOTS:\n";
+    for(const auto & r : mc_rbdyn::RobotLoader::available_robots()) { std::cout << "- " << r << "\n"; }
+    BOOST_REQUIRE(mc_rbdyn::RobotLoader::available_robots().empty());
+  }
+};
+
+BOOST_FIXTURE_TEST_CASE(MainRobotSimple, TestGlobalControllerConfigurationFixture)
+{
+  mc_control::MCGlobalController::GlobalConfiguration cfg("@MAIN_ROBOT_SIMPLE_CFG@", nullptr, true);
+  BOOST_REQUIRE(cfg.main_robot_module);
+  BOOST_REQUIRE(cfg.main_robot_module->name == "jvrc1");
+}
+
+BOOST_FIXTURE_TEST_CASE(MainRobotSimpleVector, TestGlobalControllerConfigurationFixture)
+{
+  mc_control::MCGlobalController::GlobalConfiguration cfg("@MAIN_ROBOT_SIMPLE_VECTOR_CFG@", nullptr, true);
+  BOOST_REQUIRE(cfg.main_robot_module);
+  BOOST_REQUIRE(cfg.main_robot_module->name == "jvrc1");
+}
+
+BOOST_FIXTURE_TEST_CASE(MainRobotObject, TestGlobalControllerConfigurationFixture)
+{
+  mc_control::MCGlobalController::GlobalConfiguration cfg("@MAIN_ROBOT_OBJECT_CFG@", nullptr, true);
+  BOOST_REQUIRE(cfg.main_robot_module);
+  BOOST_REQUIRE(cfg.main_robot_module->name == "jvrc1");
+}
+
+BOOST_FIXTURE_TEST_CASE(MainRobotObjectVector, TestGlobalControllerConfigurationFixture)
+{
+  mc_control::MCGlobalController::GlobalConfiguration cfg("@MAIN_ROBOT_OBJECT_VECTOR_CFG@", nullptr, true);
+  BOOST_REQUIRE(cfg.main_robot_module);
+  BOOST_REQUIRE(cfg.main_robot_module->name == "jvrc1");
+}


### PR DESCRIPTION
This PR allows to rename the main robot declared in `mc_rtc.yaml` as the one named in a controller configuration in `robots`