### PR TITLE
Overload task constructors to hide targets and poses in GUI

### DIFF
--- a/include/mc_tasks/AdmittanceTask.h
+++ b/include/mc_tasks/AdmittanceTask.h
@@ -51,7 +51,7 @@ public:
    * \throws If the frame does not have a force sensor attached
    *
    */
-  AdmittanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness = 5.0, double weight = 1000.0);
+  AdmittanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness = 5.0, double weight = 1000.0, bool showTarget = true, bool showPose = true);
 
   /*! \brief Initialize a new admittance task.
    *
@@ -74,7 +74,9 @@ public:
                  const mc_rbdyn::Robots & robots,
                  unsigned robotIndex,
                  double stiffness = 5.0,
-                 double weight = 1000.0);
+                 double weight = 1000.0,
+                 bool showTarget = true, 
+                 bool showPose = true);
 
   /*! \brief Reset the task
    *

--- a/include/mc_tasks/AdmittanceTask.h
+++ b/include/mc_tasks/AdmittanceTask.h
@@ -205,6 +205,9 @@ protected:
   void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
   void addToLogger(mc_rtc::Logger & logger) override;
 
+  bool showTarget_ = true;
+  bool showPose_ = true;
+
   /** Transform's refVelB() becomes internal to the task. */
   using TransformTask::refVelB;
 

--- a/include/mc_tasks/AdmittanceTask.h
+++ b/include/mc_tasks/AdmittanceTask.h
@@ -51,7 +51,11 @@ public:
    * \throws If the frame does not have a force sensor attached
    *
    */
-  AdmittanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness = 5.0, double weight = 1000.0, bool showTarget = true, bool showPose = true);
+  AdmittanceTask(const mc_rbdyn::RobotFrame & frame,
+                 double stiffness = 5.0,
+                 double weight = 1000.0,
+                 bool showTarget = true,
+                 bool showPose = true);
 
   /*! \brief Initialize a new admittance task.
    *
@@ -75,7 +79,7 @@ public:
                  unsigned robotIndex,
                  double stiffness = 5.0,
                  double weight = 1000.0,
-                 bool showTarget = true, 
+                 bool showTarget = true,
                  bool showPose = true);
 
   /*! \brief Reset the task

--- a/include/mc_tasks/ImpedanceTask.h
+++ b/include/mc_tasks/ImpedanceTask.h
@@ -183,6 +183,10 @@ public:
 protected:
   ImpedanceGains gains_ = ImpedanceGains::Default();
 
+  bool showTarget_ = true;
+  bool showPose_ = true;
+  bool showCompliance_ = true;
+
   /** Relative pose, velocity, and acceleration from target frame to compliance frame represented in the world frame.
    *  To store these values across control cycles, represent them in a constant world frame instead of the time-varying
    *  surface frame.

--- a/include/mc_tasks/ImpedanceTask.h
+++ b/include/mc_tasks/ImpedanceTask.h
@@ -73,7 +73,10 @@ public:
                 const mc_rbdyn::Robots & robots,
                 unsigned robotIndex,
                 double stiffness = 5.0,
-                double weight = 1000.0);
+                double weight = 1000.0,
+                bool showTarget = true,
+                bool showPose= true,
+                bool showCompliance = true);
 
   /** \brief Constructor
    *
@@ -85,7 +88,10 @@ public:
    *
    * \throws If the frame does not have a force sensor attached to it
    */
-  ImpedanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness = 5.0, double weight = 1000.0);
+  ImpedanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness = 5.0, double weight = 1000.0,
+                                                                            bool showTarget = true,
+                                                                            bool showPose= true,
+                                                                            bool showCompliance = true);
 
   /*! \brief Reset the task
    *

--- a/include/mc_tasks/ImpedanceTask.h
+++ b/include/mc_tasks/ImpedanceTask.h
@@ -75,7 +75,7 @@ public:
                 double stiffness = 5.0,
                 double weight = 1000.0,
                 bool showTarget = true,
-                bool showPose= true,
+                bool showPose = true,
                 bool showCompliance = true);
 
   /** \brief Constructor
@@ -88,10 +88,12 @@ public:
    *
    * \throws If the frame does not have a force sensor attached to it
    */
-  ImpedanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness = 5.0, double weight = 1000.0,
-                                                                            bool showTarget = true,
-                                                                            bool showPose= true,
-                                                                            bool showCompliance = true);
+  ImpedanceTask(const mc_rbdyn::RobotFrame & frame,
+                double stiffness = 5.0,
+                double weight = 1000.0,
+                bool showTarget = true,
+                bool showPose = true,
+                bool showCompliance = true);
 
   /*! \brief Reset the task
    *

--- a/include/mc_tasks/TransformTask.h
+++ b/include/mc_tasks/TransformTask.h
@@ -23,7 +23,11 @@ public:
    *
    * \param weight Task weight
    */
-  TransformTask(const mc_rbdyn::RobotFrame & frame, double stiffness = 2.0, double weight = 500.0, bool showTarget = true, bool showPose = true);
+  TransformTask(const mc_rbdyn::RobotFrame & frame,
+                double stiffness = 2.0,
+                double weight = 500.0,
+                bool showTarget = true,
+                bool showPose = true);
 
   /*! \brief Constructor
    *
@@ -44,7 +48,7 @@ public:
                 const mc_rbdyn::Robots & robots,
                 unsigned int robotIndex,
                 double stiffness = 2.0,
-                double weight = 500, 
+                double weight = 500,
                 bool showTarget = true,
                 bool showPose = true);
 

--- a/include/mc_tasks/TransformTask.h
+++ b/include/mc_tasks/TransformTask.h
@@ -210,8 +210,8 @@ protected:
    * ambiguous. */
   using TrajectoryTaskGeneric::refVel;
 
-  bool showTarget_ = false;
-  bool showPose_ = false;
+  bool showTarget_ = true;
+  bool showPose_ = true;
 };
 
 } // namespace mc_tasks

--- a/include/mc_tasks/TransformTask.h
+++ b/include/mc_tasks/TransformTask.h
@@ -209,6 +209,9 @@ protected:
   /* Don't use parent's refVel() as the velocity frame (spatial or body) is
    * ambiguous. */
   using TrajectoryTaskGeneric::refVel;
+
+  bool showTarget_ = false;
+  bool showPose_ = false;
 };
 
 } // namespace mc_tasks

--- a/include/mc_tasks/TransformTask.h
+++ b/include/mc_tasks/TransformTask.h
@@ -23,7 +23,7 @@ public:
    *
    * \param weight Task weight
    */
-  TransformTask(const mc_rbdyn::RobotFrame & frame, double stiffness = 2.0, double weight = 500.0);
+  TransformTask(const mc_rbdyn::RobotFrame & frame, double stiffness = 2.0, double weight = 500.0, bool showTarget = true, bool showPose = true);
 
   /*! \brief Constructor
    *
@@ -44,7 +44,9 @@ public:
                 const mc_rbdyn::Robots & robots,
                 unsigned int robotIndex,
                 double stiffness = 2.0,
-                double weight = 500);
+                double weight = 500, 
+                bool showTarget = true,
+                bool showPose = true);
 
   /*! \brief Reset the task
    *

--- a/src/mc_tasks/AdmittanceTask.cpp
+++ b/src/mc_tasks/AdmittanceTask.cpp
@@ -11,9 +11,9 @@
 
 #include <mc_rtc/gui/ArrayInput.h>
 #include <mc_rtc/gui/ArrayLabel.h>
+#include <mc_rtc/gui/Checkbox.h>
 #include <mc_rtc/gui/NumberInput.h>
 #include <mc_rtc/gui/Transform.h>
-#include <mc_rtc/gui/Checkbox.h>
 
 #include <mc_rtc/deprecated.h>
 
@@ -36,7 +36,11 @@ AdmittanceTask::AdmittanceTask(const std::string & surfaceName,
 {
 }
 
-AdmittanceTask::AdmittanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness, double weight, bool showTarget, bool showPose)
+AdmittanceTask::AdmittanceTask(const mc_rbdyn::RobotFrame & frame,
+                               double stiffness,
+                               double weight,
+                               bool showTarget,
+                               bool showPose)
 : TransformTask(frame, stiffness, weight)
 {
   if(!frame.hasForceSensor())
@@ -124,10 +128,9 @@ void AdmittanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
   {
     if(showTarget_)
     {
-      gui.addElement({"Tasks", name_},
-                      mc_rtc::gui::Transform(
-                      "targetPose", [this]() { return this->targetPose(); },
-                      [this](const sva::PTransformd & pos) { this->targetPose(pos); }));
+      gui.addElement({"Tasks", name_}, mc_rtc::gui::Transform(
+                                           "targetPose", [this]() { return this->targetPose(); },
+                                           [this](const sva::PTransformd & pos) { this->targetPose(pos); }));
     }
     else { gui.removeElement({"Tasks", name_}, "targetPose"); }
   };
@@ -136,8 +139,7 @@ void AdmittanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
   {
     if(showPose_)
     {
-      gui.addElement({"Tasks", name_},
-                     mc_rtc::gui::Transform("pose", [this]() { return this->surfacePose(); }));
+      gui.addElement({"Tasks", name_}, mc_rtc::gui::Transform("pose", [this]() { return this->surfacePose(); }));
     }
     else { gui.removeElement({"Tasks", name_}, "pose"); }
   };

--- a/src/mc_tasks/AdmittanceTask.cpp
+++ b/src/mc_tasks/AdmittanceTask.cpp
@@ -29,12 +29,14 @@ AdmittanceTask::AdmittanceTask(const std::string & surfaceName,
                                const mc_rbdyn::Robots & robots,
                                unsigned int robotIndex,
                                double stiffness,
-                               double weight)
-: AdmittanceTask(robots.robot(robotIndex).frame(surfaceName), stiffness, weight)
+                               double weight,
+                               bool showTarget,
+                               bool showPose)
+: AdmittanceTask(robots.robot(robotIndex).frame(surfaceName), stiffness, weight, showTarget, showPose)
 {
 }
 
-AdmittanceTask::AdmittanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness, double weight)
+AdmittanceTask::AdmittanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness, double weight, bool showTarget, bool showPose)
 : TransformTask(frame, stiffness, weight)
 {
   if(!frame.hasForceSensor())
@@ -44,6 +46,8 @@ AdmittanceTask::AdmittanceTask(const mc_rbdyn::RobotFrame & frame, double stiffn
   }
   name_ = "admittance_" + frame.robot().name() + "_" + frame.name();
   reset();
+  showTarget_ = showTarget;
+  showPose_ = showPose;
 }
 
 void AdmittanceTask::update(mc_solver::QPSolver &)

--- a/src/mc_tasks/ImpedanceTask.cpp
+++ b/src/mc_tasks/ImpedanceTask.cpp
@@ -287,12 +287,6 @@ void ImpedanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
   showTarget();
   showCompliance();
   gui.addElement({"Tasks", name_},
-                 // pose
-                //  mc_rtc::gui::Transform(
-                //      "targetPose", [this]() -> const sva::PTransformd & { return this->targetPose(); },
-                //      [this](const sva::PTransformd & pos) { this->targetPose(pos); }),
-                //  mc_rtc::gui::Transform("compliancePose", [this]() { return this->compliancePose(); }),
-                //  mc_rtc::gui::Transform("pose", [this]() { return this->surfacePose(); }),
                  // wrench
                  mc_rtc::gui::ArrayInput(
                      "targetWrench", {"cx", "cy", "cz", "fx", "fy", "fz"},

--- a/src/mc_tasks/ImpedanceTask.cpp
+++ b/src/mc_tasks/ImpedanceTask.cpp
@@ -32,10 +32,12 @@ ImpedanceTask::ImpedanceTask(const std::string & surfaceName,
 {
 }
 
-ImpedanceTask::ImpedanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness, double weight,
-                                                                                  bool showTarget,
-                                                                                  bool showPose,
-                                                                                  bool showCompliance)
+ImpedanceTask::ImpedanceTask(const mc_rbdyn::RobotFrame & frame,
+                             double stiffness,
+                             double weight,
+                             bool showTarget,
+                             bool showPose,
+                             bool showCompliance)
 : TransformTask(frame, stiffness, weight), lowPass_(0.005, cutoffPeriod_)
 {
   const auto & robot = frame.robot();
@@ -241,9 +243,9 @@ void ImpedanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
     if(showTarget_)
     {
       gui.addElement({"Tasks", name_},
-                      mc_rtc::gui::Transform(
-                      "targetPose", [this]() -> const sva::PTransformd & { return this->targetPose(); },
-                      [this](const sva::PTransformd & pos) { this->targetPose(pos); }));
+                     mc_rtc::gui::Transform(
+                         "targetPose", [this]() -> const sva::PTransformd & { return this->targetPose(); },
+                         [this](const sva::PTransformd & pos) { this->targetPose(pos); }));
     }
     else { gui.removeElement({"Tasks", name_}, "targetPose"); }
   };
@@ -253,8 +255,7 @@ void ImpedanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
     if(showCompliance_)
     {
       gui.addElement({"Tasks", name_},
-                      mc_rtc::gui::Transform(
-                      "compliancePose", [this]() { return this->compliancePose(); }));
+                     mc_rtc::gui::Transform("compliancePose", [this]() { return this->compliancePose(); }));
     }
     else { gui.removeElement({"Tasks", name_}, "compliancePose"); }
   };
@@ -263,8 +264,7 @@ void ImpedanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
   {
     if(showPose_)
     {
-      gui.addElement({"Tasks", name_},
-                     mc_rtc::gui::Transform("pose", [this]() { return this->surfacePose(); }));
+      gui.addElement({"Tasks", name_}, mc_rtc::gui::Transform("pose", [this]() { return this->surfacePose(); }));
     }
     else { gui.removeElement({"Tasks", name_}, "pose"); }
   };
@@ -284,7 +284,7 @@ void ImpedanceTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
                        showPose_ = !showPose_;
                        showPose();
                      }),
-                  mc_rtc::gui::Checkbox(
+                 mc_rtc::gui::Checkbox(
                      "Show compliance frame", [this]() { return showCompliance_; },
                      [this, showCompliance]()
                      {

--- a/src/mc_tasks/ImpedanceTask.cpp
+++ b/src/mc_tasks/ImpedanceTask.cpp
@@ -24,13 +24,19 @@ ImpedanceTask::ImpedanceTask(const std::string & surfaceName,
                              const mc_rbdyn::Robots & robots,
                              unsigned int robotIndex,
                              double stiffness,
-                             double weight)
-: ImpedanceTask(robots.robot(robotIndex).frame(surfaceName), stiffness, weight)
+                             double weight,
+                             bool showTarget,
+                             bool showPose,
+                             bool showCompliance)
+: ImpedanceTask(robots.robot(robotIndex).frame(surfaceName), stiffness, weight, showTarget, showPose, showCompliance)
 {
 }
 
-ImpedanceTask::ImpedanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness, double weight)
-: TransformTask(frame, stiffness, weight, false, false), lowPass_(0.005, cutoffPeriod_)
+ImpedanceTask::ImpedanceTask(const mc_rbdyn::RobotFrame & frame, double stiffness, double weight,
+                                                                                  bool showTarget,
+                                                                                  bool showPose,
+                                                                                  bool showCompliance)
+: TransformTask(frame, stiffness, weight), lowPass_(0.005, cutoffPeriod_)
 {
   const auto & robot = frame.robot();
   type_ = "impedance";
@@ -40,6 +46,9 @@ ImpedanceTask::ImpedanceTask(const mc_rbdyn::RobotFrame & frame, double stiffnes
   {
     mc_rtc::log::error_and_throw("[{}] Frame {} does not have a force sensor attached", name_, frame.name());
   }
+  showTarget_ = showTarget;
+  showPose_ = showPose;
+  showCompliance_ = showCompliance;
 }
 
 void ImpedanceTask::update(mc_solver::QPSolver & solver)

--- a/src/mc_tasks/TransformTask.cpp
+++ b/src/mc_tasks/TransformTask.cpp
@@ -15,8 +15,8 @@
 #include <mc_rbdyn/hat.h>
 #include <mc_rtc/ConfigurationHelpers.h>
 #include <mc_rtc/deprecated.h>
-#include <mc_rtc/gui/Transform.h>
 #include <mc_rtc/gui/Checkbox.h>
+#include <mc_rtc/gui/Transform.h>
 
 namespace mc_tasks
 {
@@ -24,7 +24,11 @@ namespace mc_tasks
 static inline mc_rtc::void_ptr_caster<tasks::qp::SurfaceTransformTask> tasks_error{};
 static inline mc_rtc::void_ptr_caster<mc_tvm::TransformFunction> tvm_error{};
 
-TransformTask::TransformTask(const mc_rbdyn::RobotFrame & frame, double stiffness, double weight, bool showTarget, bool showPose)
+TransformTask::TransformTask(const mc_rbdyn::RobotFrame & frame,
+                             double stiffness,
+                             double weight,
+                             bool showTarget,
+                             bool showPose)
 : TrajectoryTaskGeneric(frame.robot().robots(), frame.robot().robotIndex(), stiffness, weight), frame_(frame)
 {
   switch(backend_)
@@ -51,7 +55,7 @@ TransformTask::TransformTask(const std::string & surfaceName,
                              unsigned int robotIndex,
                              double stiffness,
                              double weight,
-                             bool showTarget, 
+                             bool showTarget,
                              bool showPose)
 : TransformTask(robots.robot(robotIndex).frame(surfaceName), stiffness, weight, showTarget, showPose)
 {
@@ -251,10 +255,9 @@ void TransformTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
   {
     if(showTarget_)
     {
-      gui.addElement({"Tasks", name_},
-                     mc_rtc::gui::Transform(
-                         "targetPose", [this]() { return this->target(); },
-                         [this](const sva::PTransformd & pos) { this->target(pos); }));
+      gui.addElement({"Tasks", name_}, mc_rtc::gui::Transform(
+                                           "targetPose", [this]() { return this->target(); },
+                                           [this](const sva::PTransformd & pos) { this->target(pos); }));
     }
     else { gui.removeElement({"Tasks", name_}, "targetPose"); }
   };
@@ -263,8 +266,7 @@ void TransformTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
   {
     if(showPose_)
     {
-      gui.addElement({"Tasks", name_},
-                     mc_rtc::gui::Transform("pose", [this]() { return frame_->position(); }));
+      gui.addElement({"Tasks", name_}, mc_rtc::gui::Transform("pose", [this]() { return frame_->position(); }));
     }
     else { gui.removeElement({"Tasks", name_}, "pose"); }
   };

--- a/src/mc_tasks/TransformTask.cpp
+++ b/src/mc_tasks/TransformTask.cpp
@@ -24,7 +24,7 @@ namespace mc_tasks
 static inline mc_rtc::void_ptr_caster<tasks::qp::SurfaceTransformTask> tasks_error{};
 static inline mc_rtc::void_ptr_caster<mc_tvm::TransformFunction> tvm_error{};
 
-TransformTask::TransformTask(const mc_rbdyn::RobotFrame & frame, double stiffness, double weight)
+TransformTask::TransformTask(const mc_rbdyn::RobotFrame & frame, double stiffness, double weight, bool showTarget, bool showPose)
 : TrajectoryTaskGeneric(frame.robot().robots(), frame.robot().robotIndex(), stiffness, weight), frame_(frame)
 {
   switch(backend_)
@@ -42,14 +42,18 @@ TransformTask::TransformTask(const mc_rbdyn::RobotFrame & frame, double stiffnes
 
   type_ = "transform";
   name_ = "transform_" + frame.robot().name() + "_" + frame.name();
+  showTarget_ = showTarget;
+  showPose_ = showPose;
 }
 
 TransformTask::TransformTask(const std::string & surfaceName,
                              const mc_rbdyn::Robots & robots,
                              unsigned int robotIndex,
                              double stiffness,
-                             double weight)
-: TransformTask(robots.robot(robotIndex).frame(surfaceName), stiffness, weight)
+                             double weight,
+                             bool showTarget, 
+                             bool showPose)
+: TransformTask(robots.robot(robotIndex).frame(surfaceName), stiffness, weight, showTarget, showPose)
 {
 }
 

--- a/src/mc_tasks/TransformTask.cpp
+++ b/src/mc_tasks/TransformTask.cpp
@@ -253,10 +253,10 @@ void TransformTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
     {
       gui.addElement({"Tasks", name_},
                      mc_rtc::gui::Transform(
-                         "pos_target", [this]() { return this->target(); },
+                         "targetPose", [this]() { return this->target(); },
                          [this](const sva::PTransformd & pos) { this->target(pos); }));
     }
-    else { gui.removeElement({"Tasks", name_}, "pos_target"); }
+    else { gui.removeElement({"Tasks", name_}, "targetPose"); }
   };
 
   auto showPose = [this, &gui]()
@@ -264,9 +264,9 @@ void TransformTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
     if(showPose_)
     {
       gui.addElement({"Tasks", name_},
-                     mc_rtc::gui::Transform("pos", [this]() { return frame_->position(); }));
+                     mc_rtc::gui::Transform("pose", [this]() { return frame_->position(); }));
     }
-    else { gui.removeElement({"Tasks", name_}, "pos"); }
+    else { gui.removeElement({"Tasks", name_}, "pose"); }
   };
 
   gui.addElement({"Tasks", name_},

--- a/src/mc_tasks/TransformTask.cpp
+++ b/src/mc_tasks/TransformTask.cpp
@@ -16,6 +16,7 @@
 #include <mc_rtc/ConfigurationHelpers.h>
 #include <mc_rtc/deprecated.h>
 #include <mc_rtc/gui/Transform.h>
+#include <mc_rtc/gui/Checkbox.h>
 
 namespace mc_tasks
 {
@@ -242,11 +243,45 @@ std::function<bool(const mc_tasks::MetaTask &, std::string &)> TransformTask::bu
 void TransformTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
 {
   TrajectoryTaskGeneric::addToGUI(gui);
+  auto showTarget = [this, &gui]()
+  {
+    if(showTarget_)
+    {
+      gui.addElement({"Tasks", name_},
+                     mc_rtc::gui::Transform(
+                         "pos_target", [this]() { return this->target(); },
+                         [this](const sva::PTransformd & pos) { this->target(pos); }));
+    }
+    else { gui.removeElement({"Tasks", name_}, "pos_target"); }
+  };
+
+  auto showPose = [this, &gui]()
+  {
+    if(showPose_)
+    {
+      gui.addElement({"Tasks", name_},
+                     mc_rtc::gui::Transform("pos", [this]() { return frame_->position(); }));
+    }
+    else { gui.removeElement({"Tasks", name_}, "pos"); }
+  };
+
   gui.addElement({"Tasks", name_},
-                 mc_rtc::gui::Transform(
-                     "pos_target", [this]() { return this->target(); },
-                     [this](const sva::PTransformd & pos) { this->target(pos); }),
-                 mc_rtc::gui::Transform("pos", [this]() { return frame_->position(); }));
+                 mc_rtc::gui::Checkbox(
+                     "Show target", [this]() { return showTarget_; },
+                     [this, showTarget]()
+                     {
+                       showTarget_ = !showTarget_;
+                       showTarget();
+                     }),
+                 mc_rtc::gui::Checkbox(
+                     "Show pose", [this]() { return showPose_; },
+                     [this, showPose]()
+                     {
+                       showPose_ = !showPose_;
+                       showPose();
+                     }));
+  showTarget();
+  showPose();
 }
 
 } // namespace mc_tasks


### PR DESCRIPTION
The default behavior of the transform task and force tasks is to add the target and current pose of the task to the GUI.
This can get very cluttered in cases where there are lots of tasks such as retargetting.
This PR overloads the constructors and the GUI functions of the TransformTask, ImpedanceTask and AdmittanceTask to allow hiding the various frames of the task, and adds checkboxes to show them or not.
By default the behavior is showing everything so this should not change anything for pre-existing controllers.