### PR TITLE
Remove the default all signal handler to avoid  signal_handler message and FULL ROS MESSAGE QUEUE error

### DIFF
--- a/plugins/ROS/src/mc_rtc_ros/ros.cpp
+++ b/plugins/ROS/src/mc_rtc_ros/ros.cpp
@@ -7,6 +7,8 @@
 #include <mc_rtc/logging.h>
 #include <mc_rtc/utils.h>
 #include <mc_rtc_ros/ros.h>
+#include <rclcpp/init_options.hpp>
+#include <rclcpp/utilities.hpp>
 
 #include <RBDyn/FK.h>
 
@@ -586,7 +588,7 @@ inline bool ros_init([[maybe_unused]] const std::string & name)
   if(ros::ok()) { return true; }
   int argc = 0;
 #ifdef MC_RTC_ROS_IS_ROS2
-  rclcpp::init(argc, nullptr);
+  rclcpp::init(argc, nullptr, rclcpp::InitOptions(), rclcpp::SignalHandlerOptions::SigTerm);
 #else
   ros::init(argc, nullptr, name.c_str(), ros::init_options::NoSigintHandler);
   if(!ros::master::check())

--- a/plugins/ROS/src/mc_rtc_ros/ros.cpp
+++ b/plugins/ROS/src/mc_rtc_ros/ros.cpp
@@ -7,8 +7,7 @@
 #include <mc_rtc/logging.h>
 #include <mc_rtc/utils.h>
 #include <mc_rtc_ros/ros.h>
-#include <rclcpp/init_options.hpp>
-#include <rclcpp/utilities.hpp>
+
 
 #include <RBDyn/FK.h>
 
@@ -21,6 +20,8 @@
 #  include <std_msgs/msg/string.hpp>
 
 #  include <rclcpp/rclcpp.hpp>
+# include <rclcpp/init_options.hpp>
+# include <rclcpp/utilities.hpp>
 #else
 #  include <geometry_msgs/WrenchStamped.h>
 #  include <mc_rtc_msgs/JointSensors.h>

--- a/src/mc_rtcMacros.in.cmake
+++ b/src/mc_rtcMacros.in.cmake
@@ -235,14 +235,14 @@ macro(find_description_package PACKAGE)
   find_package(${PACKAGE} REQUIRED)
   if("${${PACKAGE}_INSTALL_PREFIX}" STREQUAL "")
     if("${${PACKAGE}_SOURCE_PREFIX}" STREQUAL "")
-       if("${${PACKAGE}_DIR}" STREQUAL "")
-         message(
+      if("${${PACKAGE}_DIR}" STREQUAL "")
+        message(
           FATAL_ERROR
             "Your ${PACKAGE} does not define where to find the data, please update."
-         )
-       else()
-         set(${PACKAGE_PATH_VAR} "${${PACKAGE}_DIR}/..")
-       endif()
+        )
+      else()
+        set(${PACKAGE_PATH_VAR} "${${PACKAGE}_DIR}/..")
+      endif()
     else()
       set(${PACKAGE_PATH_VAR} "${${PACKAGE}_SOURCE_PREFIX}")
     endif()

--- a/src/mc_rtcMacros.in.cmake
+++ b/src/mc_rtcMacros.in.cmake
@@ -235,10 +235,14 @@ macro(find_description_package PACKAGE)
   find_package(${PACKAGE} REQUIRED)
   if("${${PACKAGE}_INSTALL_PREFIX}" STREQUAL "")
     if("${${PACKAGE}_SOURCE_PREFIX}" STREQUAL "")
-      message(
-        FATAL_ERROR
-          "Your ${PACKAGE} does not define where to find the data, please update."
-      )
+       if("${${PACKAGE}_DIR}" STREQUAL "")
+         message(
+          FATAL_ERROR
+            "Your ${PACKAGE} does not define where to find the data, please update."
+         )
+       else()
+         set(${PACKAGE_PATH_VAR} "${${PACKAGE}_DIR}/..")
+       endif()
     else()
       set(${PACKAGE_PATH_VAR} "${${PACKAGE}_SOURCE_PREFIX}")
     endif()


### PR DESCRIPTION
Avoid signint handler message and error concerning FULL ROS MESSAGE QUEUE by removing siginthandler as it has been done for ros1. 

[https://docs.ros.org/en/iron/p/rclcpp/generated/function_namespacerclcpp_1a026b2ac505c383735117de5d1679ed80.html](https://docs.ros.org/en/iron/p/rclcpp/generated/function_namespacerclcpp_1a026b2ac505c383735117de5d1679ed80.html)