### PR TITLE
[mc_rtc_ros] Fix force sensor publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,12 @@ jobs:
           - path: jrl-umi3218/RBDyn
           - path: jrl-umi3218/Tasks
           - path: jrl-umi3218/mc_rbdyn_urdf
-          - path: jrl-umi3218/mc_rtc_data
+          - path: jrl-umi3218/jvrc_description
+            options: -DDISABLE_ROS:BOOL=ON
+          - path: jrl-umi3218/mc_env_description
+            options: -DDISABLE_ROS:BOOL=ON
+          - path: jrl-umi3218/mc_int_obj_description
+            options: -DDISABLE_ROS:BOOL=ON
           - path: jrl-umi3218/eigen-quadprog
           - path: jrl-umi3218/state-observation
           - path: jrl-umi3218/tvm

--- a/utils/build_and_install.sh
+++ b/utils/build_and_install.sh
@@ -941,7 +941,9 @@ then
   check_and_clone_git_dependency jrl-umi3218/mc_rtc_msgs $CATKIN_DATA_WORKSPACE_SRC
   check_and_clone_git_dependency jrl-umi3218/mc_rtc_ros $CATKIN_WORKSPACE_SRC
 else
-  check_and_clone_git_dependency jrl-umi3218/mc_rtc_data $SOURCE_DIR
+  check_and_clone_git_dependency jrl-umi3218/jvrc_description $SOURCE_DIR
+  check_and_clone_git_dependency jrl-umi3218/mc_env_description $SOURCE_DIR
+  check_and_clone_git_dependency jrl-umi3218/mc_int_obj_description $SOURCE_DIR
 fi
 
 echo_log "-- [OK] All manadatory repositories successfuly cloned or updated"
@@ -1270,7 +1272,11 @@ if $WITH_ROS_SUPPORT
 then
   build_catkin_workspace $CATKIN_DATA_WORKSPACE
 else
-  build_git_dependency jrl-umi3218/mc_rtc_data
+  export CMAKE_ADDITIONAL_OPTIONS="${OLD_CMAKE_OPTIONS} -DDISABLE_ROS:BOOL=ON"
+  build_git_dependency jrl-umi3218/jvrc_description
+  build_git_dependency jrl-umi3218/mc_env_description
+  build_git_dependency jrl-umi3218/mc_int_obj_description
+  export CMAKE_ADDITIONAL_OPTIONS="${OLD_CMAKE_OPTIONS}"
 fi
 
 echo_log "-- [SUCCESS] All mandatory dependencies have been successfully built, tested and installed"


### PR DESCRIPTION
This PR fix a segfault error when adding the new  `mc_rbyn:Robot::addForceSensor` and using the `mc_rtc_ros` plugin.
As the msg list was not updated after adding a new force sensor, the plugin throwed a segfault.

The PR will add new force sensors to the msg list.