### PR TITLE
[mc_rbdyn] Implement addForceSensor

### DIFF
--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -663,6 +663,19 @@ public:
    * @{
    */
 
+  /** Add a new force sensor to the robot
+   *
+   * This also updates frames' sensors.
+   *
+   * This does not load the calibration file for this sensor. It is up to the caller to do so if they have a file
+   * availble.
+   *
+   * \param sensor Sensor to be added to the robot
+   *
+   * \throws If a sensor with the same name already exists within this robot
+   */
+  void addForceSensor(const mc_rbdyn::ForceSensor & fs);
+
   /** Check if a force sensor exists
    *
    * @param name Name of the sensor
@@ -684,7 +697,10 @@ public:
    * @returns True if the body has a force sensor attached to it, false
    * otherwise
    */
-  inline bool bodyHasForceSensor(const std::string & body) const noexcept { return bodyForceSensors_.count(body) != 0; }
+  inline bool bodyHasForceSensor(const std::string & body) const noexcept
+  {
+    return data_->bodyForceSensors_.count(body) != 0;
+  }
 
   /**
    * @brief Checks if the surface has a force sensor directly attached to it
@@ -715,7 +731,7 @@ public:
    */
   inline bool bodyHasIndirectForceSensor(const std::string & body) const
   {
-    return bodyHasForceSensor(body) || findIndirectForceSensorBodyName(body).size() != 0;
+    return bodyHasForceSensor(body) || findIndirectForceSensorBodyName(body).empty();
   }
 
   /** Check if the surface has a force sensor attached to it (directly or
@@ -1129,8 +1145,6 @@ private:
   Springs springs_;
   /** Flexibility in this instance */
   std::vector<Flexibility> flexibility_;
-  /** Correspondance between bodies' names and attached force sensors */
-  std::map<std::string, size_t> bodyForceSensors_;
   /** Frames in this robot */
   std::unordered_map<std::string, RobotFramePtr> frames_;
   /** Mass of this robot */

--- a/include/mc_rbdyn/RobotData.h
+++ b/include/mc_rbdyn/RobotData.h
@@ -17,6 +17,8 @@
 namespace mc_rbdyn
 {
 
+struct Robot;
+
 /** Hold data and objects that are shared among different views of a robot (control/real/output)
  *
  * The framework enforce consistency between these views
@@ -42,6 +44,8 @@ struct RobotData
   std::vector<ForceSensor> forceSensors;
   /** Correspondance between force sensor's name and force sensor index */
   std::unordered_map<std::string, size_t> forceSensorsIndex;
+  /** Correspondance between bodies' names and attached force sensors */
+  std::unordered_map<std::string, size_t> bodyForceSensors_;
   /** Hold all body sensors */
   BodySensorVector bodySensors;
   /** Correspondance between body sensor's name and body sensor index*/
@@ -60,6 +64,10 @@ struct RobotData
   DevicePtrVector devices;
   /** Correspondance between a device's name and a device index */
   std::unordered_map<std::string, size_t> devicesIndex;
+  /** A list of robots that share this data
+   *
+   * This is used to communicate changes to the data to all instances that share this data */
+  std::vector<Robot *> robots;
 };
 
 using RobotDataPtr = std::shared_ptr<RobotData>;

--- a/include/mc_rbdyn/RobotFrame.h
+++ b/include/mc_rbdyn/RobotFrame.h
@@ -155,6 +155,9 @@ protected:
   const ForceSensor * sensor_ = nullptr;
 
   void init_tvm_frame() const final;
+
+  /** Search for a force sensor inside Robot again */
+  void resetForceSensor() noexcept;
 };
 
 } // namespace mc_rbdyn

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -528,7 +528,8 @@ void Robot::addBodySensor(const BodySensor & sensor)
     data_->bodySensors.push_back(sensor);
     data_->bodySensorsIndex.insert({sensor.name(), data_->bodySensors.size() - 1});
 
-    if(!bodyHasBodySensor(sensor.name())) data_->bodyBodySensors.insert({sensor.name(), data_->bodySensors.size() - 1});
+    if(!bodyHasBodySensor(sensor.parentBody()))
+      data_->bodyBodySensors.insert({sensor.parentBody(), data_->bodySensors.size() - 1});
   }
 
   else { mc_rtc::log::error_and_throw("Body sensor named {} already attached to {}", sensor.name(), this->name()); }

--- a/src/mc_rbdyn/RobotFrame.cpp
+++ b/src/mc_rbdyn/RobotFrame.cpp
@@ -31,8 +31,7 @@ RobotFrame::RobotFrame(NewRobotFrameToken tkn,
 
 void RobotFrame::resetForceSensor() noexcept
 {
-  if(parent_) { sensor_ = (static_cast<RobotFrame *>(parent_.get()))->sensor_; }
-  else { sensor_ = robot_.findBodyForceSensor(body()); }
+  sensor_ = robot_.findBodyForceSensor(body());
 }
 
 const std::string & RobotFrame::body() const noexcept

--- a/src/mc_rbdyn/RobotFrame.cpp
+++ b/src/mc_rbdyn/RobotFrame.cpp
@@ -29,6 +29,12 @@ RobotFrame::RobotFrame(NewRobotFrameToken tkn,
 {
 }
 
+void RobotFrame::resetForceSensor() noexcept
+{
+  if(parent_) { sensor_ = (static_cast<RobotFrame *>(parent_.get()))->sensor_; }
+  else { sensor_ = robot_.findBodyForceSensor(body()); }
+}
+
 const std::string & RobotFrame::body() const noexcept
 {
   return robot_.mb().body(static_cast<int>(bodyMbcIdx_)).name();


### PR DESCRIPTION
This function allows to insert a new force sensor into a robot at run-time.

This also updates the frames of every robot that uses the same data. This means that adding a force sensor to the control robot will not only update the frames of the control robot but also the real/observed robot and their outputs counterpart.

The sensor calibration file is not searched, the usual scenario where this might be used implies that calibration files do not exist or do not reside in the usual location so searching for them would be wasteful.