### PR TITLE
mc_bin_to_log : set double precision 

### DIFF
--- a/utils/mc_bin_to_log.cpp
+++ b/utils/mc_bin_to_log.cpp
@@ -183,7 +183,7 @@ void write_data<std::vector<double>>(std::ofstream & ofs, const std::vector<doub
 }
 
 template<>
-void write_data<double>(std::ofstream &ofs, const double & data, size_t s)
+void write_data<double>(std::ofstream & ofs, const double & data, size_t s)
 {
   ofs << std::fixed << std::setprecision(7);
   ofs << data;

--- a/utils/mc_bin_to_log.cpp
+++ b/utils/mc_bin_to_log.cpp
@@ -4,7 +4,7 @@
 
 #include "mc_bin_utils.h"
 #include <fstream>
-
+#include <iomanip>
 struct SizedType
 {
   mc_rtc::log::LogType type;
@@ -180,6 +180,13 @@ void write_data<std::vector<double>>(std::ofstream & ofs, const std::vector<doub
   {
     if(i + 1 != fsize) { ofs << ';'; }
   }
+}
+
+template<>
+void write_data<double>(std::ofstream &ofs, const double & data, size_t s)
+{
+  ofs << std::fixed << std::setprecision(7);
+  ofs << data;
 }
 
 template<>

--- a/utils/mc_bin_to_log_main.cpp
+++ b/utils/mc_bin_to_log_main.cpp
@@ -4,8 +4,8 @@
 
 #include <mc_rtc/logging.h>
 
-#include <boost/filesystem.hpp>
-namespace bfs = boost::filesystem;
+#include <filesystem>
+namespace fs = std::filesystem;
 
 #include "mc_bin_to_log.h"
 
@@ -26,7 +26,7 @@ int main(int argc, char * argv[])
   if(argc == 3) { out = argv[2]; }
   else
   {
-    out = bfs::path(argv[1]).filename().replace_extension(".csv").string();
+    out = fs::path(argv[1]).filename().replace_extension(".csv").string();
     if(out == in)
     {
       mc_rtc::log::error("Please specify a different output name");
@@ -35,5 +35,6 @@ int main(int argc, char * argv[])
     mc_rtc::log::info("Output converted log to {}", out);
   }
   mc_bin_to_log(in, out);
+  mc_rtc::log::success("Log successfully converted to {}", out);
   return 0;
 }


### PR DESCRIPTION
This PR intends to avoid missing milliseconds information in the exported csv file given after running `mc_bin_to_log`. This happens when increasing dt. 
It can be problematic to differentiate data as they might have the same time value. 