### PR TITLE
Make QP run optional in FSM Controllers

### DIFF
--- a/include/mc_solver/QPSolver.h
+++ b/include/mc_solver/QPSolver.h
@@ -67,7 +67,9 @@ enum class MC_SOLVER_DLLAPI FeedbackType
   ClosedLoop = ObservedRobots,
   /** Run in closed loop w.r.t realRobots using the observation pipeline and integrate over the real state of the system
    */
-  ClosedLoopIntegrateReal
+  ClosedLoopIntegrateReal,
+  /** Skip the QP entirely */
+  SkipQP
 };
 
 MC_RTC_diagnostic_pop

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -820,12 +820,12 @@ bool MCController::run(mc_solver::FeedbackType fType)
   auto startUpdateContacts = mc_rtc::clock::now();
   updateContacts();
   updateContacts_dt_ = mc_rtc::clock::now() - startUpdateContacts;
+  if(fType == mc_solver::FeedbackType::SkipQP) { return true; }
   if(!qpsolver->run(fType))
   {
     mc_rtc::log::error("QP failed to run()");
     return false;
   }
-  return true;
 }
 
 void MCController::reset(const ControllerResetData & reset_data)

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -820,12 +820,12 @@ bool MCController::run(mc_solver::FeedbackType fType)
   auto startUpdateContacts = mc_rtc::clock::now();
   updateContacts();
   updateContacts_dt_ = mc_rtc::clock::now() - startUpdateContacts;
-  if(fType == mc_solver::FeedbackType::SkipQP) { return true; }
-  if(!qpsolver->run(fType))
+  if(fType != mc_solver::FeedbackType::SkipQP && !qpsolver->run(fType))
   {
     mc_rtc::log::error("QP failed to run()");
     return false;
   }
+  return true;
 }
 
 void MCController::reset(const ControllerResetData & reset_data)

--- a/src/mc_control/fsm/Controller.cpp
+++ b/src/mc_control/fsm/Controller.cpp
@@ -116,7 +116,11 @@ bool Controller::run(mc_solver::FeedbackType fType)
       teardownIdleState();
     }
   }
-  return MCController::run(fType);
+  if(fType == mc_solver::FeedbackType::SkipQP) { return true; }
+  else
+  {
+    return MCController::run(fType);
+  }
 }
 
 void Controller::reset(const ControllerResetData & data)


### PR DESCRIPTION
This PR allows to avoid running the QP in an FSM controller.

Use

```cpp
bool YourController::run()
{
  return mc_control::fsm::Controller::run(mc_solver::FeedbackType::SkipQP);
}
```
