### PR TITLE
mc_log_tab: set minimum widget width 

### DIFF
--- a/utils/mc_log_gui/mc_log_ui/mc_log_tab.py
+++ b/utils/mc_log_gui/mc_log_ui/mc_log_tab.py
@@ -802,7 +802,8 @@ class MCLogTab(QtWidgets.QWidget):
             font_metric = QtGui.QFontMetrics(ySelector.font())
 
             for index in indices:
-                if not index.isValid() or not (text := index.data()): continue
+                if not index.isValid() or not (text := index.data()):
+                    continue
 
                 depth = 0
                 parent = index.parent()
@@ -810,7 +811,11 @@ class MCLogTab(QtWidgets.QWidget):
                     depth += 1
                     parent = parent.parent()
 
-                total_width = (ySelector.indentation() * depth if hasattr(ySelector, "indentation") else 20 * depth) + font_metric.horizontalAdvance(text)
+                total_width = (
+                    ySelector.indentation() * depth
+                    if hasattr(ySelector, "indentation")
+                    else 20 * depth
+                ) + font_metric.horizontalAdvance(text)
 
                 if total_width > cwidth:
                     cwidth = total_width


### PR DESCRIPTION
Based on users feedback, I'd be better to be able to visualize all Data entries even on window resize.
This PR aims to set min and max width of the QWidget based on the deepest and longest entry given in the tree. 
