### PR TITLE
Correct TVM contact constraints to enable torque control

### DIFF
--- a/binding/python/mc_solver/c_mc_solver.pxd
+++ b/binding/python/mc_solver/c_mc_solver.pxd
@@ -36,9 +36,9 @@ cdef extern from "<mc_solver/ConstraintSet.h>" namespace "mc_solver":
 
 cdef extern from "<mc_solver/ContactConstraint.h>" namespace "mc_solver":
   ctypedef enum ContactConstraintContactType "mc_solver::ContactConstraint::ContactType":
-    ContactTypeAcceleration "mc_solver::ContactConstraint::Acceleration"
-    ContactTypeVelocity "mc_solver::ContactConstraint::Velocity"
-    ContactTypePosition "mc_solver::ContactConstraint::Position"
+    ContactTypeAcceleration "mc_solver::ContactConstraint::ContactType::Acceleration"
+    ContactTypeVelocity "mc_solver::ContactConstraint::ContactType::Velocity"
+    ContactTypePosition "mc_solver::ContactConstraint::ContactType::Position"
 
   cdef cppclass ContactConstraint(ConstraintSet):
     ContactConstraint(double, ContactConstraintContactType)

--- a/include/mc_solver/ContactConstraint.h
+++ b/include/mc_solver/ContactConstraint.h
@@ -23,7 +23,7 @@ public:
   /** This enum list the possible types of ContactConstr, see Tasks
    * documentation for mathematical details on each of them
    */
-  enum ContactType
+  enum class ContactType
   {
     /** Acceleration constraint */
     Acceleration = 0,
@@ -41,7 +41,7 @@ public:
    * \param contactType Enable different geometric constraint
    *
    */
-  ContactConstraint(double timeStep, ContactType contactType = Velocity);
+  ContactConstraint(double timeStep, ContactType contactType = ContactType::Velocity);
 
   /** Implementation of mc_solver::ConstraintSet::addToSolver */
   void addToSolverImpl(QPSolver & solver) override;
@@ -55,6 +55,9 @@ public:
    */
   tasks::qp::ContactConstr * contactConstr();
 
+  /** Returns the contact type for this constraint */
+  ContactType contactType() const noexcept { return contactType_; }
+
 private:
   /** Holds the contact constraint implementation
    *
@@ -64,7 +67,7 @@ private:
    * No-op in TVM backend
    */
   mc_rtc::void_ptr constraint_;
-  int contactType_;
+  ContactType contactType_;
 };
 
 } // namespace mc_solver

--- a/include/mc_solver/ContactConstraint.h
+++ b/include/mc_solver/ContactConstraint.h
@@ -64,6 +64,7 @@ private:
    * No-op in TVM backend
    */
   mc_rtc::void_ptr constraint_;
+  int contactType_;
 };
 
 } // namespace mc_solver

--- a/include/mc_solver/TVMQPSolver.h
+++ b/include/mc_solver/TVMQPSolver.h
@@ -22,6 +22,17 @@ namespace mc_solver
  */
 struct MC_SOLVER_DLLAPI TVMQPSolver final : public QPSolver
 {
+  /** Types for the geometric contact constraints */
+  enum ContactConstraintTypes
+  {
+    /** Acceleration constraint */
+    Acceleration = 0,
+    /** Velocity constraint */
+    Velocity = 1,
+    /** Position constraint */
+    Position = 2
+  };
+
   TVMQPSolver(mc_rbdyn::RobotsPtr robots, double timeStep);
 
   TVMQPSolver(double timeStep);
@@ -66,6 +77,12 @@ struct MC_SOLVER_DLLAPI TVMQPSolver final : public QPSolver
     return static_cast<const TVMQPSolver &>(solver);
   }
 
+  /** Setter for the global contact constraint type */
+  void contactConstraintType(int type) { contactConstraintType_ = type; }
+
+  /** Getter overload */
+  int contactConstraintType() { return contactConstraintType_; }
+
 private:
   /** Control problem */
   tvm::LinearizedControlProblem problem_;
@@ -87,6 +104,9 @@ private:
   };
   /** Related contact functions */
   std::vector<ContactData> contactsData_;
+  /** Contact constraint type currently set (position by default) */
+  int contactConstraintType_{Position};
+
   /** Runtime of the latest run call */
   mc_rtc::duration_ms solve_dt_{0};
 

--- a/include/mc_solver/TVMQPSolver.h
+++ b/include/mc_solver/TVMQPSolver.h
@@ -22,17 +22,6 @@ namespace mc_solver
  */
 struct MC_SOLVER_DLLAPI TVMQPSolver final : public QPSolver
 {
-  /** Types for the geometric contact constraints */
-  enum ContactConstraintTypes
-  {
-    /** Acceleration constraint */
-    Acceleration = 0,
-    /** Velocity constraint */
-    Velocity = 1,
-    /** Position constraint */
-    Position = 2
-  };
-
   TVMQPSolver(mc_rbdyn::RobotsPtr robots, double timeStep);
 
   TVMQPSolver(double timeStep);
@@ -78,7 +67,7 @@ struct MC_SOLVER_DLLAPI TVMQPSolver final : public QPSolver
   }
 
   /** Setter for the global contact constraint type */
-  void contactConstraintType(int type) { contactConstraintType_ = type; }
+  void setContactConstraintType(int type) { contactConstraintType_ = type; }
 
   /** Getter overload */
   int contactConstraintType() { return contactConstraintType_; }
@@ -105,7 +94,7 @@ private:
   /** Related contact functions */
   std::vector<ContactData> contactsData_;
   /** Contact constraint type currently set (position by default) */
-  int contactConstraintType_{Position};
+  int contactConstraintType_;
 
   /** Runtime of the latest run call */
   mc_rtc::duration_ms solve_dt_{0};

--- a/include/mc_solver/TVMQPSolver.h
+++ b/include/mc_solver/TVMQPSolver.h
@@ -66,12 +66,6 @@ struct MC_SOLVER_DLLAPI TVMQPSolver final : public QPSolver
     return static_cast<const TVMQPSolver &>(solver);
   }
 
-  /** Setter for the global contact constraint type */
-  void setContactConstraintType(int type) { contactConstraintType_ = type; }
-
-  /** Getter overload */
-  int contactConstraintType() { return contactConstraintType_; }
-
 private:
   /** Control problem */
   tvm::LinearizedControlProblem problem_;
@@ -93,8 +87,6 @@ private:
   };
   /** Related contact functions */
   std::vector<ContactData> contactsData_;
-  /** Contact constraint type currently set (position by default) */
-  int contactConstraintType_;
 
   /** Runtime of the latest run call */
   mc_rtc::duration_ms solve_dt_{0};

--- a/src/mc_solver/ContactConstraint.cpp
+++ b/src/mc_solver/ContactConstraint.cpp
@@ -5,7 +5,6 @@
 #include <mc_solver/ContactConstraint.h>
 
 #include <mc_solver/ConstraintSetLoader.h>
-#include <mc_solver/TVMQPSolver.h>
 #include <mc_solver/TasksQPSolver.h>
 
 #include <mc_rtc/logging.h>

--- a/src/mc_solver/ContactConstraint.cpp
+++ b/src/mc_solver/ContactConstraint.cpp
@@ -59,7 +59,7 @@ void ContactConstraint::addToSolverImpl(QPSolver & solver)
       break;
     case QPSolver::Backend::TVM:
       // Let's assume the parameter is set when the created constraint is "added"
-      mc_solver::TVMQPSolver::from_solver(solver).contactConstraintType(contactType_);
+      mc_solver::TVMQPSolver::from_solver(solver).setContactConstraintType(contactType_);
       break;
     default:
       break;

--- a/src/mc_solver/ContactConstraint.cpp
+++ b/src/mc_solver/ContactConstraint.cpp
@@ -58,8 +58,7 @@ void ContactConstraint::addToSolverImpl(QPSolver & solver)
           ->addToSolver(solver.robots().mbs(), tasks_solver(solver).solver());
       break;
     case QPSolver::Backend::TVM:
-      // Let's assume the parameter is set when the created constraint is "added"
-      mc_solver::TVMQPSolver::from_solver(solver).setContactConstraintType(contactType_);
+      // No specific impl, contactType_ will be checked by TVMQPSolver
       break;
     default:
       break;
@@ -74,8 +73,7 @@ void ContactConstraint::removeFromSolverImpl(QPSolver & solver)
       static_cast<tasks::qp::ContactConstr *>(constraint_.get())->removeFromSolver(tasks_solver(solver).solver());
       break;
     case QPSolver::Backend::TVM:
-      // It makes no sense to remove the geometric contact constraint in TVM for now as they are set in any case but we
-      // could imagine a type "none" that removes them
+      // No specific impl, TVMQPSolver will not add geometric contact constraints if this is not in the solver
       break;
     default:
       break;
@@ -101,9 +99,9 @@ static auto registered = mc_solver::ConstraintSetLoader::register_load_function(
     [](mc_solver::QPSolver & solver, const mc_rtc::Configuration & config)
     {
       std::string cTypeStr = config("contactType", std::string{"velocity"});
-      auto cType = mc_solver::ContactConstraint::Velocity;
-      if(cTypeStr == "acceleration") { cType = mc_solver::ContactConstraint::Acceleration; }
-      else if(cTypeStr == "position") { cType = mc_solver::ContactConstraint::Position; }
+      auto cType = mc_solver::ContactConstraint::ContactType::Velocity;
+      if(cTypeStr == "acceleration") { cType = mc_solver::ContactConstraint::ContactType::Acceleration; }
+      else if(cTypeStr == "position") { cType = mc_solver::ContactConstraint::ContactType::Position; }
       else if(cTypeStr != "velocity")
       {
         mc_rtc::log::error("Stored contact type for contact constraint not recognized, default to velocity");

--- a/src/mc_solver/TVMQPSolver.cpp
+++ b/src/mc_solver/TVMQPSolver.cpp
@@ -425,6 +425,8 @@ auto TVMQPSolver::addVirtualContactImpl(const mc_rbdyn::Contact & contact) -> st
                                          contactType);
             break;
         }
+        // Breaking out of the for loop in case there is more than one contact constraint in the solver
+        break;
       }
     }
 

--- a/src/mc_solver/TVMQPSolver.cpp
+++ b/src/mc_solver/TVMQPSolver.cpp
@@ -30,11 +30,11 @@ inline static Eigen::MatrixXd discretizedFrictionCone(double muI)
 }
 
 TVMQPSolver::TVMQPSolver(mc_rbdyn::RobotsPtr robots, double dt)
-: QPSolver(robots, dt, Backend::TVM), solver_(tvm::solver::DefaultLSSolverOptions{})
+: QPSolver(robots, dt, Backend::TVM), solver_(tvm::solver::DefaultLSSolverOptions{}), contactConstraintType_(ContactConstraint::Velocity)
 {
 }
 
-TVMQPSolver::TVMQPSolver(double dt) : QPSolver(dt, Backend::TVM), solver_(tvm::solver::DefaultLSSolverOptions{}) {}
+TVMQPSolver::TVMQPSolver(double dt) : QPSolver(dt, Backend::TVM), solver_(tvm::solver::DefaultLSSolverOptions{}), contactConstraintType_(ContactConstraint::Velocity) {}
 
 size_t TVMQPSolver::getContactIdx(const mc_rbdyn::Contact & contact)
 {

--- a/src/mc_solver/TVMQPSolver.cpp
+++ b/src/mc_solver/TVMQPSolver.cpp
@@ -5,6 +5,7 @@
 #include <mc_solver/TVMQPSolver.h>
 
 #include <mc_solver/DynamicsConstraint.h>
+#include <mc_solver/ContactConstraint.h>
 
 #include <mc_tasks/MetaTask.h>
 
@@ -386,7 +387,7 @@ auto TVMQPSolver::addVirtualContactImpl(const mc_rbdyn::Contact & contact) -> st
     auto contact_fn = std::make_shared<mc_tvm::ContactFunction>(f1, f2, contact.dof());
     switch(contactConstraintType_)
     {
-      case ContactConstraintTypes::Acceleration:
+      case ContactConstraint::Acceleration:
       {
         // Acceleration constraint: the second order dynamics of the contact function, ie the relative acceleration
         // between the frames tracks a reference of zero
@@ -395,14 +396,14 @@ auto TVMQPSolver::addVirtualContactImpl(const mc_rbdyn::Contact & contact) -> st
             problem_.add(contact_fn == 0., tvm::task_dynamics::PD(0., 0.), {tvm::requirements::PriorityLevel(0)});
         break;
       }
-      case ContactConstraintTypes::Velocity:
+      case ContactConstraint::Velocity:
       {
         // Velocity constraint: the dynamics of the contact function track only the velocity error
         data.contactConstraint_ = problem_.add(contact_fn == 0., tvm::task_dynamics::PD(0., 1.0 / dt()),
                                                {tvm::requirements::PriorityLevel(0)});
         break;
       }
-      case ContactConstraintTypes::Position:
+      case ContactConstraint::Position:
       {
         // Position constraint: regular contact function and position error tracking with PD dynamics
         // Using a PD dynamics with these gains basically equates to a one-step to convergence

--- a/src/mc_solver/TVMQPSolver.cpp
+++ b/src/mc_solver/TVMQPSolver.cpp
@@ -30,11 +30,16 @@ inline static Eigen::MatrixXd discretizedFrictionCone(double muI)
 }
 
 TVMQPSolver::TVMQPSolver(mc_rbdyn::RobotsPtr robots, double dt)
-: QPSolver(robots, dt, Backend::TVM), solver_(tvm::solver::DefaultLSSolverOptions{}), contactConstraintType_(ContactConstraint::Velocity)
+: QPSolver(robots, dt, Backend::TVM), solver_(tvm::solver::DefaultLSSolverOptions{}),
+  contactConstraintType_(ContactConstraint::Velocity)
 {
 }
 
-TVMQPSolver::TVMQPSolver(double dt) : QPSolver(dt, Backend::TVM), solver_(tvm::solver::DefaultLSSolverOptions{}), contactConstraintType_(ContactConstraint::Velocity) {}
+TVMQPSolver::TVMQPSolver(double dt)
+: QPSolver(dt, Backend::TVM), solver_(tvm::solver::DefaultLSSolverOptions{}),
+  contactConstraintType_(ContactConstraint::Velocity)
+{
+}
 
 size_t TVMQPSolver::getContactIdx(const mc_rbdyn::Contact & contact)
 {

--- a/src/mc_solver/TVMQPSolver.cpp
+++ b/src/mc_solver/TVMQPSolver.cpp
@@ -4,8 +4,8 @@
 
 #include <mc_solver/TVMQPSolver.h>
 
-#include <mc_solver/DynamicsConstraint.h>
 #include <mc_solver/ContactConstraint.h>
+#include <mc_solver/DynamicsConstraint.h>
 
 #include <mc_tasks/MetaTask.h>
 


### PR DESCRIPTION
This correctly implements velocity and acceleration contact constraints for TVM: only position was used before, regardless of the contact constraint type, which made torque control fail.

- The solver contact constraint now passes the contact type to the tvm backend instead of only to tasks.
- This type is stored in the TVMQPSolver when a contact type constraint is added to the solver and is used to implement the correct type when a new contact is added.