### PR TITLE
Revert "feat(config): Load mc_rtc.yaml from MC_RTC_CONTROLLER_CONFIG env variable"

### DIFF
--- a/doc/_i18n/en/tutorials/introduction/configuration.html
+++ b/doc/_i18n/en/tutorials/introduction/configuration.html
@@ -8,7 +8,6 @@
 
 <ol>
   <li>{% ihighlight bash %}$INSTALL_PREFIX/etc/mc_rtc.yaml{% endihighlight %}</li>
-  <li>{% ihighlight bash %}An optional path defined in MC_RTC_CONTROLLER_CONFIG environment variable. This is typically used to provide a default setup on docker environments{% endihighlight %}</li>
   <li><ul><li>Linux/MacOS: {% ihighlight bash %}$HOME/.config/mc_rtc/mc_rtc.yaml{% endihighlight %}</li><li>Windows: {% ihighlight msshell %}%APPDATA%/mc_rtc/mc_rtc.yaml{% endihighlight %}</li></ul></li>
 </ol>
 

--- a/doc/_i18n/jp/tutorials/introduction/configuration.html
+++ b/doc/_i18n/jp/tutorials/introduction/configuration.html
@@ -8,7 +8,6 @@
 
 <ol>
   <li>{% ihighlight bash %}$INSTALL_PREFIX/etc/mc_rtc.yaml{% endihighlight %}</li>
-  <li>{% ihighlight bash %}MC_RTC_CONTROLLER_CONFIG 環境変数で定義されたオプションのパス。これは通常、Docker環境でデフォルトのセットアップを提供するために使用されます。{% endihighlight %}</li>
   <li><ul><li>Linux/MacOS: {% ihighlight bash %}$HOME/.config/mc_rtc/mc_rtc.yaml{% endihighlight %}</li><li>Windows: {% ihighlight msshell %}%APPDATA%/mc_rtc/mc_rtc.yaml{% endihighlight %}</li></ul></li>
 </ol>
 

--- a/src/mc_control/mc_global_controller_configuration.cpp
+++ b/src/mc_control/mc_global_controller_configuration.cpp
@@ -34,26 +34,6 @@ MCGlobalController::GlobalConfiguration::GlobalConfiguration(const std::string &
       config.load(globalPath);
     }
 
-    // If the env MC_RTC_CONTROLLER_CONFIG is set, load this file as well
-    const char * env_config = std::getenv("MC_RTC_CONTROLLER_CONFIG");
-    if(env_config)
-    {
-      bfs::path envConfigPath(env_config);
-      if(bfs::exists(envConfigPath))
-      {
-        mc_rtc::log::info(
-            "Loading additional global configuration from MC_RTC_CONTROLLER_CONFIG environment variable {}",
-            envConfigPath.string());
-        config.load(envConfigPath.string());
-      }
-      else if(envConfigPath.string().size())
-      {
-        mc_rtc::log::error_and_throw(
-            "MC_RTC_CONTROLLER_CONFIG environment variable is set to \"{}\", but this file does not exist",
-            envConfigPath.string());
-      }
-    }
-
     bfs::path config_path = mc_rtc::user_config_directory_path("mc_rtc.conf");
     // Load user's local configuration if it exists
     if(!bfs::exists(config_path)) { config_path.replace_extension(".yaml"); }


### PR DESCRIPTION
Reverts jrl-umi3218/mc_rtc#477

I changed my mind on this: it adds confusion, messes with unit tests when set, and isn't strictly speaking necessary right now.