### PR TITLE
[Explicit Compliance and Safety][2/3] Add optional feedforward compensation torques to DynamicConstraint in TVM and Tasks backends

### DIFF
--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -17,6 +17,7 @@
 #include <RBDyn/MultiBodyConfig.h>
 #include <RBDyn/MultiBodyGraph.h>
 
+#include <Eigen/src/Core/Matrix.h>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -1114,6 +1115,42 @@ public:
    */
   mc_tvm::Convex & tvmConvex(const std::string & name) const;
 
+  /** @name External Torques
+   *
+   * These functions are used to get or set:
+   * - The estimation of external torques being applied on the robot and its 'equivalent' acceleration
+   * - The additional feedforward compensation torque and its 'equivalent' acceleration
+   *
+   * @{
+   */
+
+  /** Set the external torques */
+  void setExternalTorques(const Eigen::VectorXd & torques);
+
+  /** Get the external torques */
+  const Eigen::VectorXd & externalTorques(void) const;
+
+  /** Set the external torques equivalent accelerations */
+  void setExternalTorquesAcc(const Eigen::VectorXd & accelerations);
+
+  /** Get the external torques equivalent accelerations */
+  const Eigen::VectorXd & externalTorquesAcc(void) const;
+
+  /** Set the compensation torques */
+  void setCompensationTorques(const Eigen::VectorXd & torques);
+
+  /** Get the compensation torques */
+  const std::optional<Eigen::VectorXd> & compensationTorques(void) const;
+
+  /** Set the compensation torques equivalent accelerations */
+  void setCompensationTorquesAcc(const Eigen::VectorXd & accelerations);
+
+  /** Get the compensation torques equivalent accelerations */
+  const std::optional<Eigen::VectorXd> & compensationTorquesAcc(void) const;
+
+  /** @} */
+  /* End of External Forces group */
+
 private:
   Robots * robots_;
   unsigned int robots_idx_;
@@ -1149,6 +1186,14 @@ private:
   std::unordered_map<std::string, RobotFramePtr> frames_;
   /** Mass of this robot */
   double mass_ = 0.0;
+  /** Non modeled external forces acting on the robot **/
+  Eigen::VectorXd externalTorques_;
+  /** Joint accelerations from external forces acting on the robot **/
+  Eigen::VectorXd externalTorquesEquivalentAcc_;
+  /** External forces to be compensated in the commanded torque **/
+  std::optional<Eigen::VectorXd> externalTorqueCompensation_ = std::nullopt;
+  /** Joint accelerations from the compensation in the commanded torque **/
+  std::optional<Eigen::VectorXd> compensationEquivalentAcc_ = std::nullopt;
 
 protected:
   struct NewRobotToken

--- a/include/mc_rtc/Configuration.h
+++ b/include/mc_rtc/Configuration.h
@@ -1807,11 +1807,11 @@ template<>
 struct formatter<mc_rtc::Configuration> : public formatter<string_view>
 {
   template<typename FormatContext>
-  #if FMT_VERSION <= 9 * 10000
-    auto format(const mc_rtc::Configuration & c, FormatContext & ctx)
-  #else
-      auto format(const mc_rtc::Configuration & c, FormatContext & ctx) const -> decltype(ctx.out())
-  #endif
+#if FMT_VERSION <= 9 * 10000
+  auto format(const mc_rtc::Configuration & c, FormatContext & ctx)
+#else
+  auto format(const mc_rtc::Configuration & c, FormatContext & ctx) const -> decltype(ctx.out())
+#endif
   {
     return formatter<string_view>::format(static_cast<std::string>(c), ctx);
   }

--- a/include/mc_solver/DynamicsConstraint.h
+++ b/include/mc_solver/DynamicsConstraint.h
@@ -28,8 +28,15 @@ public:
    * \param robotIndex The index of the robot affected by this constraint
    * \param timeStep Solver timestep
    * \param infTorque If true, ignore the torque limits set in the robot model
+   * \param compensateExtTorques If true, compensates external disturbances using a feedworward torque signal. The
+   * constraint will search for the compensation value in robot by calling `compensationTorques()` method, if not an
+   * estimation of external torques acting on the robot will be used by calling `externalTorques()` method.
    */
-  DynamicsConstraint(const mc_rbdyn::Robots & robots, unsigned int robotIndex, double timeStep, bool infTorque = false);
+  DynamicsConstraint(const mc_rbdyn::Robots & robots,
+                     unsigned int robotIndex,
+                     double timeStep,
+                     bool infTorque = false,
+                     bool compensateExtTorques = false);
 
   /** Constructor
    * Builds a damped joint limits constraint and a motion constr depending on
@@ -42,13 +49,17 @@ public:
    * offset}
    * \param velocityPercent Maximum joint velocity percentage, 0.5 is advised
    * \param infTorque If true, ignore the torque limits set in the robot model
+   * \param compensateExtTorques If true, compensates external disturbances using a feedworward torque signal. The
+   * constraint will search for the compensation value in robot by calling `compensationTorques()` method, if not an
+   * estimation of external torques acting on the robot will be used by calling `externalTorques()` method.
    */
   DynamicsConstraint(const mc_rbdyn::Robots & robots,
                      unsigned int robotIndex,
                      double timeStep,
                      const std::array<double, 3> & damper,
                      double velocityPercent = 1.0,
-                     bool infTorque = false);
+                     bool infTorque = false,
+                     bool compensateExtTorques = false);
 
   /** Returns the tasks::qp::MotionConstr
    *

--- a/include/mc_solver/DynamicsConstraint.h
+++ b/include/mc_solver/DynamicsConstraint.h
@@ -61,6 +61,14 @@ public:
                      bool infTorque = false,
                      bool compensateExtTorques = false);
 
+  /** \brief Update the constraint
+   *
+   * This is called at every iteration of the controller once the constraint has been added to a solver
+   *
+   * \param solver Solver in which the constraint has been inserted
+   */
+  void update(QPSolver & solver) override;
+
   /** Returns the tasks::qp::MotionConstr
    *
    * This assumes the backend was Tasks

--- a/include/mc_solver/QPSolver.h
+++ b/include/mc_solver/QPSolver.h
@@ -344,11 +344,11 @@ template<>
 struct formatter<mc_solver::QPSolver::Backend> : public formatter<string_view>
 {
   template<typename FormatContext>
-  #if FMT_VERSION <= 9 * 10000
-    auto format(const mc_solver::QPSolver::Backend & backend, FormatContext & ctx)
-  #else
-    auto format(const mc_solver::QPSolver::Backend & backend, FormatContext & ctx) const -> decltype(ctx.out())
-  #endif
+#if FMT_VERSION <= 9 * 10000
+  auto format(const mc_solver::QPSolver::Backend & backend, FormatContext & ctx)
+#else
+  auto format(const mc_solver::QPSolver::Backend & backend, FormatContext & ctx) const -> decltype(ctx.out())
+#endif
   {
     using Backend = mc_solver::QPSolver::Backend;
     switch(backend)

--- a/include/mc_tvm/DynamicFunction.h
+++ b/include/mc_tvm/DynamicFunction.h
@@ -36,7 +36,7 @@ public:
   SET_UPDATES(DynamicFunction, Jacobian, B)
 
   /** Construct the equation of motion for a given robot */
-  DynamicFunction(const mc_rbdyn::Robot & robot);
+  DynamicFunction(const mc_rbdyn::Robot & robot, bool compensateExternalForces = false);
 
   /** Add a contact to the function
    *
@@ -73,6 +73,7 @@ protected:
   void updateb();
 
   const mc_rbdyn::Robot & robot_;
+  const bool compensateExternalForces_;
 
   /** Holds data for the force part of the motion equation */
   struct ForceContact

--- a/include/mc_tvm/Robot.h
+++ b/include/mc_tvm/Robot.h
@@ -16,6 +16,8 @@
 
 #include <RBDyn/FD.h>
 
+#include <optional>
+
 namespace mc_tvm
 {
 
@@ -47,8 +49,8 @@ namespace mc_tvm
  */
 struct MC_TVM_DLLAPI Robot : public tvm::graph::abstract::Node<Robot>
 {
-  SET_OUTPUTS(Robot, FK, FV, FA, NormalAcceleration, tau, H, C)
-  SET_UPDATES(Robot, FK, FV, FA, NormalAcceleration, H, C)
+  SET_OUTPUTS(Robot, FK, FV, FA, NormalAcceleration, tau, H, C, ExternalForces)
+  SET_UPDATES(Robot, FK, FV, FA, NormalAcceleration, H, C, ExternalForces)
 
   friend struct mc_rbdyn::Robot;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -96,6 +98,11 @@ public:
   /** Access q second derivative (joint acceleration) */
   inline tvm::VariablePtr & alphaD() noexcept { return ddq_; }
 
+  /** Access joint acceleration from external forces (const) */
+  inline const Eigen::VectorXd & alphaDExternal() const noexcept { return ddq_ext_; }
+  /** Access joint acceleration from external forces */
+  inline Eigen::VectorXd & alphaDExternal() noexcept { return ddq_ext_; }
+
   /** Access floating-base variable (const) */
   inline const tvm::VariablePtr & qFloatingBase() const noexcept { return q_fb_; }
   /** Access free-flyer variable */
@@ -133,6 +140,21 @@ public:
   inline const tvm::VariablePtr & tau() const noexcept { return tau_; }
   /** Access tau variable */
   inline tvm::VariablePtr & tau() { return tau_; }
+
+  /** Access tau external variable (const) */
+  inline const Eigen::VectorXd & tauExternal() const noexcept { return tau_ext_; }
+  /** Access tau external variable */
+  inline Eigen::VectorXd & tauExternal() { return tau_ext_; }
+
+  /** Access tau compensation (const) */
+  inline const std::optional<Eigen::VectorXd> & tauCompensation() const noexcept { return tau_comp_; }
+  /** Access tau compensation */
+  inline std::optional<Eigen::VectorXd> & tauCompensation() noexcept { return tau_comp_; }
+
+  /** Access joint acceleration from compensation torques (const) */
+  inline const std::optional<Eigen::VectorXd> & alphaDCompensation() const noexcept { return ddq_comp_; }
+  /** Access joint acceleration from compensation torques */
+  inline std::optional<Eigen::VectorXd> & alphaDCompensation() noexcept { return ddq_comp_; }
 
   /** Returns the CoM algorithm associated to this robot (const) */
   inline const CoM & comAlgo() const noexcept { return *com_; }
@@ -203,8 +225,16 @@ private:
   tvm::VariablePtr dq_;
   /** Double derivative of q */
   tvm::VariablePtr ddq_;
+  /** Joint acceleration from external forces */
+  Eigen::VectorXd ddq_ext_;
+  /** Joint acceleration from compensation torques */
+  std::optional<Eigen::VectorXd> ddq_comp_;
   /** Tau variable */
   tvm::VariablePtr tau_;
+  /** Tau external variable */
+  Eigen::VectorXd tau_ext_;
+  /** Tau compensation variable */
+  std::optional<Eigen::VectorXd> tau_comp_;
   /** Normal accelerations of the bodies */
   std::vector<sva::MotionVecd> normalAccB_;
   /** Forward dynamics algorithm associated to this robot */
@@ -225,6 +255,7 @@ private:
   void updateNormalAcceleration();
   void updateH();
   void updateC();
+  void updateExternalForces();
 };
 
 } // namespace mc_tvm

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -18,10 +18,13 @@
 
 #include <RBDyn/CoM.h>
 #include <RBDyn/FA.h>
+#include <RBDyn/FD.h>
 #include <RBDyn/FK.h>
 #include <RBDyn/FV.h>
 #include <RBDyn/NumericalIntegration.h>
 
+#include <Eigen/src/Core/Matrix.h>
+#include <optional>
 #include <sch/S_Object/S_Cylinder.h>
 #include <sch/S_Object/S_Superellipsoid.h>
 
@@ -510,6 +513,9 @@ Robot::Robot(NewRobotToken,
   flexibility_ = module_.flexibility();
 
   zmp_ = Eigen::Vector3d::Zero();
+
+  externalTorques_ = Eigen::VectorXd::Zero(mb().nrDof());
+  externalTorquesEquivalentAcc_ = Eigen::VectorXd::Zero(mb().nrDof());
 }
 
 Robot::~Robot()
@@ -1565,6 +1571,58 @@ mc_tvm::Convex & Robot::tvmConvex(const std::string & name) const
                                                                   frame(cvx.first), collisionTransform(name))}});
   }
   return *it->second;
+}
+
+void Robot::setExternalTorques(const Eigen::VectorXd & torques)
+{
+  externalTorques_.noalias() = torques;
+}
+
+const Eigen::VectorXd & Robot::externalTorques(void) const
+{
+  return externalTorques_;
+}
+
+void Robot::setExternalTorquesAcc(const Eigen::VectorXd & accelerations)
+{
+  externalTorquesEquivalentAcc_.noalias() = accelerations;
+}
+
+const Eigen::VectorXd & Robot::externalTorquesAcc(void) const
+{
+  return externalTorquesEquivalentAcc_;
+}
+
+void Robot::setCompensationTorques(const Eigen::VectorXd & torques)
+{
+  if(!externalTorqueCompensation_) { externalTorqueCompensation_.emplace(torques.size()); }
+  else if(externalTorqueCompensation_->size() == torques.size())
+  {
+    externalTorqueCompensation_->resize(torques.size());
+  }
+
+  externalTorqueCompensation_->noalias() = torques;
+}
+
+const std::optional<Eigen::VectorXd> & Robot::compensationTorques(void) const
+{
+  return externalTorqueCompensation_;
+}
+
+void Robot::setCompensationTorquesAcc(const Eigen::VectorXd & accelerations)
+{
+  if(!externalTorqueCompensation_) { compensationEquivalentAcc_.emplace(accelerations.size()); }
+  else if(externalTorqueCompensation_->size() == accelerations.size())
+  {
+
+    compensationEquivalentAcc_->resize(accelerations.size());
+  }
+  compensationEquivalentAcc_->noalias() = accelerations;
+}
+
+const std::optional<Eigen::VectorXd> & Robot::compensationTorquesAcc(void) const
+{
+  return compensationEquivalentAcc_;
 }
 
 } // namespace mc_rbdyn

--- a/src/mc_rbdyn/configuration_io.cpp
+++ b/src/mc_rbdyn/configuration_io.cpp
@@ -29,11 +29,11 @@ template<>
 struct formatter<rbd::Joint::Type> : public formatter<string_view>
 {
   template<typename FormatContext>
-  #if FMT_VERSION <= 9 * 10000
-    auto format(const rbd::Joint::Type & t, FormatContext & ctx)
-  #else
-    auto format(const rbd::Joint::Type & t, FormatContext & ctx) const -> decltype(ctx.out())
-  #endif
+#if FMT_VERSION <= 9 * 10000
+  auto format(const rbd::Joint::Type & t, FormatContext & ctx)
+#else
+  auto format(const rbd::Joint::Type & t, FormatContext & ctx) const -> decltype(ctx.out())
+#endif
   {
     switch(t)
     {

--- a/src/mc_solver/DynamicsConstraint.cpp
+++ b/src/mc_solver/DynamicsConstraint.cpp
@@ -19,7 +19,8 @@ namespace mc_solver
 static mc_rtc::void_ptr initialize_tasks(const mc_rbdyn::Robots & robots,
                                          unsigned int robotIndex,
                                          double timeStep,
-                                         bool infTorque)
+                                         bool infTorque,
+                                         bool compensateExtTorques)
 {
   const auto & robot = robots.robot(robotIndex);
   std::vector<std::vector<double>> tl = robot.tl();
@@ -54,13 +55,47 @@ static mc_rtc::void_ptr initialize_tasks(const mc_rbdyn::Robots & robots,
     {
       sjList.push_back(tasks::qp::SpringJoint(flex.jointName, flex.K, flex.C, flex.O));
     }
-    return mc_rtc::make_void_ptr<tasks::qp::MotionSpringConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
-                                                                tDBound, timeStep, sjList);
+    if(compensateExtTorques)
+    {
+      if(robot.compensationTorques())
+      {
+        return mc_rtc::make_void_ptr<tasks::qp::MotionSpringConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
+                                                                    tDBound, timeStep, sjList,
+                                                                    robot.compensationTorques().value());
+      }
+      else
+      {
+
+        return mc_rtc::make_void_ptr<tasks::qp::MotionSpringConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
+                                                                    tDBound, timeStep, sjList, robot.externalTorques());
+      }
+    }
+    else
+    {
+      return mc_rtc::make_void_ptr<tasks::qp::MotionSpringConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
+                                                                  tDBound, timeStep, sjList);
+    }
   }
   else
   {
-    return mc_rtc::make_void_ptr<tasks::qp::MotionConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound, tDBound,
-                                                          timeStep);
+    if(compensateExtTorques)
+    {
+      if(robot.compensationTorques())
+      {
+        return mc_rtc::make_void_ptr<tasks::qp::MotionConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
+                                                              tDBound, timeStep, robot.compensationTorques().value());
+      }
+      else
+      {
+        return mc_rtc::make_void_ptr<tasks::qp::MotionConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
+                                                              tDBound, timeStep, robot.externalTorques());
+      }
+    }
+    else
+    {
+      return mc_rtc::make_void_ptr<tasks::qp::MotionConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound, tDBound,
+                                                            timeStep);
+    }
   }
 }
 
@@ -73,12 +108,13 @@ static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
                                    const mc_rbdyn::Robots & robots,
                                    unsigned int robotIndex,
                                    double timeStep,
-                                   bool infTorque)
+                                   bool infTorque,
+                                   bool compensateExtTorques)
 {
   switch(backend)
   {
     case QPSolver::Backend::Tasks:
-      return initialize_tasks(robots, robotIndex, timeStep, infTorque);
+      return initialize_tasks(robots, robotIndex, timeStep, infTorque, compensateExtTorques);
     case QPSolver::Backend::TVM:
       return initialize_tvm(robots.robot(robotIndex));
     default:
@@ -89,9 +125,11 @@ static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
 DynamicsConstraint::DynamicsConstraint(const mc_rbdyn::Robots & robots,
                                        unsigned int robotIndex,
                                        double timeStep,
-                                       bool infTorque)
+                                       bool infTorque,
+                                       bool compensateExtTorques)
 : KinematicsConstraint(robots, robotIndex, timeStep),
-  motion_constr_(initialize(backend_, robots, robotIndex, timeStep, infTorque)), robotIndex_(robotIndex)
+  motion_constr_(initialize(backend_, robots, robotIndex, timeStep, infTorque, compensateExtTorques)),
+  robotIndex_(robotIndex)
 {
 }
 
@@ -100,9 +138,11 @@ DynamicsConstraint::DynamicsConstraint(const mc_rbdyn::Robots & robots,
                                        double timeStep,
                                        const std::array<double, 3> & damper,
                                        double velocityPercent,
-                                       bool infTorque)
+                                       bool infTorque,
+                                       bool compensateExtTorques)
 : KinematicsConstraint(robots, robotIndex, timeStep, damper, velocityPercent),
-  motion_constr_(initialize(backend_, robots, robotIndex, timeStep, infTorque)), robotIndex_(robotIndex)
+  motion_constr_(initialize(backend_, robots, robotIndex, timeStep, infTorque, compensateExtTorques)),
+  robotIndex_(robotIndex)
 {
 }
 

--- a/src/mc_solver/DynamicsConstraint.cpp
+++ b/src/mc_solver/DynamicsConstraint.cpp
@@ -99,9 +99,10 @@ static mc_rtc::void_ptr initialize_tasks(const mc_rbdyn::Robots & robots,
   }
 }
 
-mc_rtc::void_ptr initialize_tvm(const mc_rbdyn::Robot & robot)
+mc_rtc::void_ptr initialize_tvm(const mc_rbdyn::Robot & robot, bool compensateExtTorques)
 {
-  return mc_rtc::make_void_ptr<mc_tvm::DynamicFunctionPtr>(std::make_shared<mc_tvm::DynamicFunction>(robot));
+  return mc_rtc::make_void_ptr<mc_tvm::DynamicFunctionPtr>(
+      std::make_shared<mc_tvm::DynamicFunction>(robot, compensateExtTorques));
 }
 
 static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
@@ -116,7 +117,7 @@ static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
     case QPSolver::Backend::Tasks:
       return initialize_tasks(robots, robotIndex, timeStep, infTorque, compensateExtTorques);
     case QPSolver::Backend::TVM:
-      return initialize_tvm(robots.robot(robotIndex));
+      return initialize_tvm(robots.robot(robotIndex), compensateExtTorques);
     default:
       mc_rtc::log::error_and_throw("[DynamicsConstraint] Not implemented for solver backend: {}", backend);
   }

--- a/src/mc_solver/DynamicsConstraint.cpp
+++ b/src/mc_solver/DynamicsConstraint.cpp
@@ -147,6 +147,23 @@ DynamicsConstraint::DynamicsConstraint(const mc_rbdyn::Robots & robots,
 {
 }
 
+void DynamicsConstraint::update(QPSolver & solver)
+{
+  if(backend_ == QPSolver::Backend::Tasks)
+  {
+    auto & robot = solver.robot(robotIndex_);
+    if(robot.compensationTorques())
+    {
+      static_cast<tasks::qp::MotionConstr *>(motion_constr_.get())
+          ->setExternalTorques(robot.compensationTorques().value());
+    }
+    else
+    {
+      static_cast<tasks::qp::MotionConstr *>(motion_constr_.get())->setExternalTorques(robot.externalTorques());
+    }
+  }
+}
+
 void DynamicsConstraint::addToSolverImpl(QPSolver & solver)
 {
   KinematicsConstraint::addToSolverImpl(solver);

--- a/src/mc_solver/TVMQPSolver.cpp
+++ b/src/mc_solver/TVMQPSolver.cpp
@@ -221,6 +221,15 @@ bool TVMQPSolver::runClosedLoop(bool integrateControlState)
     robot.forwardKinematics();
     robot.forwardVelocity();
     robot.forwardAcceleration();
+
+    // Update robot with realRobot's external/compenstation torques informations
+    robot.setExternalTorques(realRobot.externalTorques());
+    robot.setExternalTorquesAcc(realRobot.externalTorquesAcc());
+    if(realRobot.compensationTorques())
+    {
+      robot.setCompensationTorques(realRobot.compensationTorques().value());
+      robot.setCompensationTorquesAcc(realRobot.compensationTorquesAcc().value());
+    }
   }
 
   // Solve QP and integrate

--- a/src/mc_solver/TasksQPSolver.cpp
+++ b/src/mc_solver/TasksQPSolver.cpp
@@ -155,6 +155,21 @@ const sva::ForceVecd TasksQPSolver::desiredContactForce(const mc_rbdyn::Contact 
 bool TasksQPSolver::run_impl(FeedbackType fType)
 {
   bool success = false;
+
+  for(size_t i = 0; i < robots().size(); ++i)
+  {
+    auto & realRobot = realRobots().robot(i);
+    if(realRobot.externalTorques().size() == 0) continue;
+    auto fd = rbd::ForwardDynamics(realRobot.mb());
+    fd.computeH(realRobot.mb(), realRobot.mbc());
+    auto Hinv = fd.H().ldlt();
+    realRobot.setExternalTorquesAcc(Hinv.solve(realRobot.externalTorques()));
+    if(realRobot.compensationTorques() && !realRobot.compensationTorquesAcc())
+    {
+      realRobot.setCompensationTorquesAcc(Hinv.solve(realRobot.compensationTorques().value()));
+    }
+  }
+
   switch(fType)
   {
     case FeedbackType::None:
@@ -315,6 +330,14 @@ bool TasksQPSolver::runClosedLoop(bool integrateControlState)
     robot.forwardKinematics();
     robot.forwardVelocity();
     robot.forwardAcceleration();
+    // Update robot with realRobot's external/compenstation torques informations
+    robot.setExternalTorques(realRobot.externalTorques());
+    robot.setExternalTorquesAcc(realRobot.externalTorquesAcc());
+    if(realRobot.compensationTorques())
+    {
+      robot.setCompensationTorques(realRobot.compensationTorques().value());
+      robot.setCompensationTorquesAcc(realRobot.compensationTorquesAcc().value());
+    }
   }
 
   // Update tasks and constraints from estimated robots

--- a/src/mc_tvm/DynamicFunction.cpp
+++ b/src/mc_tvm/DynamicFunction.cpp
@@ -10,8 +10,9 @@
 namespace mc_tvm
 {
 
-DynamicFunction::DynamicFunction(const mc_rbdyn::Robot & robot)
-: tvm::function::abstract::LinearFunction(robot.mb().nrDof()), robot_(robot)
+DynamicFunction::DynamicFunction(const mc_rbdyn::Robot & robot, bool compensateExternalForces)
+: tvm::function::abstract::LinearFunction(robot.mb().nrDof()), robot_(robot),
+  compensateExternalForces_(compensateExternalForces)
 {
   registerUpdates(Update::B, &DynamicFunction::updateb);
   registerUpdates(Update::Jacobian, &DynamicFunction::updateJacobian);
@@ -20,6 +21,10 @@ DynamicFunction::DynamicFunction(const mc_rbdyn::Robot & robot)
   auto & tvm_robot = robot.tvmRobot();
   addInputDependency<DynamicFunction>(Update::Jacobian, tvm_robot, Robot::Output::H);
   addInputDependency<DynamicFunction>(Update::B, tvm_robot, Robot::Output::C);
+  if(compensateExternalForces_)
+  {
+    addInputDependency<DynamicFunction>(Update::B, tvm_robot, Robot::Output::ExternalForces);
+  }
   addVariable(tvm::dot(tvm_robot.q(), 2), true);
   addVariable(tvm_robot.tau(), true);
   jacobian_[tvm_robot.tau().get()] = -Eigen::MatrixXd::Identity(robot_.mb().nrDof(), robot_.mb().nrDof());
@@ -103,6 +108,14 @@ sva::ForceVecd DynamicFunction::contactForce(const mc_rbdyn::RobotFrame & frame)
 void DynamicFunction::updateb()
 {
   b_ = robot_.tvmRobot().C();
+  if(compensateExternalForces_)
+  {
+    if(robot_.tvmRobot().tauCompensation()) { b_ -= robot_.tvmRobot().tauCompensation().value(); }
+    else
+    {
+      b_ -= robot_.tvmRobot().tauExternal();
+    }
+  }
 }
 
 void DynamicFunction::updateJacobian()

--- a/src/mc_tvm/Robot.cpp
+++ b/src/mc_tvm/Robot.cpp
@@ -136,6 +136,8 @@ Robot::Robot(NewRobotToken, const mc_rbdyn::Robot & robot)
   dq_->setZero();
   ddq_->setZero();
   tau_->setZero();
+  tau_ext_ = Eigen::VectorXd::Zero(robot.mb().nrDof());
+  ddq_ext_ = Eigen::VectorXd::Zero(robot.mb().nrDof());
 
   const auto & rjo = robot.refJointOrder();
   refJointIndexToQIndex_.resize(rjo.size());
@@ -159,7 +161,7 @@ Robot::Robot(NewRobotToken, const mc_rbdyn::Robot & robot)
   /** Signal setup */
   registerUpdates(Update::FK, &Robot::updateFK, Update::FV, &Robot::updateFV, Update::FA, &Robot::updateFA,
                   Update::NormalAcceleration, &Robot::updateNormalAcceleration, Update::H, &Robot::updateH, Update::C,
-                  &Robot::updateC);
+                  &Robot::updateC, Update::ExternalForces, &Robot::updateExternalForces);
   /** Output dependencies setup */
   addOutputDependency(Output::FK, Update::FK);
   addOutputDependency(Output::FV, Update::FV);
@@ -168,12 +170,15 @@ Robot::Robot(NewRobotToken, const mc_rbdyn::Robot & robot)
   addOutputDependency(Output::H, Update::H);
   addOutputDependency(Output::C, Update::C);
   addOutputDependency(Output::FV, Update::FV);
+  addOutputDependency(Output::ExternalForces, Update::ExternalForces);
   /** Internal dependencies setup */
   addInternalDependency(Update::FV, Update::FK);
   addInternalDependency(Update::H, Update::FV);
   addInternalDependency(Update::C, Update::FV);
   addInternalDependency(Update::FA, Update::FV);
   addInternalDependency(Update::NormalAcceleration, Update::FV);
+  addInternalDependency(Update::ExternalForces, Update::H);
+  addInternalDependency(Update::ExternalForces, Update::FA);
 }
 
 void Robot::updateFK()
@@ -236,6 +241,19 @@ tvm::VariablePtr Robot::qJoint(size_t jIdx)
   const auto & j = mb.joints()[jIdx];
   return q_->subvariable(tvm::Space(j.dof(), j.params(), j.dof()), j.name(),
                          tvm::Space(offsetDof, offsetParam, offsetDof));
+}
+
+void Robot::updateExternalForces()
+{
+  tau_ext_ = robot_.externalTorques();
+  tau_comp_ = robot_.compensationTorques();
+  auto H_inv = H().ldlt();
+  ddq_ext_ = H_inv.solve(tau_ext_);
+  if(tau_comp_)
+  {
+    if(ddq_comp_->size() != tau_comp_->size()) { ddq_comp_->resize(tau_comp_->size()); }
+    ddq_comp_ = H_inv.solve(tau_comp_.value());
+  }
 }
 
 } // namespace mc_tvm


### PR DESCRIPTION
This PR extends the previous torque propagation framework by introducing feedforward compensation torques into the `DynamicConstraint` for both the TVM and Tasks backends.

For the TVM backend, a new boolean flag is added to `mc_tvm::DynamicFunction` to enable external torque disturbance compensation. The flag defaults to `false` to avoid breaking existing behavior. When enabled, feedforward compensation torques are retrieved directly within `DynamicFunction` from `Robot`, using `mc_tvm::Robot::tauCompensation()` when available, or falling back to the estimated external torques otherwise.

For the Tasks backend, a similar boolean flag is added to `DynamicConstraint` to activate disturbance compensation, also defaulted to `false`.
The feedforward torques are explicitly passed as `Eigen::VectorXd` to Tasks’ `MotionConstr` and `MotionSpringConstr`, using `mc_rbdyn::Robot::compensationTorques()` when provided, or `mc_rbdyn::Robot::externalTorques()` as a fallback.

Together, these changes enable optional feedforward disturbance rejection in the solver while preserving backward compatibility.

This PR include the content/commits of #500 and extend it.
It is also dependent on this [PR](https://github.com/jrl-umi3218/Tasks/pull/112) in Tasks.