### PR TITLE
[ImpedanceTask] Fix use of targetSurface and implement targetFrame/targetFrameVelocity

### DIFF
--- a/include/mc_tasks/ImpedanceTask.h
+++ b/include/mc_tasks/ImpedanceTask.h
@@ -111,7 +111,7 @@ public:
   const sva::MotionVecd & targetVel() const noexcept { return targetVelW_; }
 
   /*! \brief Set the target velocity of the surface in the world frame. */
-  void targetVel(const sva::MotionVecd & vel) { targetVelW_ = vel; }
+  void targetVel(const sva::MotionVecd & worldVel) override { targetVelW_ = worldVel; }
 
   /*! \brief Get the target acceleration of the surface in the world frame. */
   const sva::MotionVecd & targetAccel() const noexcept { return targetAccelW_; }
@@ -235,11 +235,7 @@ private:
   using TransformTask::refVelB;
 
   /* \brief Same as targetPose(const sva::PTransformd &) */
-  void target(const sva::PTransformd & pos) override
-  {
-    mc_rtc::log::info("ImpedanceTask::target");
-    targetPose(pos);
-  }
+  void target(const sva::PTransformd & pos) override { targetPose(pos); }
 
   /* \brief Same as targetPose() */
   sva::PTransformd target() const override { return targetPose(); }

--- a/include/mc_tasks/ImpedanceTask.h
+++ b/include/mc_tasks/ImpedanceTask.h
@@ -227,10 +227,22 @@ private:
   /** Targets of SurfaceTransformTask should not be set by the user.
    *  Instead, the user can set the targetPose, targetVel, and targetAccel.
    *  Targets of SurfaceTransformTask are determined from the target values through the impedance equation.
+   *
+   *  We override the target functions of TransformTask to set the targetPose instead.
+   *  This allows functions such as targetFrame, targetSurface to work as expected.
    */
   using TransformTask::refAccel;
   using TransformTask::refVelB;
-  using TransformTask::target;
+
+  /* \brief Same as targetPose(const sva::PTransformd &) */
+  void target(const sva::PTransformd & pos) override
+  {
+    mc_rtc::log::info("ImpedanceTask::target");
+    targetPose(pos);
+  }
+
+  /* \brief Same as targetPose() */
+  sva::PTransformd target() const override { return targetPose(); }
 };
 
 } // namespace force

--- a/include/mc_tasks/TransformTask.h
+++ b/include/mc_tasks/TransformTask.h
@@ -7,6 +7,7 @@
 #include <mc_tasks/TrajectoryTaskGeneric.h>
 
 #include <mc_rbdyn/RobotFrame.h>
+#include <SpaceVecAlg/SpaceVecAlg>
 
 namespace mc_tasks
 {
@@ -56,14 +57,14 @@ public:
   void reset() override;
 
   /*! \brief Get the task's target */
-  sva::PTransformd target() const;
+  virtual sva::PTransformd target() const;
 
   /*! \brief Set the task's target
    *
    * \param pos Target in world frame
    *
    */
-  void target(const sva::PTransformd & pos);
+  virtual void target(const sva::PTransformd & pos);
 
   /**
    * @brief Targets a robot surface with an optional offset.
@@ -76,7 +77,9 @@ public:
    * @param offset
    *  offset defined in the target contact frame
    */
-  void targetSurface(unsigned int robotIndex, const std::string & surfaceName, const sva::PTransformd & offset);
+  void targetSurface(unsigned int robotIndex,
+                     const std::string & surfaceName,
+                     const sva::PTransformd & offset = sva::PTransformd::Identity());
 
   /**
    * @brief Targets a given frame with an optional offset
@@ -87,7 +90,18 @@ public:
    *
    * \param offset Offset relative to \p targetFrame
    */
-  void target(const mc_rbdyn::Frame & frame, const sva::PTransformd & offset);
+  void targetFrame(const mc_rbdyn::Frame & targetFrame, const sva::PTransformd & offset = sva::PTransformd::Identity());
+
+  /**
+   * @brief Targets a given frame with an optional offset
+   *
+   * The offset is given in the target frame
+   *
+   * \param targetFrame Target frame
+   *
+   * \param offset Offset relative to \p targetFrame
+   */
+  virtual void target(const mc_rbdyn::Frame & frame, const sva::PTransformd & offset);
 
   /*! \brief Retrieve the controlled frame name */
   inline const std::string & surface() const noexcept { return frame_->name(); }

--- a/include/mc_tasks/TransformTask.h
+++ b/include/mc_tasks/TransformTask.h
@@ -7,7 +7,6 @@
 #include <mc_tasks/TrajectoryTaskGeneric.h>
 
 #include <mc_rbdyn/RobotFrame.h>
-#include <SpaceVecAlg/SpaceVecAlg>
 
 namespace mc_tasks
 {
@@ -64,7 +63,13 @@ public:
    * \param pos Target in world frame
    *
    */
-  virtual void target(const sva::PTransformd & pos);
+  virtual void target(const sva::PTransformd & worldPos);
+
+  /*! \brief Get the task's target velocity
+   *
+   * \param vel Target velocity in world frame
+   */
+  virtual void targetVel(const sva::MotionVecd & worldVel);
 
   /**
    * @brief Targets a robot surface with an optional offset.
@@ -91,6 +96,18 @@ public:
    * \param offset Offset relative to \p targetFrame
    */
   void targetFrame(const mc_rbdyn::Frame & targetFrame, const sva::PTransformd & offset = sva::PTransformd::Identity());
+
+  /**
+   * @brief Targets a given frame velocity with an optional offset
+   *
+   * The offset is given in the target frame
+   *
+   * \param targetFrame Target frame
+   *
+   * \param offset Offset relative to \p targetFrame
+   */
+  void targetFrameVelocity(const mc_rbdyn::Frame & targetFrame,
+                           const sva::PTransformd & offset = sva::PTransformd::Identity());
 
   /**
    * @brief Targets a given frame with an optional offset

--- a/src/mc_tasks/ImpedanceTask.cpp
+++ b/src/mc_tasks/ImpedanceTask.cpp
@@ -143,7 +143,7 @@ void ImpedanceTask::update(mc_solver::QPSolver & solver)
   // 5. Set compliance values to the targets of SurfaceTransformTask
   refAccel(T_0_s * (targetAccelW_ + deltaCompAccelW_)); // represented in the surface frame
   refVelB(T_0_s * (targetVelW_ + deltaCompVelW_)); // represented in the surface frame
-  target(compliancePose()); // represented in the world frame
+  TransformTask::target(compliancePose()); // represented in the world frame
 }
 
 void ImpedanceTask::reset()
@@ -153,7 +153,7 @@ void ImpedanceTask::reset()
   TransformTask::reset();
 
   // Set the target and compliance poses to the SurfaceTransformTask target (i.e., the current pose)
-  targetPoseW_ = target();
+  targetPoseW_ = TransformTask::target();
   deltaCompPoseW_ = sva::PTransformd::Identity();
 
   // Reset the target and compliance velocity and acceleration to zero

--- a/src/mc_tasks/ImpedanceTask.cpp
+++ b/src/mc_tasks/ImpedanceTask.cpp
@@ -142,7 +142,7 @@ void ImpedanceTask::update(mc_solver::QPSolver & solver)
 
   // 5. Set compliance values to the targets of SurfaceTransformTask
   refAccel(T_0_s * (targetAccelW_ + deltaCompAccelW_)); // represented in the surface frame
-  refVelB(T_0_s * (targetVelW_ + deltaCompVelW_)); // represented in the surface frame
+  TransformTask::refVelB(T_0_s * (targetVelW_ + deltaCompVelW_)); // represented in the surface frame
   TransformTask::target(compliancePose()); // represented in the world frame
 }
 

--- a/src/mc_tasks/TransformTask.cpp
+++ b/src/mc_tasks/TransformTask.cpp
@@ -12,6 +12,7 @@
 
 #include <mc_rbdyn/rpy_utils.h>
 
+#include <mc_rbdyn/hat.h>
 #include <mc_rtc/ConfigurationHelpers.h>
 #include <mc_rtc/deprecated.h>
 #include <mc_rtc/gui/Transform.h>
@@ -145,19 +146,26 @@ sva::PTransformd TransformTask::target() const
   }
 }
 
-void TransformTask::target(const sva::PTransformd & pose)
+void TransformTask::target(const sva::PTransformd & worldPose)
 {
   switch(backend_)
   {
     case Backend::Tasks:
-      tasks_error(errorT)->target(pose);
+      tasks_error(errorT)->target(worldPose);
       break;
     case Backend::TVM:
-      tvm_error(errorT)->pose(pose);
+      tvm_error(errorT)->pose(worldPose);
       break;
     default:
       break;
   }
+}
+
+void TransformTask::targetVel(const sva::MotionVecd & worldVec)
+{
+  auto X_0_f = frame_->position();
+  auto velB = X_0_f * worldVec;
+  refVelB(velB);
 }
 
 void TransformTask::targetSurface(unsigned int robotIndex,
@@ -170,6 +178,14 @@ void TransformTask::targetSurface(unsigned int robotIndex,
 void TransformTask::targetFrame(const mc_rbdyn::Frame & targetFrame, const sva::PTransformd & offset)
 {
   target(targetFrame, offset);
+}
+
+void TransformTask::targetFrameVelocity(const mc_rbdyn::Frame & targetFrame, const sva::PTransformd & offset)
+{
+  auto vel = targetFrame.velocity();
+  auto X_0_f = targetFrame.position();
+  vel.linear() += -mc_rbdyn::hat(X_0_f.rotation().transpose() * offset.translation()) * vel.angular();
+  targetVel(vel);
 }
 
 void TransformTask::target(const mc_rbdyn::Frame & frame, const sva::PTransformd & offset)

--- a/src/mc_tasks/TransformTask.cpp
+++ b/src/mc_tasks/TransformTask.cpp
@@ -167,6 +167,11 @@ void TransformTask::targetSurface(unsigned int robotIndex,
   target(robots.robot(robotIndex).frame(surfaceName), offset);
 }
 
+void TransformTask::targetFrame(const mc_rbdyn::Frame & targetFrame, const sva::PTransformd & offset)
+{
+  target(targetFrame, offset);
+}
+
 void TransformTask::target(const mc_rbdyn::Frame & frame, const sva::PTransformd & offset)
 {
   target(offset * frame.position());


### PR DESCRIPTION
We noticed with @Hugo-L3174 that it is possible to call `ImpedanceTask::targetSurface` but that the implementation is wrong. In the current implementation calling the parent's `TransformTask::refVelB` and `TransformTask::target` are explicitly disallowed as the impedance task needs to keep track of the desired target (that is modified through the impedance equation to provide a compliance pose/velocity/acceleration that is then given as the TransformTask's target). However since `ImpedanceTask::targetSurface` is not hidden it is possible to directly modify the target of the underlying `TransformTask` without modifying the impedance target.

To fix this I propose:
- To make `TransformTask::target` virtual, which allows `ImpedanceTask` to override it to keep track of the desired target pose
- To add a `virtual TransformTask::targetVel` function that allows setting the velocity in world frame. This is both for convenience and to mimic the existing `ImpedanceTask::targetVel`
- For convenience I also added `TransformTask::targetFrame` and `TransformTask::targetFrameVelocity` functions. They work as expected for the ImpedanceTask as they simply call the newly introduced virtual functions.

If we wish to be a bit more comprehensive, we could also do the same for `refVelB` which is currently still hidden in `ImpedanceTask`. 