### PR TITLE
[robots] Fix init attitude for fixed based robots

### DIFF
--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -293,6 +293,13 @@ Robot::Robot(NewRobotToken,
       const auto & attitude = module_.default_attitude();
       initQ[0] = {std::begin(attitude), std::end(attitude)};
     }
+    else
+    {
+      const auto & attitude = module_.default_attitude();
+      posW(sva::PTransformd{
+          Eigen::Quaterniond(attitude[0], attitude[1], attitude[2], attitude[3]).toRotationMatrix().inverse(),
+          Eigen::Vector3d(attitude[4], attitude[5], attitude[6])});
+    }
     mbc().q = initQ;
     forwardKinematics();
     forwardVelocity();


### PR DESCRIPTION
This PR fixes the initialization of `posW` in case of a fixed-based robot.
In that case we do not have a floating joint and cannot simply set `mbc().q[0]`.