### PR TITLE
Autoload improvments

### DIFF
--- a/plugins/CMakeLists.txt
+++ b/plugins/CMakeLists.txt
@@ -3,11 +3,14 @@
 #
 
 macro(add_plugin plugin)
-  option(AUTOLOAD_${plugin}_PLUGIN "Automatically load ${plugin} plugin" ON)
+  cmake_parse_arguments(ADD_PLUGIN "AUTOLOAD" "" "" ${ARGN})
+  option(AUTOLOAD_${plugin}_PLUGIN "Automatically load ${plugin} plugin"
+         ${ADD_PLUGIN_AUTOLOAD}
+  )
   if(MC_RTC_BUILD_STATIC)
-    target_sources(mc_control PRIVATE ${ARGN})
+    target_sources(mc_control PRIVATE ${ADD_PLUGIN_UNPARSED_ARGUMENTS})
   else()
-    add_library(${plugin} SHARED ${ARGN})
+    add_library(${plugin} SHARED ${ADD_PLUGIN_UNPARSED_ARGUMENTS})
     set_target_properties(${plugin} PROPERTIES PREFIX "")
     target_link_libraries(${plugin} PUBLIC mc_rtc::mc_control)
     install(
@@ -27,6 +30,15 @@ macro(add_plugin plugin)
   if(AUTOLOAD_${plugin}_PLUGIN)
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/stage/autoload/${plugin}.yaml"
             DESTINATION "${MC_PLUGINS_RUNTIME_INSTALL_PREFIX}/autoload/"
+    )
+  else()
+    set(AUTOLOAD_DESTINATION "${AUTOLOAD_DESTINATION}/${plugin}.yaml")
+    install(
+      CODE "
+    if(EXISTS \"${AUTOLOAD_DESTINATION}\")
+      message(STATUS \"Removing: ${AUTOLOAD_DESTINATION}\")
+      file(REMOVE \"${AUTOLOAD_DESTINATION}\")
+    endif()"
     )
   endif()
 endmacro()

--- a/plugins/ROS/CMakeLists.txt
+++ b/plugins/ROS/CMakeLists.txt
@@ -92,7 +92,7 @@ set(plugin_SRC "${CMAKE_CURRENT_SOURCE_DIR}/src/plugin/ROS.cpp"
 set(plugin_HDR "${CMAKE_CURRENT_SOURCE_DIR}/src/plugin/ROS.h"
                "${CMAKE_CURRENT_SOURCE_DIR}/src/plugin/Services.h"
 )
-add_plugin(ROS "${plugin_SRC}" "${plugin_HDR}")
+add_plugin(ROS AUTOLOAD ${plugin_SRC} ${plugin_HDR})
 set_target_properties(ROS PROPERTIES COMPILE_FLAGS "-DMC_RTC_ROS_PLUGIN_EXPORTS")
 target_link_libraries(ROS PUBLIC mc_rtc_ros mc_tasks_ros)
 install(FILES etc/ROS.yaml DESTINATION "${MC_PLUGINS_RUNTIME_INSTALL_PREFIX}/etc")

--- a/src/mc_control/mc_global_controller_configuration.cpp
+++ b/src/mc_control/mc_global_controller_configuration.cpp
@@ -157,10 +157,16 @@ MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string &
         std::ifstream ifs(p.string());
         std::stringstream ss;
         ss << ifs.rdbuf();
-        auto plugin = ss.str();
+        auto plugin = [&ss]()
+        {
+          auto out = ss.str();
+          out.erase(std::find_if(out.rbegin(), out.rend(), [](unsigned char ch) { return !std::isspace(ch); }).base(),
+                    out.end());
+          return out;
+        }();
         if(std::find(global_plugins.begin(), global_plugins.end(), plugin) == global_plugins.end())
         {
-          global_plugins.push_back(ss.str());
+          global_plugins.push_back(plugin);
           global_plugins_autoload.push_back(global_plugins.back());
         }
       }


### PR DESCRIPTION
This PR fixes three small issues with the plugin autoload feature:
- defaults autoload to `OFF`, one can pass the `AUTOLOAD` parameter to the `add_plugin` macro to restore the old behavior
- when the autoload option is switched off, the file is also uninstalled (previously it had to be removed manually)
- trim the content of the autoload file, this prevents an issue when the file is edited manually