### PR TITLE
Schema: Add support for Eigen::MatrixXd

### DIFF
--- a/doc/_i18n/en/tutorials/usage/schema.md
+++ b/doc/_i18n/en/tutorials/usage/schema.md
@@ -230,6 +230,12 @@ If you are using a `_DEFAULT_` macro, this is `mc_rtc::Default<T>` which is:
 - `mc_rtc::Default<T>` for `std::variant<T, Others...>`
 - Default values for a schema-based structure
 
+Note that for some types such as `Eigen::MatrixXd`, `Eigen::VecotrXd`, no reasonable default can be guessed and one must be provided explicitly. Use `MC_RTC_SCHEMA_MEMBER` for these elements.
+
+```cpp
+MC_RTC_SCHEMA_MEMBER(MySchema, Eigen::MatrixXd, matrix, "Some matrix", mc_rtc::schema::Required, Eigen::MatrixXd::Identity(12, 4))
+```
+
 ### About `NAMES`
 
 These extra parameter has two possible use-case:

--- a/doc/_i18n/jp/tutorials/usage/schema.md
+++ b/doc/_i18n/jp/tutorials/usage/schema.md
@@ -215,6 +215,12 @@ struct InteractiveSchema
 - `std::variant<T>`の場合は`mc_rtc::Default<T>`です
 - スキーマベースの構造の場合はデフォルト値
 
+`Eigen::MatrixXd` や `Eigen::VectorXd` などの型については、適切なデフォルト値を推測することができないため、明示的に指定する必要があります。これらの要素には `MC_RTC_SCHEMA_MEMBER` を使用してください。
+
+```cpp
+MC_RTC_SCHEMA_MEMBER(MySchema, Eigen::MatrixXd, matrix, "Some matrix", mc_rtc::schema::Required, Eigen::MatrixXd::Identity(12, 4))
+```
+
 ### `NAMES`について
 
 これらの追加パラメータには2つの可能な使用例があります：

--- a/include/mc_rtc/MessagePackBuilder.h
+++ b/include/mc_rtc/MessagePackBuilder.h
@@ -197,6 +197,12 @@ struct MC_RTC_UTILS_DLLAPI MessagePackBuilder
    */
   void write(const Eigen::Matrix3d & m);
 
+  /* Write an Eigen::MatrixXd
+   *
+   * Serialized as an array of arrays
+   */
+  void write(const Eigen::MatrixXd & m);
+
   /** Write an sva::PTransformd
    *
    * Serialized as an array of size 12 (Matrix3d + Vector3d)

--- a/include/mc_rtc/Schema.h
+++ b/include/mc_rtc/Schema.h
@@ -103,6 +103,20 @@ struct is_eigen_vector<Eigen::Matrix<Scalar, Rows, 1, Options, MaxRows, 1>> : pu
 template<typename T>
 inline constexpr bool is_eigen_vector_v = is_eigen_vector<T>::value;
 
+/** Type-trait to detect if something is an Eigen::MatrixXd */
+template<typename T>
+struct is_eigen_matrixxd : public std::false_type
+{
+};
+
+template<>
+struct is_eigen_matrixxd<Eigen::MatrixXd> : public std::true_type
+{
+};
+
+template<typename T>
+inline constexpr bool is_eigen_matrixxd_v = is_eigen_matrixxd<T>::value;
+
 template<typename T, bool IsRequired, bool IsInteractive, bool HasChoices = false, bool IsStatic = false>
 void addValueToForm(const T & value,
                     const std::string & description,
@@ -199,6 +213,10 @@ void addValueToForm(const T & value,
   else if constexpr(std::is_same_v<T, sva::ForceVecd> || details::is_eigen_vector_v<T>)
   {
     form.addElement(mc_rtc::gui::FormArrayInput(description, IsRequired, get_value));
+  }
+  else if constexpr(details::is_eigen_matrixxd_v<T>)
+  {
+    // do nothing, we don't support MatrixXd in forms for now but allow MatrixXd in schemas
   }
   else { static_assert(!std::is_same_v<T, T>, "addValueToForm must be implemented for this value type"); }
 }

--- a/src/mc_rtc/MessagePackBuilder.cpp
+++ b/src/mc_rtc/MessagePackBuilder.cpp
@@ -229,6 +229,18 @@ void MessagePackBuilder::write(const Eigen::Matrix3d & m)
   finish_array();
 }
 
+void MessagePackBuilder::write(const Eigen::MatrixXd & m)
+{
+  start_array(static_cast<size_t>(m.rows()));
+  for(Eigen::Index i = 0; i < m.rows(); ++i)
+  {
+    start_array(static_cast<size_t>(m.cols()));
+    for(Eigen::Index j = 0; j < m.cols(); ++j) { write(m(i, j)); }
+    finish_array();
+  }
+  finish_array();
+}
+
 void MessagePackBuilder::write(const sva::PTransformd & pt)
 {
   start_array(12);

--- a/tests/samples_Schema.h
+++ b/tests/samples_Schema.h
@@ -18,4 +18,10 @@ struct SimpleSchema
   MEMBER(Eigen::Vector2d, v2d, "Some 2d setting")
   MEMBER(Eigen::Vector4d, v4d, "Some 4d setting")
 #undef MEMBER
+  MC_RTC_SCHEMA_MEMBER(SimpleSchema,
+                       Eigen::MatrixXd,
+                       matrixXd,
+                       "Some MatrixXd setting",
+                       mc_rtc::schema::None,
+                       Eigen::MatrixXd::Identity(6, 6))
 };


### PR DESCRIPTION
This PR adds support for loading and saving `Eigen::MatrixXd` objects with an `mc_rtc::Schema`