### PR TITLE
feat(gui): Support string litterals as array/combo/table labels

### DIFF
--- a/binding/python/mc_rtc/gui/c_gui.pxd
+++ b/binding/python/mc_rtc/gui/c_gui.pxd
@@ -49,13 +49,13 @@ cdef extern from "<mc_rtc/gui.h>" namespace "mc_rtc::gui::details":
   cdef cppclass StringInputImpl[GetT, SetT](Element):
     pass
 
-  cdef cppclass ArrayInputImpl[GetT, SetT](Element):
+  cdef cppclass ArrayInputImpl[GetT, SetT, LabelsContainerT](Element):
     pass
 
-  cdef cppclass ComboInputImpl[GetT, SetT](Element):
+  cdef cppclass ComboInputImpl[GetT, SetT, LabelsContainerT](Element):
     pass
 
-  cdef cppclass DataComboInputImpl[GetT, SetT](Element):
+  cdef cppclass DataComboInputImpl[GetT, SetT, RefsContainerT](Element):
     pass
 
   cdef cppclass Point3DImpl[GetT, SetT](Element):
@@ -105,13 +105,13 @@ cdef extern from "<mc_rtc/gui.h>" namespace "mc_rtc::gui":
   cdef TransformImpl[GetT, nullptr_t] TransformRO"mc_rtc::gui::Transform"[GetT, nullptr_t](const string&, GetT)
   cdef TransformImpl[GetT,SetT] Transform[GetT,SetT](const string&, GetT, SetT)
 
-  cdef cppclass FormComboInput:
+  cdef cppclass FormComboInput[LabelsContainerT=*]:
     FormComboInput()
-    FormComboInput(const string&, cppbool, const vector[string]&, cppbool)
+    FormComboInput(const string&, cppbool, const LabelsContainerT&, cppbool)
 
-  cdef cppclass FormDataComboInput:
+  cdef cppclass FormDataComboInput[RefContainerT]:
     FormDataComboInput()
-    FormDataComboInput(const string&, cppbool, const vector[string]&, cppbool)
+    FormDataComboInput(const string&, cppbool, const RefContainerT&, cppbool)
 
   cdef FormImpl[Callback] Form[Callback](const string&, Callback)
 

--- a/binding/python/mc_rtc/gui/c_gui.pxd
+++ b/binding/python/mc_rtc/gui/c_gui.pxd
@@ -89,12 +89,12 @@ cdef extern from "<mc_rtc/gui.h>" namespace "mc_rtc::gui":
 
   cdef NumberSliderImpl[GetT, SetT] NumberSlider[GetT, SetT](const string&, GetT, SetT, double, double)
 
-  cdef ArrayInputImpl[GetT, SetT] ArrayInput[GetT, SetT](const string&, GetT, SetT)
-  cdef ArrayInputImpl[GetT, SetT] ArrayInput[GetT, SetT](const string&, const vector[string]&, GetT, SetT)
+  cdef ArrayInputImpl[GetT, SetT, LabelsContainerT] ArrayInput[GetT, SetT, LabelsContainerT](const string&, GetT, SetT)
+  cdef ArrayInputImpl[GetT, SetT, LabelsContainerT] ArrayInput[GetT, SetT, LabelsContainerT](const string&, const LabelsContainerT&, GetT, SetT)
 
-  cdef ComboInputImpl[GetT, SetT] ComboInput[GetT, SetT](const string&, const vector[string]&, GetT, SetT)
+  cdef ComboInputImpl[GetT, SetT, LabelsContainerT] ComboInput[GetT, SetT, LabelsContainerT](const string&, const LabelsContainerT&, GetT, SetT)
 
-  cdef DataComboInputImpl[GetT, SetT] DataComboInput[GetT, SetT](const string&, const vector[string]&, GetT, SetT)
+  cdef DataComboInputImpl[GetT, SetT, RefContainerT] DataComboInput[GetT, SetT, RefContainerT](const string&, const RefContainerT&, GetT, SetT)
 
   cdef Point3DImpl[GetT, nullptr_t] Point3DRO"mc_rtc::gui::Point3D"[GetT, nullptr_t](const string&, GetT, void *)
   cdef Point3DImpl[GetT,SetT] Point3D[GetT,SetT](const string&, GetT, SetT)

--- a/binding/python/mc_rtc/gui/gui.pyx
+++ b/binding/python/mc_rtc/gui/gui.pyx
@@ -393,11 +393,11 @@ cdef class StateBuilder(object):
     elif t is NumberSlider:
       self.impl.get().addElement[c_gui.NumberSliderImpl[c_gui.get_fn, c_gui.set_fn]](py2cpp(category), (<NumberSlider>element).impl)
     elif t is ArrayInput:
-      self.impl.get().addElement[c_gui.ArrayInputImpl[c_gui.get_fn, c_gui.set_fn]](py2cpp(category), (<ArrayInput>element).impl)
+      self.impl.get().addElement[c_gui.ArrayInputImpl[c_gui.get_fn, c_gui.set_fn, vector[string]]](py2cpp(category), (<ArrayInput>element).impl)
     elif t is ComboInput:
-      self.impl.get().addElement[c_gui.ComboInputImpl[c_gui.get_fn, c_gui.set_fn]](py2cpp(category), (<ComboInput>element).impl)
+      self.impl.get().addElement[c_gui.ComboInputImpl[c_gui.get_fn, c_gui.set_fn, vector[string]]](py2cpp(category), (<ComboInput>element).impl)
     elif t is DataComboInput:
-      self.impl.get().addElement[c_gui.DataComboInputImpl[c_gui.get_fn, c_gui.set_fn]](py2cpp(category), (<DataComboInput>element).impl)
+      self.impl.get().addElement[c_gui.DataComboInputImpl[c_gui.get_fn, c_gui.set_fn, vector[string]]](py2cpp(category), (<DataComboInput>element).impl)
     elif t is Point3D:
       is_ro = (<Point3D>element).is_ro
       if is_ro:

--- a/binding/python/mc_rtc/gui/gui.pyx
+++ b/binding/python/mc_rtc/gui/gui.pyx
@@ -130,7 +130,7 @@ cdef class NumberSlider(Element):
     self.base = &self.impl
 
 cdef class ArrayInput(Element):
-  cdef c_gui.ArrayInputImpl[c_gui.get_fn, c_gui.set_fn] impl
+  cdef c_gui.ArrayInputImpl[c_gui.get_fn, c_gui.set_fn, vector[string]] impl
   cdef _get_fn
   cdef _set_fn
   cdef _cb_ret_type
@@ -140,11 +140,11 @@ cdef class ArrayInput(Element):
     self._get_fn = get_fn
     self._set_fn = set_fn
     self._cb_ret_type = [float]
-    self.impl = c_gui.ArrayInput[c_gui.get_fn, c_gui.set_fn](name, py2cpp(labels), c_gui.make_getter(python_to_conf, get_fn), c_gui.make_setter(conf_to_python_list, set_fn, self._cb_ret_type))
+    self.impl = c_gui.ArrayInput[c_gui.get_fn, c_gui.set_fn, vector[string]](name, py2cpp(labels), c_gui.make_getter(python_to_conf, get_fn), c_gui.make_setter(conf_to_python_list, set_fn, self._cb_ret_type))
     self.base = &self.impl
 
 cdef class ComboInput(Element):
-  cdef c_gui.ComboInputImpl[c_gui.get_fn, c_gui.set_fn] impl
+  cdef c_gui.ComboInputImpl[c_gui.get_fn, c_gui.set_fn, vector[string]] impl
   cdef _get_fn
   cdef _set_fn
   def __cinit__(self, name, values, get_fn, set_fn):
@@ -152,11 +152,11 @@ cdef class ComboInput(Element):
       name = name.encode(u'ascii')
     self._get_fn = get_fn
     self._set_fn = set_fn
-    self.impl = c_gui.ComboInput[c_gui.get_fn, c_gui.set_fn](name, py2cpp(values), c_gui.make_getter(python_to_conf, get_fn), c_gui.make_setter(conf_to_python, set_fn, str))
+    self.impl = c_gui.ComboInput[c_gui.get_fn, c_gui.set_fn, vector[string]](name, py2cpp(values), c_gui.make_getter(python_to_conf, get_fn), c_gui.make_setter(conf_to_python, set_fn, str))
     self.base = &self.impl
 
 cdef class DataComboInput(Element):
-  cdef c_gui.DataComboInputImpl[c_gui.get_fn, c_gui.set_fn] impl
+  cdef c_gui.DataComboInputImpl[c_gui.get_fn, c_gui.set_fn, vector[string]] impl
   cdef _get_fn
   cdef _set_fn
   def __cinit__(self, name, ref, get_fn, set_fn):
@@ -164,7 +164,7 @@ cdef class DataComboInput(Element):
       name = name.encode(u'ascii')
     self._get_fn = get_fn
     self._set_fn = set_fn
-    self.impl = c_gui.DataComboInput[c_gui.get_fn, c_gui.set_fn](name, py2cpp(ref), c_gui.make_getter(python_to_conf, get_fn), c_gui.make_setter(conf_to_python, set_fn, str))
+    self.impl = c_gui.DataComboInput[c_gui.get_fn, c_gui.set_fn, vector[string]](name, py2cpp(ref), c_gui.make_getter(python_to_conf, get_fn), c_gui.make_setter(conf_to_python, set_fn, str))
     self.base = &self.impl
 
 cdef class Point3D(Element):
@@ -322,18 +322,18 @@ class FormStringArrayInput(object):
         c_gui.add_form_string_array(form.impl, self.name, self.required, self.default, self.fixed_size)
 
 cdef class FormComboInput(object):
-  cdef c_gui.FormComboInput impl
+  cdef c_gui.FormComboInput[vector[string]] impl
   def __cinit__(self, name, required, values, send_index = False):
     if isinstance(name, unicode):
       name = name.encode(u'ascii')
-    self.impl = c_gui.FormComboInput(name, required, py2cpp(values), send_index)
+    self.impl = c_gui.FormComboInput[vector[string]](name, required, py2cpp(values), send_index)
 
 cdef class FormDataComboInput(object):
-  cdef c_gui.FormDataComboInput impl
+  cdef c_gui.FormDataComboInput[vector[string]] impl
   def __cinit__(self, name, required, values, send_index = False):
     if isinstance(name, unicode):
       name = name.encode(u'ascii')
-    self.impl = c_gui.FormDataComboInput(name, required, py2cpp(values), send_index)
+    self.impl = c_gui.FormDataComboInput[vector[string]](name, required, py2cpp(values), send_index)
 
 cdef class Form(Element):
   cdef c_gui.FormImpl[c_gui.set_fn] impl

--- a/include/mc_rtc/gui/ArrayInput.h
+++ b/include/mc_rtc/gui/ArrayInput.h
@@ -23,7 +23,7 @@ namespace details
  * the array
  *
  */
-template<typename GetT, typename SetT>
+template<typename GetT, typename SetT, typename LabelsContainerT = std::vector<std::string>>
 struct ArrayInputImpl : public CommonInputImpl<GetT, SetT>
 {
   static constexpr auto type = Elements::ArrayInput;
@@ -32,8 +32,8 @@ struct ArrayInputImpl : public CommonInputImpl<GetT, SetT>
   ArrayInputImpl(const std::string & name, GetT get_fn, SetT set_fn) : ArrayInputImpl(name, {}, get_fn, set_fn) {}
 
   /** Constructor with labels per-dimension */
-  ArrayInputImpl(const std::string & name, const std::vector<std::string> & labels, GetT get_fn, SetT set_fn)
-  : CommonInputImpl<GetT, SetT>::CommonInputImpl(name, get_fn, set_fn), labels_(labels)
+  ArrayInputImpl(const std::string & name, const LabelsContainerT & labels, GetT get_fn, SetT set_fn)
+  : CommonInputImpl<GetT, SetT>::CommonInputImpl(name, get_fn, set_fn), labels_(details::to_string_vector(labels))
   {
   }
 
@@ -62,15 +62,15 @@ auto ArrayInput(const std::string & name, GetT get_fn, SetT set_fn)
 }
 
 /** Helper function to create an ArrayInput element (with labels) */
-template<typename GetT, typename SetT>
-auto ArrayInput(const std::string & name, const std::vector<std::string> & labels, GetT get_fn, SetT set_fn)
+template<typename GetT, typename SetT, typename LabelsContainer = std::vector<std::string>>
+auto ArrayInput(const std::string & name, const LabelsContainer & labels, GetT get_fn, SetT set_fn)
 {
   return details::ArrayInputImpl(name, labels, get_fn, set_fn);
 }
 
 /** Helper function to build an ArrayInput from a variable */
-template<typename T>
-auto ArrayInput(const std::string & name, const std::vector<std::string> & labels, T & value)
+template<typename T, typename LabelsContainer = std::vector<std::string>>
+auto ArrayInput(const std::string & name, const LabelsContainer & labels, T & value)
 {
   return details::ArrayInputImpl(name, labels, details::read(value), details::write(value));
 }

--- a/include/mc_rtc/gui/ComboInput.h
+++ b/include/mc_rtc/gui/ComboInput.h
@@ -18,13 +18,13 @@ namespace details
  *
  * \tparam SetT Should accept the choice made by the user
  */
-template<typename GetT, typename SetT>
+template<typename GetT, typename SetT, typename LabelsContainerT = std::vector<std::string>>
 struct ComboInputImpl : public CommonInputImpl<GetT, SetT>
 {
   static constexpr auto type = Elements::ComboInput;
 
-  ComboInputImpl(const std::string & name, const std::vector<std::string> & values, GetT get_fn, SetT set_fn)
-  : CommonInputImpl<GetT, SetT>(name, get_fn, set_fn), values_(values)
+  ComboInputImpl(const std::string & name, const LabelsContainerT & values, GetT get_fn, SetT set_fn)
+  : CommonInputImpl<GetT, SetT>(name, get_fn, set_fn), values_(details::to_string_vector(values))
   {
     static_assert(details::CheckReturnType<GetT, std::string>::value,
                   "ComboInput element getter callback should return an std::string");
@@ -48,14 +48,15 @@ private:
 } // namespace details
 
 /** Helper function to create a ComboInputImpl */
-template<typename GetT, typename SetT>
-auto ComboInput(const std::string & name, const std::vector<std::string> & values, GetT get_fn, SetT set_fn)
+template<typename GetT, typename SetT, typename ContainerT = std::vector<std::string>>
+auto ComboInput(const std::string & name, const ContainerT & values, GetT get_fn, SetT set_fn)
 {
   return details::ComboInputImpl(name, values, get_fn, set_fn);
 }
 
 /** Helper function to create a ComboInputImpl from a variable */
-inline auto ComboInput(const std::string & name, const std::vector<std::string> & values, std::string & value)
+template<typename Container = std::vector<std::string>>
+inline auto ComboInput(const std::string & name, const Container & values, std::string & value)
 {
   return ComboInput(name, values, details::read(value), details::write(value));
 }

--- a/include/mc_rtc/gui/DataComboInput.h
+++ b/include/mc_rtc/gui/DataComboInput.h
@@ -19,13 +19,13 @@ namespace details
  *
  * \tparam SetT Should accept the choice made by the user
  */
-template<typename GetT, typename SetT>
+template<typename GetT, typename SetT, typename LabelsContainerT = std::vector<std::string>>
 struct DataComboInputImpl : public CommonInputImpl<GetT, SetT>
 {
   static constexpr auto type = Elements::DataComboInput;
 
-  DataComboInputImpl(const std::string & name, const std::vector<std::string> & data_ref, GetT get_fn, SetT set_fn)
-  : CommonInputImpl<GetT, SetT>(name, get_fn, set_fn), data_ref_(data_ref)
+  DataComboInputImpl(const std::string & name, const LabelsContainerT & data_ref, GetT get_fn, SetT set_fn)
+  : CommonInputImpl<GetT, SetT>(name, get_fn, set_fn), data_ref_(details::to_string_vector(data_ref))
   {
   }
 
@@ -47,14 +47,15 @@ private:
 } // namespace details
 
 /** Helper function to build a DataComboInputImpl */
-template<typename GetT, typename SetT>
-auto DataComboInput(const std::string & name, const std::vector<std::string> & values, GetT get_fn, SetT set_fn)
+template<typename GetT, typename SetT, typename LabelsContainerT = std::vector<std::string>>
+auto DataComboInput(const std::string & name, const LabelsContainerT & values, GetT get_fn, SetT set_fn)
 {
   return details::DataComboInputImpl(name, values, get_fn, set_fn);
 }
 
 /** Helper function to build a DataComboInputImpl from a variable */
-inline auto DataComboInput(const std::string & name, const std::vector<std::string> & values, std::string & value)
+template<typename LabelsContainerT = std::vector<std::string>>
+inline auto DataComboInput(const std::string & name, const LabelsContainerT & values, std::string & value)
 {
   return DataComboInput(name, values, details::read(value), details::write(value));
 }

--- a/include/mc_rtc/gui/Form.h
+++ b/include/mc_rtc/gui/Form.h
@@ -8,6 +8,7 @@
 #include <mc_rtc/gui/elements.h>
 
 #include <mc_rtc/logging.h>
+#include "mc_rtc/gui/Label.h"
 
 namespace mc_rtc::gui
 {
@@ -341,24 +342,21 @@ MAKE_INTERACTIVE_DATA_INPUT_HELPER(sva::PTransformd, Elements::Transform, FormTr
 namespace details
 {
 
-template<typename T>
-struct FormArrayInput : public FormElement<FormArrayInput<T>, Elements::ArrayInput>
+template<typename T, typename LabelsContainerT = std::vector<std::string>>
+struct FormArrayInput : public FormElement<FormArrayInput<T, LabelsContainerT>, Elements::ArrayInput>
 {
   FormArrayInput(const std::string & name,
                  bool required,
-                 const std::vector<std::string> & labels,
+                 const LabelsContainerT & labels,
                  const T & def,
                  bool fixed_size = true)
-  : FormElement<FormArrayInput<T>, Elements::ArrayInput>(name, required), def_{def}, fixed_size_(fixed_size),
-    has_def_(true), labels_(labels)
+  : FormElement<FormArrayInput<T, LabelsContainerT>, Elements::ArrayInput>(name, required), def_{def},
+    fixed_size_(fixed_size), has_def_(true), labels_(details::to_string_vector(labels))
   {
   }
 
-  FormArrayInput(const std::string & name,
-                 bool required,
-                 const std::vector<std::string> & labels = {},
-                 bool fixed_size = false)
-  : FormArrayInput<T>(name, required, labels, {}, fixed_size)
+  FormArrayInput(const std::string & name, bool required, const LabelsContainerT & labels = {}, bool fixed_size = false)
+  : FormArrayInput<T>(name, required, details::to_string_vector(labels), {}, fixed_size)
   {
     has_def_ = false;
   }
@@ -408,15 +406,16 @@ auto FormArrayInput(const std::string & name, bool required, T && value, bool fi
   }
 }
 
-struct FormComboInput : public FormElement<FormComboInput, Elements::ComboInput>
+template<typename LabelsContainerT = std::vector<std::string>>
+struct FormComboInput : public FormElement<FormComboInput<LabelsContainerT>, Elements::ComboInput>
 {
   inline FormComboInput(const std::string & name,
                         bool required,
-                        const std::vector<std::string> & values,
+                        const LabelsContainerT & values,
                         bool send_index = false,
                         int def = -1)
-  : FormElement<FormComboInput, Elements::ComboInput>(name, required), values_(values), send_index_(send_index),
-    def_(def)
+  : FormElement<FormComboInput<LabelsContainerT>, Elements::ComboInput>(name, required),
+    values_(details::to_string_vector(values)), send_index_(send_index), def_(def)
   {
   }
 
@@ -438,13 +437,12 @@ private:
   int def_;
 };
 
-struct FormDataComboInput : public FormElement<FormDataComboInput, Elements::DataComboInput>
+template<typename RefContainerT = std::vector<std::string>>
+struct FormDataComboInput : public FormElement<FormDataComboInput<RefContainerT>, Elements::DataComboInput>
 {
-  inline FormDataComboInput(const std::string & name,
-                            bool required,
-                            const std::vector<std::string> & ref,
-                            bool send_index = false)
-  : FormElement<FormDataComboInput, Elements::DataComboInput>(name, required), ref_(ref), send_index_(send_index)
+  inline FormDataComboInput(const std::string & name, bool required, const RefContainerT & ref, bool send_index = false)
+  : FormElement<FormDataComboInput<RefContainerT>, Elements::DataComboInput>(name, required),
+    ref_(details::to_string_vector(ref)), send_index_(send_index)
   {
   }
 

--- a/include/mc_rtc/gui/Table.h
+++ b/include/mc_rtc/gui/Table.h
@@ -87,16 +87,16 @@ private:
  * \tparam GetData should return data that can be converted to a JSON array of
  * array (e.g. vector<vector<T>> or vector<tuple<...>>)
  */
-template<typename GetData>
+template<typename GetData,
+         typename HeaderContainerT = std::vector<std::string>,
+         typename FormatContainerT = std::vector<std::string>>
 struct StaticTableImpl : public Element
 {
   static constexpr auto type = Elements::Table;
 
-  StaticTableImpl(const std::string & name,
-                  std::vector<std::string> header,
-                  std::vector<std::string> format,
-                  GetData get_data_fn)
-  : Element(name), header_(std::move(header)), format_(std::move(format)), get_data_fn_(get_data_fn)
+  StaticTableImpl(const std::string & name, HeaderContainerT header, FormatContainerT format, GetData get_data_fn)
+  : Element(name), header_(std::move(details::to_string_vector(header))),
+    format_(std::move(details::to_string_vector(format))), get_data_fn_(get_data_fn)
   {
   }
 
@@ -119,21 +119,22 @@ private:
 } // namespace details
 
 /** Helper function to a get a StaticTableImpl */
-template<typename GetData>
-auto Table(const std::string & name, std::vector<std::string> header, GetData get_data_fn)
+template<typename GetData, typename HeaderContainerT = std::vector<std::string>>
+auto Table(const std::string & name, HeaderContainerT header, GetData get_data_fn)
 {
-  return details::StaticTableImpl(name, std::move(header), std::vector<std::string>(header.size(), "{}"), get_data_fn);
+  return details::StaticTableImpl(name, details::to_string_vector(std::move(header)),
+                                  std::vector<std::string>(header.size(), "{}"), get_data_fn);
 }
 
 /** Helper function to a get a StaticTableImpl with format */
-template<typename GetData>
-auto Table(const std::string & name,
-           std::vector<std::string> header,
-           std::vector<std::string> format,
-           GetData get_data_fn)
+template<typename GetData,
+         typename HeaderContainerT = std::vector<std::string>,
+         typename FormatContainerT = std::vector<std::string>>
+auto Table(const std::string & name, HeaderContainerT header, FormatContainerT format, GetData get_data_fn)
 {
   while(format.size() < header.size()) { format.push_back("{}"); }
-  return details::StaticTableImpl(name, std::move(header), std::move(format), get_data_fn);
+  return details::StaticTableImpl(name, details::to_string_vector(std::move(header)),
+                                  details::to_string_vector(std::move(format)), get_data_fn);
 }
 
 /** Helper function to get a TableImpl */

--- a/include/mc_rtc/gui/details/traits.h
+++ b/include/mc_rtc/gui/details/traits.h
@@ -257,4 +257,55 @@ struct is_variant<std::variant<Args...>> : public std::true_type
 template<typename T>
 inline constexpr bool is_variant_v = is_variant<T>::value;
 
+/**
+  These helpers convert containers of string-like elements into an std::vector<std::string>
+  In the context of ComboInput/ArrayInput, etc, this is used to accept containers of arbitrary strings, includinging
+  string-litterals and string_view. In the current gui implementation there is no speed benefit as it gets converted to
+  std::vector anyways, so this is just for convenience on the user side.
+*/
+
+// Trait to detect .size() member function (C++17)
+template<typename T>
+auto has_size_impl(int) -> decltype(std::declval<const T &>().size(), std::true_type{});
+template<typename>
+auto has_size_impl(...) -> std::false_type;
+
+template<typename T>
+struct has_size : decltype(has_size_impl<T>(0))
+{
+};
+
+// passthrough for lvalue
+inline const std::vector<std::string> & to_string_vector(const std::vector<std::string> & v)
+{
+  return v;
+}
+// passthrough for rvalue
+inline std::vector<std::string> to_string_vector(std::vector<std::string> && v)
+{
+  return std::move(v);
+}
+
+// Helper for containers with begin()/end()
+template<typename Container>
+auto to_string_vector(const Container & c) -> std::vector<std::string>
+{
+  using std::begin;
+  using std::end;
+  std::vector<std::string> result;
+  if(has_size<Container>::value) { result.reserve(c.size()); }
+  for(const auto & v : c) { result.emplace_back(v); }
+  return result;
+}
+
+// Overload for C-style arrays of string literals
+template<size_t N>
+auto to_string_vector(const char * const (&arr)[N]) -> std::vector<std::string>
+{
+  std::vector<std::string> result;
+  result.reserve(N);
+  for(size_t i = 0; i < N; ++i) { result.emplace_back(arr[i]); }
+  return result;
+}
+
 } // namespace mc_rtc::gui::details

--- a/tests/gui_SampleServer.cpp
+++ b/tests/gui_SampleServer.cpp
@@ -10,6 +10,9 @@
 #include "gui_TestServer.h"
 #include "utils.h"
 
+#include <string_view>
+using namespace std::string_view_literals;
+
 sva::PTransformd lookAt(const Eigen::Vector3d & position, const Eigen::Vector3d & target, const Eigen::Vector3d & up)
 {
   Eigen::Matrix3d R;
@@ -330,6 +333,7 @@ SampleServer::SampleServer() : xythetaz_(4)
   builder.addElement({"Checkbox"},
                      mc_rtc::gui::Checkbox("Checkbox", [this]() { return check_; }, [this]() { check_ = !check_; }));
   builder.addElement({"Checkbox", "Simple syntax"}, mc_rtc::gui::Checkbox("Checkbox", check_));
+  constexpr std::array ComboInputStringLitterals = {"a"sv, "b"sv, "c"sv, "d"sv};
   builder.addElement({"Inputs"},
                      mc_rtc::gui::StringInput(
                          "StringInput", [this]() { return string_; },
@@ -376,6 +380,13 @@ SampleServer::SampleServer() : xythetaz_(4)
                          }),
                      mc_rtc::gui::ComboInput(
                          "ComboInput", {"a", "b", "c", "d"}, [this]() { return combo_; },
+                         [this](const std::string & s)
+                         {
+                           combo_ = s;
+                           std::cout << "combo_ changed to " << combo_ << std::endl;
+                         }),
+                     mc_rtc::gui::ComboInput(
+                         "ComboInput (string litterals)", ComboInputStringLitterals, [this]() { return combo_; },
                          [this](const std::string & s)
                          {
                            combo_ = s;


### PR DESCRIPTION
Allows use of arrays of string litterals/string_view as label type for relevant gui elements. In its current form this has no runtime benefit, and is simply a convenience for the user.

That is:
  - `ArrayInput`
  - `ComboInput`
  - `DataComboInput`
  - `FormComboInput`
  - `FormDataComboInput`


Closes #514