### PR TITLE
[GUI] Fix display of Visual's scaleV

### DIFF
--- a/src/mc_rbdyn/configuration_io.cpp
+++ b/src/mc_rbdyn/configuration_io.cpp
@@ -685,7 +685,7 @@ rbd::parsers::Geometry::Mesh ConfigurationLoader<rbd::parsers::Geometry::Mesh>::
 {
   rbd::parsers::Geometry::Mesh m;
   m.filename = static_cast<std::string>(config("filename"));
-  m.scale = config("scale");
+  m.scaleV = config("scaleV");
   return m;
 }
 
@@ -693,7 +693,7 @@ mc_rtc::Configuration ConfigurationLoader<rbd::parsers::Geometry::Mesh>::save(co
 {
   mc_rtc::Configuration config;
   config.add("filename", m.filename);
-  config.add("scale", m.scale);
+  config.add("scaleV", m.scaleV);
   return config;
 }
 

--- a/tests/testJsonIO.cpp
+++ b/tests/testJsonIO.cpp
@@ -274,7 +274,7 @@ bool operator==(const Geometry::Sphere & lhs, const Geometry::Sphere & rhs)
 
 bool operator==(const Geometry::Mesh & lhs, const Geometry::Mesh & rhs)
 {
-  return lhs.filename == rhs.filename && lhs.scale == rhs.scale;
+  return lhs.filename == rhs.filename && lhs.scaleV == rhs.scaleV;
 }
 
 bool operator==(const Geometry::Superellipsoid & lhs, const Geometry::Superellipsoid & rhs)


### PR DESCRIPTION
This PR modifies `mc_rtc::gui::Visual` to publish the `scaleV` property (scale along x,y,z axes) instead of the `scale` property (global scale for all axes). This allows the display interface to properly display scaled meshes. For example:

```cpp
  gui()->addElement({"Scale"},
        mc_rtc::gui::NumberSlider("x", [this]() { return scale.x(); }, [this](double x) { scale.x() = x; }, 0., 10.),
        mc_rtc::gui::NumberSlider("y", [this]() { return scale.y(); }, [this](double y) { scale.y() = y; }, 0, 10),
        mc_rtc::gui::NumberSlider("z", [this]() { return scale.z(); }, [this](double z) { scale.z() = z; }, 0, 10)
      );
  auto & robot = this->robot();
  for (auto & visual : const_cast<mc_rbdyn::RobotModule &>(robot.module())._visual)
  {
    for (size_t i = 0; i < visual.second.size(); i++)
    {
      auto & v = visual.second[i];
      gui()->addElement({"Human", "Visuals"},
          mc_rtc::gui::Visual(fmt::format("{}_{}", visual.first, i), [&v]() { return v;},
          [this, &robot, &v, &visual]() {
            if (v.geometry.type == rbd::parsers::Geometry::MESH)
            {
              auto & mesh = boost::get<rbd::parsers::Geometry::Mesh>(v.geometry.data);
              mesh.scaleV = scale;
            }
            return v.origin * robot.frame(visual.first).position();
          }));
    }
  }
```
This publishes all of the robot visuals and allows to rescale individiual axes of its meshes online. Note that this is displayed correctly in rviz, but currently not in magnum (as the scale is taken into account only at mesh creation).

In addition, I do not see the point of keeping both `scale` and `scaleV` properties. They are somewhat contradictory, and `scaleV` contains all of the necessary information. Thus I suggest the corresponding PR in RBDyn to remove `scale`.