### PR TITLE
[Explicit Compliance and Safety] Introduce CBF formulation for collision and joint constraints

### DIFF
--- a/include/mc_rbdyn/Collision.h
+++ b/include/mc_rbdyn/Collision.h
@@ -28,9 +28,11 @@ struct MC_RBDYN_DLLAPI Collision
             const std::optional<std::vector<std::string>> & r1Joints = {},
             const std::optional<std::vector<std::string>> & r2Joints = {},
             bool r1JointsInactive = false,
-            bool r2JointsInactive = false)
+            bool r2JointsInactive = false,
+            double m = 0,
+            double lambda = 0)
   : body1(b1), body2(b2), iDist(i), sDist(s), damping(d), r1Joints(r1Joints), r2Joints(r2Joints),
-    r1JointsInactive(r1JointsInactive), r2JointsInactive(r2JointsInactive)
+    r1JointsInactive(r1JointsInactive), r2JointsInactive(r2JointsInactive), overDamping(m), lambda(lambda)
   {
   }
   std::string body1; /** First body in the constraint */
@@ -50,6 +52,13 @@ struct MC_RBDYN_DLLAPI Collision
       r2Joints; /** Active/Inactive joints in the second robot, ignored if r1 == r2 */
   bool r1JointsInactive = false; /** When true the selected joints in r1ActiveJoints are considered inactive */
   bool r2JointsInactive = false; /** When true the selected joints in r2ActiveJoints are considered inactive */
+
+  /**
+   * CBF parameters, see details in Safe Execution of RL Policies via Acceleration-based CBF-QP Constraint Enforcement
+   * for Real-World Robotic Deployments, B.Muraccioli et al. (2026)
+   */
+  double overDamping; /** Over-damping */
+  double lambda; /** Lambda */
   inline bool isNone() { return body1 == "NONE" && body2 == "NONE"; }
 
   bool operator==(const Collision & rhs) const;

--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -17,6 +17,7 @@
 #include <RBDyn/MultiBodyConfig.h>
 #include <RBDyn/MultiBodyGraph.h>
 
+#include <Eigen/src/Core/Matrix.h>
 #include <memory>
 #include <optional>
 #include <unordered_map>
@@ -1114,6 +1115,42 @@ public:
    */
   mc_tvm::Convex & tvmConvex(const std::string & name) const;
 
+  /** @name External Torques
+   *
+   * These functions are used to get or set:
+   * - The estimation of external torques being applied on the robot and its 'equivalent' acceleration
+   * - The additional feedforward compensation torque and its 'equivalent' acceleration
+   *
+   * @{
+   */
+
+  /** Set the external torques */
+  void setExternalTorques(const Eigen::VectorXd & torques);
+
+  /** Get the external torques */
+  const Eigen::VectorXd & externalTorques(void) const;
+
+  /** Set the external torques equivalent accelerations */
+  void setExternalTorquesAcc(const Eigen::VectorXd & accelerations);
+
+  /** Get the external torques equivalent accelerations */
+  const Eigen::VectorXd & externalTorquesAcc(void) const;
+
+  /** Set the compensation torques */
+  void setCompensationTorques(const Eigen::VectorXd & torques);
+
+  /** Get the compensation torques */
+  const std::optional<Eigen::VectorXd> & compensationTorques(void) const;
+
+  /** Set the compensation torques equivalent accelerations */
+  void setCompensationTorquesAcc(const Eigen::VectorXd & accelerations);
+
+  /** Get the compensation torques equivalent accelerations */
+  const std::optional<Eigen::VectorXd> & compensationTorquesAcc(void) const;
+
+  /** @} */
+  /* End of External Forces group */
+
 private:
   Robots * robots_;
   unsigned int robots_idx_;
@@ -1149,6 +1186,14 @@ private:
   std::unordered_map<std::string, RobotFramePtr> frames_;
   /** Mass of this robot */
   double mass_ = 0.0;
+  /** Non modeled external forces acting on the robot **/
+  Eigen::VectorXd externalTorques_;
+  /** Joint accelerations from external forces acting on the robot **/
+  Eigen::VectorXd externalTorquesEquivalentAcc_;
+  /** External forces to be compensated in the commanded torque **/
+  std::optional<Eigen::VectorXd> externalTorqueCompensation_ = std::nullopt;
+  /** Joint accelerations from the compensation in the commanded torque **/
+  std::optional<Eigen::VectorXd> compensationEquivalentAcc_ = std::nullopt;
 
 protected:
   struct NewRobotToken

--- a/include/mc_solver/CollisionsConstraint.h
+++ b/include/mc_solver/CollisionsConstraint.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <mc_rtc/log/Logger.h>
 #include <mc_solver/ConstraintSet.h>
 
 #include <mc_rbdyn/Collision.h>
@@ -74,6 +75,16 @@ public:
    */
   void addCollision(QPSolver & solver, const mc_rbdyn::Collision & col);
 
+  /** Set the damping values of a set of collisions
+   *
+   * CBF parameters, see details in Safe Execution of RL Policies via Acceleration-based CBF-QP Constraint Enforcement
+   * for Real-World Robotic Deployments, B.Muraccioli et al. (2026)
+   *
+   * \param solver The solver into which this constraint was added
+   * \param dampers List of parameters: {overDamping, lambda}
+   */
+  void setCollisionsDampers(QPSolver & solver, const std::vector<double> & dampers);
+
   /** Add a set of collisions
    *
    * \see addCollision for details on wildcard collision specification
@@ -83,6 +94,18 @@ public:
    */
   void addCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols);
 
+  /** Edit a set of collisions
+   *
+   * The collision to edit is identified by the body names, the new parameters
+   * specified in col are applied to the collision, if it exists. If no such
+   * collision exists, this function does nothing.
+   *
+   * \param solver The solver into which this constraint was added \param col The
+   * collision with updated parameters, the collision to update is identified
+   * by the body names specified in col
+   */
+  void editCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols);
+
   /** Returns true if the given collision is in this constraint */
   bool hasCollision(const std::string & c1, const std::string & c2) const noexcept;
 
@@ -91,6 +114,11 @@ public:
 
   /** Get the automated monitoring setting */
   inline bool automaticMonitor() const noexcept { return autoMonitor_; }
+
+  /** Add collision logging
+   * \param a True to enable collision logging, false to disable
+   */
+  inline void logCollisions(bool a) noexcept { logCollisions_ = a; }
 
   /** Set the automated monitoring setting
    *
@@ -105,6 +133,13 @@ public:
   void update(QPSolver & solver) override;
 
   void removeFromSolverImpl(QPSolver & solver) override;
+
+  /** Get the current distance for a specific collision pair.
+   * \param b1Name Name of the first convex
+   * \param b2Name Name of the second convex
+   * \return The distance in meters. Returns infinity if the collision is not found.
+   */
+  double getDistance(const std::string & b1Name, const std::string & b2Name) const;
 
 public:
   /** Holds the constraint implementation
@@ -132,14 +167,19 @@ private:
   std::pair<int, mc_rbdyn::Collision> __popCollId(const std::string & name1, const std::string & name2);
   /** Actually adds the collision to the constraint, handles id creation and wildcard support */
   void __addCollision(mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col);
+  /** Actually removes the collision from the constraint, handles id removal */
+  void __editCollision(mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col);
 
   /* Internal management for collision display */
   bool autoMonitor_ = true;
+  bool logCollisions_ = true;
   std::unordered_set<int> monitored_;
   std::shared_ptr<mc_rtc::gui::StateBuilder> gui_;
+  std::shared_ptr<mc_rtc::Logger> logger_;
   std::vector<std::string> category_;
   void addMonitorButton(int collId, const mc_rbdyn::Collision & col);
   void toggleCollisionMonitor(int collId, const mc_rbdyn::Collision * col = nullptr);
+  void addLogs(int collId, const mc_rbdyn::Collision & col);
 };
 
 } // namespace mc_solver

--- a/include/mc_solver/DynamicsConstraint.h
+++ b/include/mc_solver/DynamicsConstraint.h
@@ -28,8 +28,15 @@ public:
    * \param robotIndex The index of the robot affected by this constraint
    * \param timeStep Solver timestep
    * \param infTorque If true, ignore the torque limits set in the robot model
+   * \param compensateExtTorques If true, compensates external disturbances using a feedworward torque signal. The
+   * constraint will search for the compensation value in robot by calling `compensationTorques()` method, if not an
+   * estimation of external torques acting on the robot will be used by calling `externalTorques()` method.
    */
-  DynamicsConstraint(const mc_rbdyn::Robots & robots, unsigned int robotIndex, double timeStep, bool infTorque = false);
+  DynamicsConstraint(const mc_rbdyn::Robots & robots,
+                     unsigned int robotIndex,
+                     double timeStep,
+                     bool infTorque = false,
+                     bool compensateExtTorques = false);
 
   /** Constructor
    * Builds a damped joint limits constraint and a motion constr depending on
@@ -42,13 +49,17 @@ public:
    * offset}
    * \param velocityPercent Maximum joint velocity percentage, 0.5 is advised
    * \param infTorque If true, ignore the torque limits set in the robot model
+   * \param compensateExtTorques If true, compensates external disturbances using a feedworward torque signal. The
+   * constraint will search for the compensation value in robot by calling `compensationTorques()` method, if not an
+   * estimation of external torques acting on the robot will be used by calling `externalTorques()` method.
    */
   DynamicsConstraint(const mc_rbdyn::Robots & robots,
                      unsigned int robotIndex,
                      double timeStep,
                      const std::array<double, 3> & damper,
                      double velocityPercent = 1.0,
-                     bool infTorque = false);
+                     bool infTorque = false,
+                     bool compensateExtTorques = false);
 
   /** Returns the tasks::qp::MotionConstr
    *

--- a/include/mc_solver/DynamicsConstraint.h
+++ b/include/mc_solver/DynamicsConstraint.h
@@ -61,6 +61,14 @@ public:
                      bool infTorque = false,
                      bool compensateExtTorques = false);
 
+  /** \brief Update the constraint
+   *
+   * This is called at every iteration of the controller once the constraint has been added to a solver
+   *
+   * \param solver Solver in which the constraint has been inserted
+   */
+  void update(QPSolver & solver) override;
+
   /** Returns the tasks::qp::MotionConstr
    *
    * This assumes the backend was Tasks

--- a/include/mc_solver/DynamicsConstraint.h
+++ b/include/mc_solver/DynamicsConstraint.h
@@ -28,7 +28,7 @@ public:
    * \param robotIndex The index of the robot affected by this constraint
    * \param timeStep Solver timestep
    * \param infTorque If true, ignore the torque limits set in the robot model
-   * \param compensateExtTorques If true, compensates external disturbances using a feedworward torque signal. The
+   * \param compensateExtTorques If true, compensates external disturbances using a feedforward torque signal. The
    * constraint will search for the compensation value in robot by calling `compensationTorques()` method, if not an
    * estimation of external torques acting on the robot will be used by calling `externalTorques()` method.
    */
@@ -36,7 +36,7 @@ public:
                      unsigned int robotIndex,
                      double timeStep,
                      bool infTorque = false,
-                     bool compensateExtTorques = false);
+                     bool compensateExtTorques = true);
 
   /** Constructor
    * Builds a damped joint limits constraint and a motion constr depending on
@@ -49,7 +49,7 @@ public:
    * offset}
    * \param velocityPercent Maximum joint velocity percentage, 0.5 is advised
    * \param infTorque If true, ignore the torque limits set in the robot model
-   * \param compensateExtTorques If true, compensates external disturbances using a feedworward torque signal. The
+   * \param compensateExtTorques If true, compensates external disturbances using a feedforward torque signal. The
    * constraint will search for the compensation value in robot by calling `compensationTorques()` method, if not an
    * estimation of external torques acting on the robot will be used by calling `externalTorques()` method.
    */
@@ -59,7 +59,26 @@ public:
                      const std::array<double, 3> & damper,
                      double velocityPercent = 1.0,
                      bool infTorque = false,
-                     bool compensateExtTorques = false);
+                     bool compensateExtTorques = true);
+
+  /** Constructor
+   * Builds a CBF joint limits constraint and a motion constr depending on
+   * the nature of the robot
+   * See details of the CBF constraint in Safe Execution of RL Policies via Acceleration-based CBF-QP Constraint
+   * Enforcement for Real-World Robotic Deployments, B.Muraccioli et al. (2026) See tasks::qp::MotionConstr for details
+   * on the latter one
+   * \param robots The robots including the robot affected by this constraint
+   * \param robotIndex The index of the robot affected by this constraint
+   * \param damperSecond Value of the damper {interaction distance, safety distance,
+   * offset, amortization margin, lambda}
+   * \param velocityPercent Maximum joint velocity percentage, 0.5 is advised
+   * \param compensateExtTorques If true, external torques are added to the dynamic model constraint
+   */
+  DynamicsConstraint(const mc_rbdyn::Robots & robots,
+                     unsigned int robotIndex,
+                     const std::array<double, 5> & damperSecond,
+                     double velocityPercent = 1.0,
+                     bool compensateExtTorques = true);
 
   /** \brief Update the constraint
    *

--- a/include/mc_solver/KinematicsConstraint.h
+++ b/include/mc_solver/KinematicsConstraint.h
@@ -45,6 +45,20 @@ public:
                        const std::array<double, 3> & damper,
                        double velocityPercent = 0.5);
 
+  /** CBF constraint constructor
+   * Builds a CBF joint limits constraint, see Safe Execution of RL Policies via Acceleration-based CBF-QP Constraint
+   * Enforcement for Real-World Robotic Deployments, B.Muraccioli et al. (2026)
+   * \param robots The robots including the robot affected by this constraint
+   * \param robotIndex The index of the robot affected by this constraint
+   * \param damperSecond Value of the damper {interaction distance, safety distance,
+   * offset, amortization margin}
+   * \param velocityPercent Maximum joint velocity percentage, 0.5 is advised
+   */
+  KinematicsConstraint(const mc_rbdyn::Robots & robots,
+                       unsigned int robotIndex,
+                       const std::array<double, 5> & damperSecond,
+                       double velocityPercent = 0.5);
+
 protected:
   /** Implementation of mc_solver::ConstraintSet::addToSolver */
   void addToSolverImpl(mc_solver::QPSolver & solver) override;

--- a/include/mc_tasks/CompliantEndEffectorTask.h
+++ b/include/mc_tasks/CompliantEndEffectorTask.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_tasks/EndEffectorTask.h>
+#include <RBDyn/MultiBody.h>
+#include <Eigen/src/Core/Matrix.h>
+
+namespace mc_tasks
+{
+
+/*! \brief Controls an end-effector
+ *
+ * This task is a thin wrapper around the appropriate tasks in Tasks.
+ * The task objective is given in the world frame. For relative control
+ * see mc_tasks::RelativeCompliantEndEffectorTask
+ */
+struct MC_TASKS_DLLAPI CompliantEndEffectorTask : public EndEffectorTask
+{
+public:
+  /*! \brief Constructor
+   *
+   * \param bodyName Name of the body to control
+   *
+   * \param robots Robots controlled by this task
+   *
+   * \param robotIndex Index of the robot controlled by this task
+   *
+   * \param stiffness Task stiffness
+   *
+   * \param weight Task weight
+   *
+   */
+  CompliantEndEffectorTask(const std::string & bodyName,
+                           const mc_rbdyn::Robots & robots,
+                           unsigned int robotIndex,
+                           double stiffness,
+                           double weight);
+
+  /** Change acceleration
+   *
+   * \p refAccel Should be of size 6
+   */
+  void refAccel(const Eigen::Vector6d & refAccel) noexcept;
+
+  // Set the compliant behavior of the task
+  void makeCompliant(bool compliance);
+  void setComplianceVector(Eigen::Vector6d gamma);
+
+  // Get compliance state of the task
+  bool isCompliant(void);
+  Eigen::Vector6d getComplianceVector(void);
+
+  void load(mc_solver::QPSolver & solver, const mc_rtc::Configuration & config) override;
+
+protected:
+  void addToSolver(mc_solver::QPSolver & solver) override;
+
+  void update(mc_solver::QPSolver & solver) override;
+
+  void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
+
+  Eigen::Matrix6d compliant_matrix_;
+
+  mc_tvm::Robot * tvm_robot_;
+  const mc_rbdyn::Robot * robot_;
+
+  unsigned int rIdx_;
+
+  std::string bodyName_;
+  const mc_rbdyn::RobotFrame & frame_;
+
+  rbd::Jacobian * jac_;
+
+  Eigen::Vector6d refAccel_;
+};
+
+} // namespace mc_tasks

--- a/include/mc_tasks/CompliantEndEffectorTask.h
+++ b/include/mc_tasks/CompliantEndEffectorTask.h
@@ -64,8 +64,8 @@ protected:
 
   Eigen::Matrix6d compliant_matrix_;
 
-  mc_tvm::Robot * tvm_robot_;
-  const mc_rbdyn::Robot * robot_;
+  const mc_rbdyn::Robot & robot_;
+  mc_tvm::Robot & tvm_robot_;
 
   unsigned int rIdx_;
 

--- a/include/mc_tasks/CompliantOrientationTask.h
+++ b/include/mc_tasks/CompliantOrientationTask.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_tasks/OrientationTask.h>
+#include <Eigen/src/Core/Matrix.h>
+
+namespace mc_tasks
+{
+
+struct MC_TASKS_DLLAPI CompliantOrientationTask : public OrientationTask
+{
+public:
+  CompliantOrientationTask(const std::string & bodyName_,
+                           const mc_rbdyn::Robots & robots,
+                           unsigned int robotIndex,
+                           double stiffness,
+                           double weight);
+
+  /** Change reference acceleration
+   *
+   * \p refAccel Should be of size nrDof
+   */
+  void refAccel(const Eigen::Vector3d & refAccel) noexcept;
+
+  // Set task to be compliant or not
+  void makeCompliant(bool compliance);
+  void setComplianceVector(Eigen::Vector3d gamma);
+  // Get compliance state of the task
+  bool isCompliant(void);
+  Eigen::Vector3d getComplianceVector(void);
+
+  // void load(mc_solver::QPSolver & solver, const mc_rtc::Configuration & config) override;
+
+protected:
+  void addToSolver(mc_solver::QPSolver & solver) override;
+
+  void update(mc_solver::QPSolver & solver) override;
+
+  void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
+
+  Eigen::Matrix3d Gamma_;
+
+  mc_tvm::Robot & tvm_robot_;
+
+  unsigned int rIdx_;
+
+  std::string bodyName_;
+  const mc_rbdyn::RobotFrame & frame_;
+
+  rbd::Jacobian * jac_;
+
+  Eigen::Vector3d refAccel_;
+};
+
+} // namespace mc_tasks

--- a/include/mc_tasks/CompliantOrientationTask.h
+++ b/include/mc_tasks/CompliantOrientationTask.h
@@ -43,6 +43,7 @@ protected:
 
   Eigen::Matrix3d Gamma_;
 
+  const mc_rbdyn::Robot & robot_;
   mc_tvm::Robot & tvm_robot_;
 
   unsigned int rIdx_;

--- a/include/mc_tasks/CompliantPositionTask.h
+++ b/include/mc_tasks/CompliantPositionTask.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_tasks/PositionTask.h>
+#include <Eigen/src/Core/Matrix.h>
+
+namespace mc_tasks
+{
+
+struct MC_TASKS_DLLAPI CompliantPositionTask : public PositionTask
+{
+public:
+  CompliantPositionTask(const std::string & bodyName_,
+                        const mc_rbdyn::Robots & robots,
+                        unsigned int robotIndex,
+                        double stiffness,
+                        double weight);
+
+  /** Change reference acceleration
+   *
+   * \p refAccel Should be of size nrDof
+   */
+  void refAccel(const Eigen::Vector3d & refAccel) noexcept;
+
+  // Set task to be compliant or not
+  void makeCompliant(bool compliance);
+  void setComplianceVector(Eigen::Vector3d gamma);
+  // Get compliance state of the task
+  bool isCompliant(void);
+  Eigen::Vector3d getComplianceVector(void);
+
+  // void load(mc_solver::QPSolver & solver, const mc_rtc::Configuration & config) override;
+
+protected:
+  void addToSolver(mc_solver::QPSolver & solver) override;
+
+  void update(mc_solver::QPSolver & solver) override;
+
+  void addToGUI(mc_rtc::gui::StateBuilder & gui) override;
+
+  Eigen::Matrix3d Gamma_;
+
+  mc_tvm::Robot & tvm_robot_;
+
+  unsigned int rIdx_;
+
+  std::string bodyName_;
+  const mc_rbdyn::RobotFrame & frame_;
+
+  rbd::Jacobian * jac_;
+
+  Eigen::Vector3d refAccel_;
+};
+
+} // namespace mc_tasks

--- a/include/mc_tasks/CompliantPositionTask.h
+++ b/include/mc_tasks/CompliantPositionTask.h
@@ -43,6 +43,7 @@ protected:
 
   Eigen::Matrix3d Gamma_;
 
+  const mc_rbdyn::Robot & robot_;
   mc_tvm::Robot & tvm_robot_;
 
   unsigned int rIdx_;

--- a/include/mc_tasks/CompliantPostureTask.h
+++ b/include/mc_tasks/CompliantPostureTask.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_tasks/PostureTask.h>
+
+namespace mc_tasks
+{
+
+struct MC_TASKS_DLLAPI CompliantPostureTask : public PostureTask
+{
+public:
+  CompliantPostureTask(const mc_solver::QPSolver & solver, unsigned int rIndex, double stiffness, double weight);
+
+  /** Change reference acceleration
+   *
+   * \p refAccel Should be of size nrDof
+   */
+  void refAccel(const Eigen::VectorXd & refAccel) noexcept;
+
+  // Set task to be compliant or not
+  void makeCompliant(bool compliance);
+  void makeCompliant(Eigen::VectorXd gamma);
+  // Get compliance state of the task
+  bool isCompliant(void);
+
+protected:
+  void update(mc_solver::QPSolver & solver);
+
+  void addToGUI(mc_rtc::gui::StateBuilder & gui);
+
+  Eigen::VectorXd gamma_;
+
+  mc_tvm::Robot & tvm_robot_;
+
+  Eigen::VectorXd refAccel_;
+};
+
+} // namespace mc_tasks

--- a/include/mc_tasks/CompliantPostureTask.h
+++ b/include/mc_tasks/CompliantPostureTask.h
@@ -33,6 +33,7 @@ protected:
 
   Eigen::VectorXd gamma_;
 
+  const mc_rbdyn::Robot & robot_;
   mc_tvm::Robot & tvm_robot_;
 
   Eigen::VectorXd refAccel_;

--- a/include/mc_tvm/DynamicFunction.h
+++ b/include/mc_tvm/DynamicFunction.h
@@ -36,7 +36,7 @@ public:
   SET_UPDATES(DynamicFunction, Jacobian, B)
 
   /** Construct the equation of motion for a given robot */
-  DynamicFunction(const mc_rbdyn::Robot & robot);
+  DynamicFunction(const mc_rbdyn::Robot & robot, bool compensateExternalForces = false);
 
   /** Add a contact to the function
    *
@@ -73,6 +73,7 @@ protected:
   void updateb();
 
   const mc_rbdyn::Robot & robot_;
+  const bool compensateExternalForces_;
 
   /** Holds data for the force part of the motion equation */
   struct ForceContact

--- a/include/mc_tvm/DynamicFunction.h
+++ b/include/mc_tvm/DynamicFunction.h
@@ -36,7 +36,7 @@ public:
   SET_UPDATES(DynamicFunction, Jacobian, B)
 
   /** Construct the equation of motion for a given robot */
-  DynamicFunction(const mc_rbdyn::Robot & robot, bool compensateExternalForces = false);
+  DynamicFunction(const mc_rbdyn::Robot & robot, bool compensateExternalForces = true);
 
   /** Add a contact to the function
    *

--- a/include/mc_tvm/Robot.h
+++ b/include/mc_tvm/Robot.h
@@ -16,6 +16,8 @@
 
 #include <RBDyn/FD.h>
 
+#include <optional>
+
 namespace mc_tvm
 {
 
@@ -47,8 +49,8 @@ namespace mc_tvm
  */
 struct MC_TVM_DLLAPI Robot : public tvm::graph::abstract::Node<Robot>
 {
-  SET_OUTPUTS(Robot, FK, FV, FA, NormalAcceleration, tau, H, C)
-  SET_UPDATES(Robot, FK, FV, FA, NormalAcceleration, H, C)
+  SET_OUTPUTS(Robot, FK, FV, FA, NormalAcceleration, tau, H, C, ExternalForces)
+  SET_UPDATES(Robot, FK, FV, FA, NormalAcceleration, H, C, ExternalForces)
 
   friend struct mc_rbdyn::Robot;
   EIGEN_MAKE_ALIGNED_OPERATOR_NEW
@@ -96,6 +98,11 @@ public:
   /** Access q second derivative (joint acceleration) */
   inline tvm::VariablePtr & alphaD() noexcept { return ddq_; }
 
+  /** Access joint acceleration from external forces (const) */
+  inline const Eigen::VectorXd & alphaDExternal() const noexcept { return ddq_ext_; }
+  /** Access joint acceleration from external forces */
+  inline Eigen::VectorXd & alphaDExternal() noexcept { return ddq_ext_; }
+
   /** Access floating-base variable (const) */
   inline const tvm::VariablePtr & qFloatingBase() const noexcept { return q_fb_; }
   /** Access free-flyer variable */
@@ -133,6 +140,21 @@ public:
   inline const tvm::VariablePtr & tau() const noexcept { return tau_; }
   /** Access tau variable */
   inline tvm::VariablePtr & tau() { return tau_; }
+
+  /** Access tau external variable (const) */
+  inline const Eigen::VectorXd & tauExternal() const noexcept { return tau_ext_; }
+  /** Access tau external variable */
+  inline Eigen::VectorXd & tauExternal() { return tau_ext_; }
+
+  /** Access tau compensation (const) */
+  inline const std::optional<Eigen::VectorXd> & tauCompensation() const noexcept { return tau_comp_; }
+  /** Access tau compensation */
+  inline std::optional<Eigen::VectorXd> & tauCompensation() noexcept { return tau_comp_; }
+
+  /** Access joint acceleration from compensation torques (const) */
+  inline const std::optional<Eigen::VectorXd> & alphaDCompensation() const noexcept { return ddq_comp_; }
+  /** Access joint acceleration from compensation torques */
+  inline std::optional<Eigen::VectorXd> & alphaDCompensation() noexcept { return ddq_comp_; }
 
   /** Returns the CoM algorithm associated to this robot (const) */
   inline const CoM & comAlgo() const noexcept { return *com_; }
@@ -203,8 +225,16 @@ private:
   tvm::VariablePtr dq_;
   /** Double derivative of q */
   tvm::VariablePtr ddq_;
+  /** Joint acceleration from external forces */
+  Eigen::VectorXd ddq_ext_;
+  /** Joint acceleration from compensation torques */
+  std::optional<Eigen::VectorXd> ddq_comp_;
   /** Tau variable */
   tvm::VariablePtr tau_;
+  /** Tau external variable */
+  Eigen::VectorXd tau_ext_;
+  /** Tau compensation variable */
+  std::optional<Eigen::VectorXd> tau_comp_;
   /** Normal accelerations of the bodies */
   std::vector<sva::MotionVecd> normalAccB_;
   /** Forward dynamics algorithm associated to this robot */
@@ -225,6 +255,7 @@ private:
   void updateNormalAcceleration();
   void updateH();
   void updateC();
+  void updateExternalForces();
 };
 
 } // namespace mc_tvm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -530,6 +530,10 @@ set(mc_tasks_SRC
     mc_tasks/lipm_stabilizer/StabilizerTask_log_gui.cpp
     mc_tasks/lipm_stabilizer/ZMPCC.cpp
     mc_tasks/lipm_stabilizer/Contact.cpp
+    mc_tasks/CompliantPostureTask.cpp
+    mc_tasks/CompliantPositionTask.cpp
+    mc_tasks/CompliantOrientationTask.cpp
+    mc_tasks/CompliantEndEffectorTask.cpp
 )
 
 set(mc_tasks_HDR
@@ -566,6 +570,10 @@ set(mc_tasks_HDR
     ../include/mc_tasks/lipm_stabilizer/StabilizerTask.h
     ../include/mc_tasks/lipm_stabilizer/Contact.h
     ../include/mc_tasks/lipm_stabilizer/ZMPCC.h
+    ../include/mc_tasks/CompliantPostureTask.h
+    ../include/mc_tasks/CompliantPositionTask.h
+    ../include/mc_tasks/CompliantOrientationTask.h
+    ../include/mc_tasks/CompliantEndEffectorTask.h
 )
 
 add_library(mc_tasks SHARED ${mc_tasks_SRC} ${mc_tasks_HDR})

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -18,10 +18,13 @@
 
 #include <RBDyn/CoM.h>
 #include <RBDyn/FA.h>
+#include <RBDyn/FD.h>
 #include <RBDyn/FK.h>
 #include <RBDyn/FV.h>
 #include <RBDyn/NumericalIntegration.h>
 
+#include <Eigen/src/Core/Matrix.h>
+#include <optional>
 #include <sch/S_Object/S_Cylinder.h>
 #include <sch/S_Object/S_Superellipsoid.h>
 
@@ -510,6 +513,9 @@ Robot::Robot(NewRobotToken,
   flexibility_ = module_.flexibility();
 
   zmp_ = Eigen::Vector3d::Zero();
+
+  externalTorques_ = Eigen::VectorXd::Zero(mb().nrDof());
+  externalTorquesEquivalentAcc_ = Eigen::VectorXd::Zero(mb().nrDof());
 }
 
 Robot::~Robot()
@@ -1565,6 +1571,58 @@ mc_tvm::Convex & Robot::tvmConvex(const std::string & name) const
                                                                   frame(cvx.first), collisionTransform(name))}});
   }
   return *it->second;
+}
+
+void Robot::setExternalTorques(const Eigen::VectorXd & torques)
+{
+  externalTorques_.noalias() = torques;
+}
+
+const Eigen::VectorXd & Robot::externalTorques(void) const
+{
+  return externalTorques_;
+}
+
+void Robot::setExternalTorquesAcc(const Eigen::VectorXd & accelerations)
+{
+  externalTorquesEquivalentAcc_.noalias() = accelerations;
+}
+
+const Eigen::VectorXd & Robot::externalTorquesAcc(void) const
+{
+  return externalTorquesEquivalentAcc_;
+}
+
+void Robot::setCompensationTorques(const Eigen::VectorXd & torques)
+{
+  if(!externalTorqueCompensation_) { externalTorqueCompensation_.emplace(torques.size()); }
+  else if(externalTorqueCompensation_->size() == torques.size())
+  {
+    externalTorqueCompensation_->resize(torques.size());
+  }
+
+  externalTorqueCompensation_->noalias() = torques;
+}
+
+const std::optional<Eigen::VectorXd> & Robot::compensationTorques(void) const
+{
+  return externalTorqueCompensation_;
+}
+
+void Robot::setCompensationTorquesAcc(const Eigen::VectorXd & accelerations)
+{
+  if(!externalTorqueCompensation_) { compensationEquivalentAcc_.emplace(accelerations.size()); }
+  else if(externalTorqueCompensation_->size() == accelerations.size())
+  {
+
+    compensationEquivalentAcc_->resize(accelerations.size());
+  }
+  compensationEquivalentAcc_->noalias() = accelerations;
+}
+
+const std::optional<Eigen::VectorXd> & Robot::compensationTorquesAcc(void) const
+{
+  return compensationEquivalentAcc_;
 }
 
 } // namespace mc_rbdyn

--- a/src/mc_solver/CollisionsConstraint.cpp
+++ b/src/mc_solver/CollisionsConstraint.cpp
@@ -19,6 +19,7 @@
 
 #include <Tasks/QPConstr.h>
 
+#include "mc_rtc/logging.h"
 #include <tvm/task_dynamics/VelocityDamper.h>
 
 #include "utils/jointsToSelector.h"
@@ -113,12 +114,16 @@ struct TVMCollisionConstraint
   void addCollision(TVMQPSolver & solver, CollisionData & data)
   {
     const auto & col = data.collision;
-    data.task = solver.problem().add(
-        data.function >= 0.,
-        tvm::task_dynamics::VelocityDamper(
-            solver.dt(), {col.iDist, col.sDist, col.damping, mc_solver::CollisionsConstraint::defaultDampingOffset},
-            tvm::constant::big_number),
-        {tvm::requirements::PriorityLevel(0)});
+    mc_rtc::log::info("[CollisionsConstraint] Adding collision constraint with xsi={}, xsioff={}, m={}, lambda={}",
+                      col.damping, mc_solver::CollisionsConstraint::defaultDampingOffset, col.overDamping, col.lambda);
+    data.task =
+        solver.problem().add(data.function >= 0.,
+                             tvm::task_dynamics::VelocityDamper(solver.dt(),
+                                                                {col.iDist, col.sDist, col.damping,
+                                                                 mc_solver::CollisionsConstraint::defaultDampingOffset,
+                                                                 col.overDamping, col.lambda},
+                                                                tvm::constant::big_number),
+                             {tvm::requirements::PriorityLevel(0)});
   }
 };
 
@@ -368,6 +373,74 @@ void CollisionsConstraint::__addCollision(mc_solver::QPSolver & solver, const mc
       break;
   }
   addMonitorButton(collId, col);
+  if(logCollisions_) addLogs(collId, col);
+}
+
+void CollisionsConstraint::__editCollision(mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col)
+{
+  // Check for the correct backend
+  if(backend_ != QPSolver::Backend::TVM)
+  {
+    mc_rtc::log::error("[CollisionsConstraint] Editing collisions is only supported for TVM backend currently.");
+    return;
+  }
+
+  // Find the collision in the existing set of constraints
+  auto collIdIt = collIdDict.find(__keyByNames(col.body1, col.body2));
+  if(collIdIt == collIdDict.end())
+  {
+    mc_rtc::log::error("[CollisionsConstraint] Attempting to edit a non-existent collision: {} - {}", col.body1,
+                       col.body2);
+    return;
+  }
+
+  // Get the current collision data
+  int collId = collIdIt->second.first;
+
+  // Remove the existing collision
+  tvm_constraint(constraint_)->deleteCollision(tvm_solver(solver), col);
+
+  // Add the new collision with updated parameters
+  const auto & robots = solver.robots();
+  const mc_rbdyn::Robot & r1 = robots.robot(r1Index);
+  const mc_rbdyn::Robot & r2 = robots.robot(r2Index);
+
+  auto computeJointsSelector =
+      [&robots](const std::optional<std::vector<std::string>> & joints, bool inactive, auto rIndex)
+  {
+    if(joints)
+    {
+      // check that all joints exist
+      for(const auto & j : *joints)
+      {
+        if(!robots.robot(rIndex).hasJoint(j))
+        {
+          mc_rtc::log::error_and_throw("[CollisionsConstraint] No joint named \"{}\" in robot \"{}\"", j,
+                                       robots.robot(rIndex).name());
+        }
+      }
+      if(inactive) { return jointsToSelector<false>(robots.robot(rIndex), *joints); }
+      else
+      {
+        return jointsToSelector<true>(robots.robot(rIndex), *joints);
+      }
+    }
+    else
+    {
+      return Eigen::VectorXd::Zero(0).eval();
+    }
+  };
+
+  auto r1Selector = computeJointsSelector(col.r1Joints, col.r1JointsInactive, r1Index);
+  auto r2Selector = r1Index == r2Index ? Eigen::VectorXd::Zero(0).eval()
+                                       : computeJointsSelector(col.r2Joints, col.r2JointsInactive, r2Index);
+
+  auto & data =
+      tvm_constraint(constraint_)->createCollision(tvm_solver(solver), r1, r2, col, collId, r1Selector, r2Selector);
+
+  tvm_constraint(constraint_)->addCollision(tvm_solver(solver), data);
+
+  mc_rtc::log::info("[CollisionsConstraint] Edited collision: {} - {}", col.body1, col.body2);
 }
 
 void CollisionsConstraint::addMonitorButton(int collId, const mc_rbdyn::Collision & col)
@@ -381,6 +454,45 @@ void CollisionsConstraint::addMonitorButton(int collId, const mc_rbdyn::Collisio
                                   "Monitor " + name, [collId, this]() { return monitored_.count(collId) != 0; },
                                   [collId, this]() { toggleCollisionMonitor(collId); }));
     category_.pop_back();
+  }
+}
+
+void CollisionsConstraint::addLogs(int collId, const mc_rbdyn::Collision & col)
+{
+  if(logger_ && inSolver_)
+  {
+    auto & logger = *logger_;
+    std::string label = col.body1 + "::" + col.body2;
+    auto addLogger = [&](auto && distance_callback, auto && di_callback, auto && ds_callback)
+    {
+      logger.addLogEntry("CollisionMonitor_" + label + "_distance",
+                         [distance_callback]() { return distance_callback(); });
+      logger.addLogEntry("CollisionMonitor_" + label + "_di", [di_callback]() { return di_callback(); });
+      logger.addLogEntry("CollisionMonitor_" + label + "_ds", [ds_callback]() { return ds_callback(); });
+    };
+    // Add the monitor
+    switch(backend_)
+    {
+      case QPSolver::Backend::Tasks:
+      {
+        auto collConstr = tasks_constraint(constraint_);
+        addLogger([collConstr, collId]() { return collConstr->getCollisionData(collId).distance; },
+                  [collConstr, collId]() { return collConstr->getCollisionData(collId).di; },
+                  [collConstr, collId]() { return collConstr->getCollisionData(collId).ds; });
+        break;
+      }
+      case QPSolver::Backend::TVM:
+      {
+        auto collConstr = tvm_constraint(constraint_);
+        auto fn = collConstr->getData(collId)->function;
+        addLogger([fn]() { return fn->distance(); },
+                  [collConstr, collId]() { return collConstr->getData(collId)->collision.iDist; },
+                  [collConstr, collId]() { return collConstr->getData(collId)->collision.sDist; });
+        break;
+      }
+      default:
+        break;
+    }
   }
 }
 
@@ -403,6 +515,7 @@ void CollisionsConstraint::toggleCollisionMonitor(int collId, const mc_rbdyn::Co
   const auto & col = *col_p;
   auto & gui = *gui_;
   std::string label = col.body1 + "::" + col.body2;
+
   if(monitored_.count(collId))
   {
     // Remove the monitor
@@ -474,9 +587,36 @@ void CollisionsConstraint::addCollisions(QPSolver & solver, const std::vector<mc
   }
 }
 
+void CollisionsConstraint::editCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols)
+{
+  // Check if the backend is TVM, as editing collisions is only supported for TVM
+  if(backend_ != QPSolver::Backend::TVM)
+  {
+    mc_rtc::log::error("[CollisionsConstraint] Editing collisions is only supported for TVM backend currently.");
+    return;
+  }
+  // Clear the existing collisions
+  // tvm_constraint(constraint_)->clear();
+  // Iterate over the list of collisions and call __editCollision for each
+  for(const auto & col : cols) { __editCollision(solver, col); }
+
+  mc_rtc::log::info("[CollisionsConstraint] Successfully edited {} collisions.", cols.size());
+}
+
+void CollisionsConstraint::setCollisionsDampers(QPSolver & solver, const std::vector<double> & dampers)
+{
+  for(auto & col : cols)
+  {
+    col.overDamping = dampers[0];
+    col.lambda = dampers[1];
+  }
+  editCollisions(solver, cols);
+}
+
 void CollisionsConstraint::addToSolverImpl(QPSolver & solver)
 {
   gui_ = solver.gui();
+  logger_ = solver.logger();
   const mc_rbdyn::Robot & r1 = solver.robots().robot(r1Index);
   const mc_rbdyn::Robot & r2 = solver.robots().robot(r2Index);
   category_ = {"Collisions", r1.name() + "/" + r2.name()};
@@ -500,7 +640,11 @@ void CollisionsConstraint::addToSolverImpl(QPSolver & solver)
     default:
       break;
   }
-  for(const auto & cols : collIdDict) { addMonitorButton(cols.second.first, cols.second.second); }
+  for(const auto & cols : collIdDict)
+  {
+    addMonitorButton(cols.second.first, cols.second.second);
+    if(logCollisions_) addLogs(cols.second.first, cols.second.second);
+  }
 }
 
 void CollisionsConstraint::update(QPSolver &)
@@ -608,6 +752,34 @@ bool CollisionsConstraint::hasCollision(const std::string & c1, const std::strin
 {
   auto it = std::find_if(cols.begin(), cols.end(), [&](const auto & c) { return c.body1 == c1 && c.body2 == c2; });
   return it != cols.end();
+}
+
+double CollisionsConstraint::getDistance(const std::string & b1Name, const std::string & b2Name) const
+{
+  std::string key = b1Name + b2Name;
+  auto it = collIdDict.find(key);
+  if(it == collIdDict.end()) { return std::numeric_limits<double>::infinity(); }
+
+  int collId = it->second.first;
+
+  auto & nonConstThis = const_cast<CollisionsConstraint &>(*this);
+
+  switch(backend_)
+  {
+    case QPSolver::Backend::Tasks:
+    {
+      auto collConstr = tasks_constraint(nonConstThis.constraint_);
+      return collConstr->getCollisionData(collId).distance;
+    }
+    case QPSolver::Backend::TVM:
+    {
+      auto collConstr = tvm_constraint(nonConstThis.constraint_);
+      auto & fn = collConstr->getData(collId)->function;
+      return fn->distance();
+    }
+    default:
+      mc_rtc::log::error_and_throw("[CollisionsConstraint] Not implemented for this backend");
+  }
 }
 
 } // namespace mc_solver

--- a/src/mc_solver/DynamicsConstraint.cpp
+++ b/src/mc_solver/DynamicsConstraint.cpp
@@ -19,7 +19,8 @@ namespace mc_solver
 static mc_rtc::void_ptr initialize_tasks(const mc_rbdyn::Robots & robots,
                                          unsigned int robotIndex,
                                          double timeStep,
-                                         bool infTorque)
+                                         bool infTorque,
+                                         bool compensateExtTorques)
 {
   const auto & robot = robots.robot(robotIndex);
   std::vector<std::vector<double>> tl = robot.tl();
@@ -54,13 +55,47 @@ static mc_rtc::void_ptr initialize_tasks(const mc_rbdyn::Robots & robots,
     {
       sjList.push_back(tasks::qp::SpringJoint(flex.jointName, flex.K, flex.C, flex.O));
     }
-    return mc_rtc::make_void_ptr<tasks::qp::MotionSpringConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
-                                                                tDBound, timeStep, sjList);
+    if(compensateExtTorques)
+    {
+      if(robot.compensationTorques())
+      {
+        return mc_rtc::make_void_ptr<tasks::qp::MotionSpringConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
+                                                                    tDBound, timeStep, sjList,
+                                                                    robot.compensationTorques().value());
+      }
+      else
+      {
+
+        return mc_rtc::make_void_ptr<tasks::qp::MotionSpringConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
+                                                                    tDBound, timeStep, sjList, robot.externalTorques());
+      }
+    }
+    else
+    {
+      return mc_rtc::make_void_ptr<tasks::qp::MotionSpringConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
+                                                                  tDBound, timeStep, sjList);
+    }
   }
   else
   {
-    return mc_rtc::make_void_ptr<tasks::qp::MotionConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound, tDBound,
-                                                          timeStep);
+    if(compensateExtTorques)
+    {
+      if(robot.compensationTorques())
+      {
+        return mc_rtc::make_void_ptr<tasks::qp::MotionConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
+                                                              tDBound, timeStep, robot.compensationTorques().value());
+      }
+      else
+      {
+        return mc_rtc::make_void_ptr<tasks::qp::MotionConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound,
+                                                              tDBound, timeStep, robot.externalTorques());
+      }
+    }
+    else
+    {
+      return mc_rtc::make_void_ptr<tasks::qp::MotionConstr>(robots.mbs(), static_cast<int>(robotIndex), tBound, tDBound,
+                                                            timeStep);
+    }
   }
 }
 
@@ -73,12 +108,13 @@ static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
                                    const mc_rbdyn::Robots & robots,
                                    unsigned int robotIndex,
                                    double timeStep,
-                                   bool infTorque)
+                                   bool infTorque,
+                                   bool compensateExtTorques)
 {
   switch(backend)
   {
     case QPSolver::Backend::Tasks:
-      return initialize_tasks(robots, robotIndex, timeStep, infTorque);
+      return initialize_tasks(robots, robotIndex, timeStep, infTorque, compensateExtTorques);
     case QPSolver::Backend::TVM:
       return initialize_tvm(robots.robot(robotIndex));
     default:
@@ -89,9 +125,11 @@ static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
 DynamicsConstraint::DynamicsConstraint(const mc_rbdyn::Robots & robots,
                                        unsigned int robotIndex,
                                        double timeStep,
-                                       bool infTorque)
+                                       bool infTorque,
+                                       bool compensateExtTorques)
 : KinematicsConstraint(robots, robotIndex, timeStep),
-  motion_constr_(initialize(backend_, robots, robotIndex, timeStep, infTorque)), robotIndex_(robotIndex)
+  motion_constr_(initialize(backend_, robots, robotIndex, timeStep, infTorque, compensateExtTorques)),
+  robotIndex_(robotIndex)
 {
 }
 
@@ -100,9 +138,11 @@ DynamicsConstraint::DynamicsConstraint(const mc_rbdyn::Robots & robots,
                                        double timeStep,
                                        const std::array<double, 3> & damper,
                                        double velocityPercent,
-                                       bool infTorque)
+                                       bool infTorque,
+                                       bool compensateExtTorques)
 : KinematicsConstraint(robots, robotIndex, timeStep, damper, velocityPercent),
-  motion_constr_(initialize(backend_, robots, robotIndex, timeStep, infTorque)), robotIndex_(robotIndex)
+  motion_constr_(initialize(backend_, robots, robotIndex, timeStep, infTorque, compensateExtTorques)),
+  robotIndex_(robotIndex)
 {
 }
 

--- a/src/mc_solver/DynamicsConstraint.cpp
+++ b/src/mc_solver/DynamicsConstraint.cpp
@@ -147,6 +147,37 @@ DynamicsConstraint::DynamicsConstraint(const mc_rbdyn::Robots & robots,
 {
 }
 
+DynamicsConstraint::DynamicsConstraint(const mc_rbdyn::Robots & robots,
+                                       unsigned int robotIndex,
+                                       double timeStep,
+                                       const std::array<double, 3> & damper,
+                                       const std::array<double, 2> & damperSecond,
+                                       double velocityPercent,
+                                       bool infTorque,
+                                       bool compensateExtTorques)
+: KinematicsConstraint(robots, robotIndex, timeStep, damper, damperSecond, velocityPercent),
+  motion_constr_(initialize(backend_, robots, robotIndex, timeStep, infTorque, compensateExtTorques)),
+  robotIndex_(robotIndex)
+{
+}
+
+void DynamicsConstraint::update(QPSolver & solver)
+{
+  if(backend_ == QPSolver::Backend::Tasks)
+  {
+    auto & robot = solver.robot(robotIndex_);
+    if(robot.compensationTorques())
+    {
+      static_cast<tasks::qp::MotionConstr *>(motion_constr_.get())
+          ->setExternalTorques(robot.compensationTorques().value());
+    }
+    else
+    {
+      static_cast<tasks::qp::MotionConstr *>(motion_constr_.get())->setExternalTorques(robot.externalTorques());
+    }
+  }
+}
+
 void DynamicsConstraint::addToSolverImpl(QPSolver & solver)
 {
   KinematicsConstraint::addToSolverImpl(solver);

--- a/src/mc_solver/DynamicsConstraint.cpp
+++ b/src/mc_solver/DynamicsConstraint.cpp
@@ -99,9 +99,10 @@ static mc_rtc::void_ptr initialize_tasks(const mc_rbdyn::Robots & robots,
   }
 }
 
-mc_rtc::void_ptr initialize_tvm(const mc_rbdyn::Robot & robot)
+mc_rtc::void_ptr initialize_tvm(const mc_rbdyn::Robot & robot, bool compensateExtTorques)
 {
-  return mc_rtc::make_void_ptr<mc_tvm::DynamicFunctionPtr>(std::make_shared<mc_tvm::DynamicFunction>(robot));
+  return mc_rtc::make_void_ptr<mc_tvm::DynamicFunctionPtr>(
+      std::make_shared<mc_tvm::DynamicFunction>(robot, compensateExtTorques));
 }
 
 static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
@@ -116,7 +117,7 @@ static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
     case QPSolver::Backend::Tasks:
       return initialize_tasks(robots, robotIndex, timeStep, infTorque, compensateExtTorques);
     case QPSolver::Backend::TVM:
-      return initialize_tvm(robots.robot(robotIndex));
+      return initialize_tvm(robots.robot(robotIndex), compensateExtTorques);
     default:
       mc_rtc::log::error_and_throw("[DynamicsConstraint] Not implemented for solver backend: {}", backend);
   }

--- a/src/mc_solver/DynamicsConstraint.cpp
+++ b/src/mc_solver/DynamicsConstraint.cpp
@@ -123,6 +123,20 @@ static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
   }
 }
 
+static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
+                                   const mc_rbdyn::Robots & robots,
+                                   unsigned int robotIndex,
+                                   bool compensateExtTorques)
+{
+  switch(backend)
+  {
+    case QPSolver::Backend::TVM:
+      return initialize_tvm(robots.robot(robotIndex), compensateExtTorques);
+    default:
+      mc_rtc::log::error_and_throw("[DynamicsConstraint] Not implemented for solver backend: {}", backend);
+  }
+}
+
 DynamicsConstraint::DynamicsConstraint(const mc_rbdyn::Robots & robots,
                                        unsigned int robotIndex,
                                        double timeStep,
@@ -149,15 +163,11 @@ DynamicsConstraint::DynamicsConstraint(const mc_rbdyn::Robots & robots,
 
 DynamicsConstraint::DynamicsConstraint(const mc_rbdyn::Robots & robots,
                                        unsigned int robotIndex,
-                                       double timeStep,
-                                       const std::array<double, 3> & damper,
-                                       const std::array<double, 2> & damperSecond,
+                                       const std::array<double, 5> & damperSecond,
                                        double velocityPercent,
-                                       bool infTorque,
                                        bool compensateExtTorques)
-: KinematicsConstraint(robots, robotIndex, timeStep, damper, damperSecond, velocityPercent),
-  motion_constr_(initialize(backend_, robots, robotIndex, timeStep, infTorque, compensateExtTorques)),
-  robotIndex_(robotIndex)
+: KinematicsConstraint(robots, robotIndex, damperSecond, velocityPercent),
+  motion_constr_(initialize(backend_, robots, robotIndex, compensateExtTorques)), robotIndex_(robotIndex)
 {
 }
 

--- a/src/mc_solver/KinematicsConstraint.cpp
+++ b/src/mc_solver/KinematicsConstraint.cpp
@@ -29,20 +29,32 @@ static mc_rtc::void_ptr initialize_tasks(const mc_rbdyn::Robots & robots, unsign
 TVMKinematicsConstraint::TVMKinematicsConstraint(const mc_rbdyn::Robot & robot,
                                                  const std::array<double, 3> & damper,
                                                  double vp)
-: robot_(robot), damper_(damper), velocityPercent_(vp)
+: robot_(robot), damper_(damper), damperSecond_({0.0, 0.0, 0.0, 0.0, 0.0}), velocityPercent_(vp)
+{
+}
+
+TVMKinematicsConstraint::TVMKinematicsConstraint(const mc_rbdyn::Robot & robot,
+                                                 const std::array<double, 5> & damperSecond,
+                                                 double vp)
+: robot_(robot), damper_({0.0, 0.0, 0.0}), damperSecond_(damperSecond), velocityPercent_(vp)
 {
 }
 
 void TVMKinematicsConstraint::addToSolver(mc_solver::TVMQPSolver & solver)
 {
+  bool useCBF = damperSecond_[3] > 1 - 1e-9; // m overDamping >= 1.0
+
   auto & tvm_robot = robot_.tvmRobot();
   /** Joint limits */
   int startParam = tvm_robot.qFloatingBase()->size();
   auto nParams = tvm_robot.qJoints()->size();
   auto ql = tvm_robot.limits().ql.segment(startParam, nParams);
   auto qu = tvm_robot.limits().qu.segment(startParam, nParams);
-  Eigen::VectorXd di = damper_[0] * (qu - ql);
-  Eigen::VectorXd ds = damper_[1] * (qu - ql);
+
+  double diGain = useCBF ? damperSecond_[0] : damper_[0];
+  double dsGain = useCBF ? damperSecond_[1] : damper_[1];
+  Eigen::VectorXd di = diGain * (qu - ql);
+  Eigen::VectorXd ds = dsGain * (qu - ql);
   for(int i = 0; i < nParams; ++i)
   {
     if(std::isinf(di(i)))
@@ -51,21 +63,48 @@ void TVMKinematicsConstraint::addToSolver(mc_solver::TVMQPSolver & solver)
       ds(i) = 0.005;
     }
   }
-  auto jl = solver.problem().add(
-      ql <= tvm_robot.qJoints() <= qu,
-      tvm::task_dynamics::VelocityDamper(solver.dt(), {di, ds, Eigen::VectorXd::Constant(nParams, 1, 0),
-                                                       Eigen::VectorXd::Constant(nParams, 1, damper_[2])}),
-      {tvm::requirements::PriorityLevel(0)});
-  constraints_.push_back(jl);
+
   /** Velocity limits */
   int startDof = tvm_robot.qFloatingBase()->space().tSize();
   auto nDof = tvm_robot.qJoints()->space().tSize();
   auto vl = tvm_robot.limits().vl.segment(startDof, nDof) * velocityPercent_;
   auto vu = tvm_robot.limits().vu.segment(startDof, nDof) * velocityPercent_;
-  auto vL =
-      solver.problem().add(vl <= tvm::dot(tvm_robot.qJoints()) <= vu, tvm::task_dynamics::Proportional(1 / solver.dt()),
-                           {tvm::requirements::PriorityLevel(0)});
-  constraints_.push_back(vL);
+
+  if(useCBF)
+  {
+    /** Add Joint limits to the QP problem */
+    auto jl = solver.problem().add(
+        ql <= tvm_robot.qJoints() <= qu,
+        tvm::task_dynamics::VelocityDamper(solver.dt(), {di, ds, Eigen::VectorXd::Constant(nParams, 1, 0),
+                                                         Eigen::VectorXd::Constant(nParams, 1, damperSecond_[2]),
+                                                         Eigen::VectorXd::Constant(nParams, 1, damperSecond_[3]),
+                                                         Eigen::VectorXd::Constant(nParams, 1, damperSecond_[4])}),
+        {tvm::requirements::PriorityLevel(0)});
+    constraints_.push_back(jl);
+
+    /** Add Velocity limits to the QP problem */
+    auto vL =
+        solver.problem().add(vl <= tvm::dot(tvm_robot.qJoints()) <= vu,
+                             tvm::task_dynamics::Proportional(damperSecond_[4]), {tvm::requirements::PriorityLevel(0)});
+    constraints_.push_back(vL);
+  }
+  else
+  {
+    /** Add Joint limits to the QP problem */
+    auto jl = solver.problem().add(
+        ql <= tvm_robot.qJoints() <= qu,
+        tvm::task_dynamics::VelocityDamper(solver.dt(), {di, ds, Eigen::VectorXd::Constant(nParams, 1, 0),
+                                                         Eigen::VectorXd::Constant(nParams, 1, damper_[2])}),
+        {tvm::requirements::PriorityLevel(0)});
+    constraints_.push_back(jl);
+
+    /** Add Velocity limits to the QP problem */
+    auto vL =
+        solver.problem().add(vl <= tvm::dot(tvm_robot.qJoints()) <= vu,
+                             tvm::task_dynamics::Proportional(1 / solver.dt()), {tvm::requirements::PriorityLevel(0)});
+    constraints_.push_back(vL);
+  }
+
   /** Acceleration limits */
   auto al = tvm_robot.limits().al.segment(startDof, nDof);
   auto au = tvm_robot.limits().au.segment(startDof, nDof);
@@ -105,6 +144,13 @@ void TVMKinematicsConstraint::removeFromSolver(mc_solver::TVMQPSolver & solver)
   mimics_constraints_.clear();
 }
 
+static mc_rtc::void_ptr initialize_tvm(const mc_rbdyn::Robot & robot,
+                                       const std::array<double, 5> & damperSecond,
+                                       double vp)
+{
+  return mc_rtc::make_void_ptr<TVMKinematicsConstraint>(robot, damperSecond, vp);
+}
+
 static mc_rtc::void_ptr initialize_tvm(const mc_rbdyn::Robot & robot, const std::array<double, 3> & damper, double vp)
 {
   return mc_rtc::make_void_ptr<TVMKinematicsConstraint>(robot, damper, vp);
@@ -112,7 +158,7 @@ static mc_rtc::void_ptr initialize_tvm(const mc_rbdyn::Robot & robot, const std:
 
 static mc_rtc::void_ptr initialize_tvm(const mc_rbdyn::Robot & robot)
 {
-  return initialize_tvm(robot, {0.1, 0.01, 0.5}, 0.5);
+  return initialize_tvm(robot, std::array<double, 3>{0.1, 0.01, 0.5}, 0.5);
 }
 
 static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
@@ -131,8 +177,31 @@ static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
   }
 }
 
+static mc_rtc::void_ptr initialize(QPSolver::Backend backend,
+                                   const mc_rbdyn::Robots & robots,
+                                   unsigned int robotIndex,
+                                   const std::array<double, 5> & damperSecond,
+                                   double velocityPercent)
+{
+  switch(backend)
+  {
+    case QPSolver::Backend::TVM:
+      return initialize_tvm(robots.robot(robotIndex), damperSecond, velocityPercent);
+    default:
+      mc_rtc::log::error_and_throw("[KinematicsConstraint] Not implemented for solver backend: {}", backend);
+  }
+}
+
 KinematicsConstraint::KinematicsConstraint(const mc_rbdyn::Robots & robots, unsigned int robotIndex, double timeStep)
 : constraint_(initialize(backend_, robots, robotIndex, timeStep))
+{
+}
+
+KinematicsConstraint::KinematicsConstraint(const mc_rbdyn::Robots & robots,
+                                           unsigned int robotIndex,
+                                           const std::array<double, 5> & damperSecond,
+                                           double velocityPercent)
+: constraint_(initialize(backend_, robots, robotIndex, damperSecond, velocityPercent))
 {
 }
 

--- a/src/mc_solver/TVMKinematicsConstraint.h
+++ b/src/mc_solver/TVMKinematicsConstraint.h
@@ -20,11 +20,13 @@ struct TVMKinematicsConstraint
 {
   const mc_rbdyn::Robot & robot_;
   std::array<double, 3> damper_;
+  std::array<double, 5> damperSecond_; // Only used for CBF constraint
   double velocityPercent_;
   std::vector<tvm::TaskWithRequirementsPtr> constraints_;
   std::vector<tvm::TaskWithRequirementsPtr> mimics_constraints_;
 
   TVMKinematicsConstraint(const mc_rbdyn::Robot & robot, const std::array<double, 3> & damper, double vp);
+  TVMKinematicsConstraint(const mc_rbdyn::Robot & robot, const std::array<double, 5> & damperSecond, double vp);
 
   void addToSolver(mc_solver::TVMQPSolver & solver);
 

--- a/src/mc_solver/TVMQPSolver.cpp
+++ b/src/mc_solver/TVMQPSolver.cpp
@@ -221,6 +221,15 @@ bool TVMQPSolver::runClosedLoop(bool integrateControlState)
     robot.forwardKinematics();
     robot.forwardVelocity();
     robot.forwardAcceleration();
+
+    // Update robot with realRobot's external/compenstation torques informations
+    robot.setExternalTorques(realRobot.externalTorques());
+    robot.setExternalTorquesAcc(realRobot.externalTorquesAcc());
+    if(realRobot.compensationTorques())
+    {
+      robot.setCompensationTorques(realRobot.compensationTorques().value());
+      robot.setCompensationTorquesAcc(realRobot.compensationTorquesAcc().value());
+    }
   }
 
   // Solve QP and integrate

--- a/src/mc_solver/TasksQPSolver.cpp
+++ b/src/mc_solver/TasksQPSolver.cpp
@@ -146,6 +146,21 @@ const sva::ForceVecd TasksQPSolver::desiredContactForce(const mc_rbdyn::Contact 
 bool TasksQPSolver::run_impl(FeedbackType fType)
 {
   bool success = false;
+
+  for(size_t i = 0; i < robots().size(); ++i)
+  {
+    auto & realRobot = realRobots().robot(i);
+    if(realRobot.externalTorques().size() == 0) continue;
+    auto fd = rbd::ForwardDynamics(realRobot.mb());
+    fd.computeH(realRobot.mb(), realRobot.mbc());
+    auto Hinv = fd.H().ldlt();
+    realRobot.setExternalTorquesAcc(Hinv.solve(realRobot.externalTorques()));
+    if(realRobot.compensationTorques() && !realRobot.compensationTorquesAcc())
+    {
+      realRobot.setCompensationTorquesAcc(Hinv.solve(realRobot.compensationTorques().value()));
+    }
+  }
+
   switch(fType)
   {
     case FeedbackType::None:
@@ -306,6 +321,14 @@ bool TasksQPSolver::runClosedLoop(bool integrateControlState)
     robot.forwardKinematics();
     robot.forwardVelocity();
     robot.forwardAcceleration();
+    // Update robot with realRobot's external/compenstation torques informations
+    robot.setExternalTorques(realRobot.externalTorques());
+    robot.setExternalTorquesAcc(realRobot.externalTorquesAcc());
+    if(realRobot.compensationTorques())
+    {
+      robot.setCompensationTorques(realRobot.compensationTorques().value());
+      robot.setCompensationTorquesAcc(realRobot.compensationTorquesAcc().value());
+    }
   }
 
   // Update tasks and constraints from estimated robots

--- a/src/mc_tasks/CompliantEndEffectorTask.cpp
+++ b/src/mc_tasks/CompliantEndEffectorTask.cpp
@@ -19,13 +19,20 @@ CompliantEndEffectorTask::CompliantEndEffectorTask(const std::string & bodyName,
                                                    double stiffness,
                                                    double weight)
 : EndEffectorTask(robots.robot(robotIndex).frame(bodyName), stiffness, weight),
-  compliant_matrix_(Eigen::Matrix6d::Zero()), tvm_robot_(nullptr), robot_(&robots.robot(robotIndex)), rIdx_(robotIndex),
-  bodyName_(bodyName), frame_(robots.robot(robotIndex).frame(bodyName)), refAccel_(Eigen::Vector6d::Zero())
+  compliant_matrix_(Eigen::Matrix6d::Zero()), robot_(robots.robot(robotIndex)),
+  tvm_robot_(robots.robot(robotIndex).tvmRobot()), rIdx_(robotIndex), bodyName_(bodyName),
+  frame_(robots.robot(robotIndex).frame(bodyName)), refAccel_(Eigen::Vector6d::Zero())
 {
-  if(backend_ != Backend::Tasks)
-    mc_rtc::log::error_and_throw<std::runtime_error>(
-        "[mc_tasks] Can't use CompliantEndEffectorTask with {} backend, please use TVM or TVMHierarchical backend",
-        backend_);
+  switch(backend_)
+  {
+    case Backend::Tasks:
+    case Backend::TVM:
+      break;
+    default:
+      mc_rtc::log::error_and_throw<std::runtime_error>(
+          "[mc_tasks] Can't use CompliantEndEffectorTask with {} backend, please use Tasks or TVM backend", backend_);
+      break;
+  }
 
   type_ = "compliant_body6d";
   name_ = "compliant_body6d_" + frame_.robot().name() + "_" + frame_.name();
@@ -64,37 +71,41 @@ Eigen::Vector6d CompliantEndEffectorTask::getComplianceVector(void)
 void CompliantEndEffectorTask::addToSolver(mc_solver::QPSolver & solver)
 {
   EndEffectorTask::addToSolver(solver);
-  tvm_robot_ = &solver.robots().robot(rIdx_).tvmRobot();
-  jac_ = new rbd::Jacobian(tvm_robot_->robot().mb(), frame_.body());
+  jac_ = new rbd::Jacobian(robot_.mb(), frame_.body());
 }
 
 void CompliantEndEffectorTask::update(mc_solver::QPSolver & solver)
 {
   Eigen::MatrixXd J = jac_->jacobian(solver.robot(rIdx_).mb(), solver.robot(rIdx_).mbc());
-  Eigen::Vector6d disturbance;
   Eigen::VectorXd acc;
 
   if(backend_ == Backend::Tasks)
   {
-    if(solver.robot().compensationTorquesAcc()) { acc = solver.robot().compensationTorquesAcc().value(); }
+    if(robot_.compensationTorquesAcc()) { acc = robot_.compensationTorquesAcc().value(); }
     else
     {
-      acc = solver.robot().externalTorquesAcc();
+      acc = robot_.externalTorquesAcc();
     }
-    mc_rtc::log::info("Task sensor acc = {}", acc.transpose());
-    disturbance = J * acc;
   }
   else
   {
-    disturbance.setZero();
+    if(tvm_robot_.alphaDCompensation()) { acc = tvm_robot_.alphaDCompensation().value(); }
+    else
+    {
+      acc = tvm_robot_.alphaDExternal();
+    }
   }
+  Eigen::Vector6d disturbance = J * acc;
+  mc_rtc::log::info("Task sensor acc = {}", acc.transpose());
+  mc_rtc::log::info("Task equivalent acc = {}", disturbance.transpose());
 
   Eigen::Vector6d disturbedAccel = refAccel_ + compliant_matrix_ * disturbance;
+  mc_rtc::log::info("Task disturbed ref acc = {}", disturbedAccel.transpose());
 
   EndEffectorTask::positionTask->refAccel(disturbedAccel.tail(3));
   EndEffectorTask::orientationTask->refAccel(disturbedAccel.head(3));
 
-  EndEffectorTask::update(solver);
+  // EndEffectorTask::update(solver);
 }
 
 void CompliantEndEffectorTask::load(mc_solver::QPSolver & solver, const mc_rtc::Configuration & config)

--- a/src/mc_tasks/CompliantEndEffectorTask.cpp
+++ b/src/mc_tasks/CompliantEndEffectorTask.cpp
@@ -96,11 +96,8 @@ void CompliantEndEffectorTask::update(mc_solver::QPSolver & solver)
     }
   }
   Eigen::Vector6d disturbance = J * acc;
-  mc_rtc::log::info("Task sensor acc = {}", acc.transpose());
-  mc_rtc::log::info("Task equivalent acc = {}", disturbance.transpose());
 
   Eigen::Vector6d disturbedAccel = refAccel_ + compliant_matrix_ * disturbance;
-  mc_rtc::log::info("Task disturbed ref acc = {}", disturbedAccel.transpose());
 
   EndEffectorTask::positionTask->refAccel(disturbedAccel.tail(3));
   EndEffectorTask::orientationTask->refAccel(disturbedAccel.head(3));

--- a/src/mc_tasks/CompliantEndEffectorTask.cpp
+++ b/src/mc_tasks/CompliantEndEffectorTask.cpp
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#include <mc_tasks/CompliantEndEffectorTask.h>
+
+#include <mc_rtc/gui/ArrayInput.h>
+#include <mc_rtc/gui/Checkbox.h>
+#include <mc_tvm/Robot.h>
+#include <SpaceVecAlg/EigenTypedef.h>
+#include <Eigen/src/Core/Matrix.h>
+
+namespace mc_tasks
+{
+
+CompliantEndEffectorTask::CompliantEndEffectorTask(const std::string & bodyName,
+                                                   const mc_rbdyn::Robots & robots,
+                                                   unsigned int robotIndex,
+                                                   double stiffness,
+                                                   double weight)
+: EndEffectorTask(robots.robot(robotIndex).frame(bodyName), stiffness, weight),
+  compliant_matrix_(Eigen::Matrix6d::Zero()), tvm_robot_(nullptr), robot_(&robots.robot(robotIndex)), rIdx_(robotIndex),
+  bodyName_(bodyName), frame_(robots.robot(robotIndex).frame(bodyName)), refAccel_(Eigen::Vector6d::Zero())
+{
+  if(backend_ != Backend::Tasks)
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "[mc_tasks] Can't use CompliantEndEffectorTask with {} backend, please use TVM or TVMHierarchical backend",
+        backend_);
+
+  type_ = "compliant_body6d";
+  name_ = "compliant_body6d_" + frame_.robot().name() + "_" + frame_.name();
+  EndEffectorTask::name(name_);
+}
+
+void CompliantEndEffectorTask::refAccel(const Eigen::Vector6d & refAccel) noexcept
+{
+  refAccel_ = refAccel;
+}
+
+void CompliantEndEffectorTask::makeCompliant(bool compliance)
+{
+  if(compliance) { compliant_matrix_.diagonal().setOnes(); }
+  else
+  {
+    compliant_matrix_.diagonal().setZero();
+  }
+}
+
+void CompliantEndEffectorTask::setComplianceVector(Eigen::Vector6d gamma)
+{
+  compliant_matrix_.diagonal() = gamma;
+}
+
+bool CompliantEndEffectorTask::isCompliant(void)
+{
+  return compliant_matrix_.diagonal().norm() > 0;
+}
+
+Eigen::Vector6d CompliantEndEffectorTask::getComplianceVector(void)
+{
+  return compliant_matrix_.diagonal();
+}
+
+void CompliantEndEffectorTask::addToSolver(mc_solver::QPSolver & solver)
+{
+  EndEffectorTask::addToSolver(solver);
+  tvm_robot_ = &solver.robots().robot(rIdx_).tvmRobot();
+  jac_ = new rbd::Jacobian(tvm_robot_->robot().mb(), frame_.body());
+}
+
+void CompliantEndEffectorTask::update(mc_solver::QPSolver & solver)
+{
+  Eigen::MatrixXd J = jac_->jacobian(solver.robot(rIdx_).mb(), solver.robot(rIdx_).mbc());
+  Eigen::Vector6d disturbance;
+  Eigen::VectorXd acc;
+
+  if(backend_ == Backend::Tasks)
+  {
+    if(solver.robot().compensationTorquesAcc()) { acc = solver.robot().compensationTorquesAcc().value(); }
+    else
+    {
+      acc = solver.robot().externalTorquesAcc();
+    }
+    mc_rtc::log::info("Task sensor acc = {}", acc.transpose());
+    disturbance = J * acc;
+  }
+  else
+  {
+    disturbance.setZero();
+  }
+
+  Eigen::Vector6d disturbedAccel = refAccel_ + compliant_matrix_ * disturbance;
+
+  EndEffectorTask::positionTask->refAccel(disturbedAccel.tail(3));
+  EndEffectorTask::orientationTask->refAccel(disturbedAccel.head(3));
+
+  EndEffectorTask::update(solver);
+}
+
+void CompliantEndEffectorTask::load(mc_solver::QPSolver & solver, const mc_rtc::Configuration & config)
+{
+  MetaTask::load(solver, config);
+  if(config.has("stiffness"))
+  {
+    auto s = config("stiffness");
+    if(s.size())
+    {
+      Eigen::VectorXd stiff = s;
+      positionTask->stiffness(stiff);
+      orientationTask->stiffness(stiff);
+    }
+    else
+    {
+      double stiff = s;
+      positionTask->stiffness(stiff);
+      orientationTask->stiffness(stiff);
+    }
+  }
+  if(config.has("damping"))
+  {
+    auto d = config("damping");
+    if(d.size())
+    {
+      positionTask->setGains(positionTask->dimStiffness(), d);
+      orientationTask->setGains(orientationTask->dimStiffness(), d);
+    }
+    else
+    {
+      positionTask->setGains(positionTask->stiffness(), d);
+      orientationTask->setGains(orientationTask->stiffness(), d);
+    }
+  }
+  if(config.has("compliance"))
+  {
+    auto g = config("compliance");
+    if(g.size()) { setComplianceVector(g); }
+    else
+    {
+      makeCompliant((double)g != 0);
+    }
+  }
+  if(config.has("weight"))
+  {
+    double w = config("weight");
+    positionTask->weight(w);
+    orientationTask->weight(w);
+  }
+}
+
+void CompliantEndEffectorTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
+{
+  gui.addElement({"Tasks", name_, "Compliance"}, mc_rtc::gui::Checkbox(
+                                                     "Compliance is active", [this]() { return isCompliant(); },
+                                                     [this]() { makeCompliant(!isCompliant()); }));
+  gui.addElement({"Tasks", name_, "Compliance"},
+                 mc_rtc::gui::ArrayInput(
+                     "Compliance parameters", {"rx", "ry", "rz", "x", "y", "z"}, [this]()
+                     { return getComplianceVector(); }, [this](Eigen::Vector6d v) { setComplianceVector(v); }));
+
+  EndEffectorTask::addToGUI(gui);
+}
+
+} // namespace mc_tasks

--- a/src/mc_tasks/CompliantOrientationTask.cpp
+++ b/src/mc_tasks/CompliantOrientationTask.cpp
@@ -15,12 +15,19 @@ CompliantOrientationTask::CompliantOrientationTask(const std::string & bodyName_
                                                    double stiffness,
                                                    double weight)
 : OrientationTask(robots.robot(robotIndex).frame(bodyName_), stiffness, weight), Gamma_(Eigen::Matrix3d::Zero()),
-  tvm_robot_(robots.robot(robotIndex).tvmRobot()), rIdx_(robotIndex), frame_(robots.robot(robotIndex).frame(bodyName_)),
-  refAccel_(Eigen::Vector3d::Zero())
+  robot_(robots.robot(robotIndex)), tvm_robot_(robots.robot(robotIndex).tvmRobot()), rIdx_(robotIndex),
+  frame_(robots.robot(robotIndex).frame(bodyName_)), refAccel_(Eigen::Vector3d::Zero())
 {
-  if(backend_ != Backend::Tasks)
-    mc_rtc::log::error_and_throw<std::runtime_error>(
-        "[mc_tasks] Can't use CompliantEndEffectorTask with {} backend, please use Tasks backend", backend_);
+  switch(backend_)
+  {
+    case Backend::Tasks:
+    case Backend::TVM:
+      break;
+    default:
+      mc_rtc::log::error_and_throw<std::runtime_error>(
+          "[mc_tasks] Can't use CompliantOrientationTask with {} backend, please use Tasks or TVM backend", backend_);
+      break;
+  }
 
   type_ = "compliant_position";
   name_ = std::string("compliant_position_") + frame_.robot().name() + "_" + frame_.name();
@@ -35,7 +42,6 @@ void CompliantOrientationTask::refAccel(const Eigen::Vector3d & refAccel) noexce
 void CompliantOrientationTask::update(mc_solver::QPSolver & solver)
 {
   auto J = jac_->jacobian(robots.robot(rIndex).mb(), robots.robot(rIndex).mbc());
-  Eigen::Vector3d disturbance;
   Eigen::VectorXd acc;
   if(backend_ == Backend::Tasks)
   {
@@ -44,13 +50,17 @@ void CompliantOrientationTask::update(mc_solver::QPSolver & solver)
     {
       acc = solver.robot().externalTorquesAcc();
     }
-    Eigen::Vector3d frame_acc = (J * acc).head(3);
-    disturbance = Gamma_ * frame_acc;
   }
   else
   {
-    disturbance.setZero();
+    if(tvm_robot_.alphaDCompensation()) { acc = tvm_robot_.alphaDCompensation().value(); }
+    else
+    {
+      acc = tvm_robot_.alphaDExternal();
+    }
   }
+  Eigen::Vector3d frame_acc = (J * acc).head(3);
+  Eigen::Vector3d disturbance = Gamma_ * frame_acc;
   // mc_rtc::log::info("Ref accel from disturbance : {}", disturbance.transpose());
   Eigen::Vector3d disturbedAccel = refAccel_ + disturbance;
   OrientationTask::refAccel(disturbedAccel);

--- a/src/mc_tasks/CompliantOrientationTask.cpp
+++ b/src/mc_tasks/CompliantOrientationTask.cpp
@@ -1,0 +1,100 @@
+#include <mc_tasks/CompliantOrientationTask.h>
+
+#include <mc_rtc/gui/ArrayInput.h>
+#include <mc_rtc/gui/Checkbox.h>
+#include <mc_tvm/Robot.h>
+#include <RBDyn/Jacobian.h>
+#include <Eigen/src/Core/Matrix.h>
+
+namespace mc_tasks
+{
+
+CompliantOrientationTask::CompliantOrientationTask(const std::string & bodyName_,
+                                                   const mc_rbdyn::Robots & robots,
+                                                   unsigned int robotIndex,
+                                                   double stiffness,
+                                                   double weight)
+: OrientationTask(robots.robot(robotIndex).frame(bodyName_), stiffness, weight), Gamma_(Eigen::Matrix3d::Zero()),
+  tvm_robot_(robots.robot(robotIndex).tvmRobot()), rIdx_(robotIndex), frame_(robots.robot(robotIndex).frame(bodyName_)),
+  refAccel_(Eigen::Vector3d::Zero())
+{
+  if(backend_ != Backend::Tasks)
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "[mc_tasks] Can't use CompliantEndEffectorTask with {} backend, please use Tasks backend", backend_);
+
+  type_ = "compliant_position";
+  name_ = std::string("compliant_position_") + frame_.robot().name() + "_" + frame_.name();
+  OrientationTask::name(name_);
+}
+
+void CompliantOrientationTask::refAccel(const Eigen::Vector3d & refAccel) noexcept
+{
+  refAccel_ = refAccel;
+}
+
+void CompliantOrientationTask::update(mc_solver::QPSolver & solver)
+{
+  auto J = jac_->jacobian(robots.robot(rIndex).mb(), robots.robot(rIndex).mbc());
+  Eigen::Vector3d disturbance;
+  Eigen::VectorXd acc;
+  if(backend_ == Backend::Tasks)
+  {
+    if(solver.robot().compensationTorquesAcc()) { acc = solver.robot().compensationTorquesAcc().value(); }
+    else
+    {
+      acc = solver.robot().externalTorquesAcc();
+    }
+    Eigen::Vector3d frame_acc = (J * acc).head(3);
+    disturbance = Gamma_ * frame_acc;
+  }
+  else
+  {
+    disturbance.setZero();
+  }
+  // mc_rtc::log::info("Ref accel from disturbance : {}", disturbance.transpose());
+  Eigen::Vector3d disturbedAccel = refAccel_ + disturbance;
+  OrientationTask::refAccel(disturbedAccel);
+  OrientationTask::update(solver);
+}
+
+void CompliantOrientationTask::makeCompliant(bool compliance)
+{
+  if(compliance) { Gamma_.diagonal().setOnes(); }
+  else
+  {
+    Gamma_.diagonal().setZero();
+  }
+}
+
+void CompliantOrientationTask::setComplianceVector(Eigen::Vector3d Gamma)
+{
+  Gamma_.diagonal() = Gamma;
+}
+
+bool CompliantOrientationTask::isCompliant(void)
+{
+  return Gamma_.diagonal().norm() > 0;
+}
+
+Eigen::Vector3d CompliantOrientationTask::getComplianceVector(void)
+{
+  return Gamma_.diagonal();
+}
+
+void CompliantOrientationTask::addToSolver(mc_solver::QPSolver & solver)
+{
+  OrientationTask::addToSolver(solver);
+  jac_ = new rbd::Jacobian(robots.robot(rIdx_).mb(), frame_.body());
+}
+
+void CompliantOrientationTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
+{
+  OrientationTask::addToGUI(gui);
+  gui.addElement(
+      {"Tasks", name_, "Compliance"},
+      mc_rtc::gui::Checkbox(
+          "Compliance is active", [this]() { return isCompliant(); }, [this]() { makeCompliant(!isCompliant()); }),
+      mc_rtc::gui::ArrayInput("Gamma", {"x", "y", "z"}, Gamma_));
+}
+
+} // namespace mc_tasks

--- a/src/mc_tasks/CompliantPositionTask.cpp
+++ b/src/mc_tasks/CompliantPositionTask.cpp
@@ -1,0 +1,100 @@
+#include <mc_tasks/CompliantPositionTask.h>
+
+#include <mc_rtc/gui/ArrayInput.h>
+#include <mc_rtc/gui/Checkbox.h>
+#include <mc_tvm/Robot.h>
+#include <RBDyn/Jacobian.h>
+#include <Eigen/src/Core/Matrix.h>
+
+namespace mc_tasks
+{
+
+CompliantPositionTask::CompliantPositionTask(const std::string & bodyName_,
+                                             const mc_rbdyn::Robots & robots,
+                                             unsigned int robotIndex,
+                                             double stiffness,
+                                             double weight)
+: PositionTask(robots.robot(robotIndex).frame(bodyName_), stiffness, weight), Gamma_(Eigen::Matrix3d::Zero()),
+  tvm_robot_(robots.robot(robotIndex).tvmRobot()), rIdx_(robotIndex), frame_(robots.robot(robotIndex).frame(bodyName_)),
+  refAccel_(Eigen::Vector3d::Zero())
+{
+  if(backend_ != Backend::Tasks)
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "[mc_tasks] Can't use CompliantEndEffectorTask with {} backend, please use Tasks backend", backend_);
+
+  type_ = "compliant_position";
+  name_ = std::string("compliant_position_") + frame_.robot().name() + "_" + frame_.name();
+  PositionTask::name(name_);
+}
+
+void CompliantPositionTask::refAccel(const Eigen::Vector3d & refAccel) noexcept
+{
+  refAccel_ = refAccel;
+}
+
+void CompliantPositionTask::update(mc_solver::QPSolver & solver)
+{
+  auto J = jac_->jacobian(robots.robot(rIndex).mb(), robots.robot(rIndex).mbc());
+  Eigen::Vector3d disturbance;
+  Eigen::VectorXd acc;
+  if(backend_ == Backend::Tasks)
+  {
+    if(solver.robot().compensationTorquesAcc()) { acc = solver.robot().compensationTorquesAcc().value(); }
+    else
+    {
+      acc = solver.robot().externalTorquesAcc();
+    }
+    Eigen::Vector3d frame_acc = (J * acc).tail(3);
+    disturbance = Gamma_ * frame_acc;
+  }
+  else
+  {
+    disturbance.setZero();
+  }
+  // mc_rtc::log::info("Ref accel from disturbance : {}", disturbance.transpose());
+  Eigen::Vector3d disturbedAccel = refAccel_ + disturbance;
+  PositionTask::refAccel(disturbedAccel);
+  PositionTask::update(solver);
+}
+
+void CompliantPositionTask::makeCompliant(bool compliance)
+{
+  if(compliance) { Gamma_.diagonal().setOnes(); }
+  else
+  {
+    Gamma_.diagonal().setZero();
+  }
+}
+
+void CompliantPositionTask::setComplianceVector(Eigen::Vector3d Gamma)
+{
+  Gamma_.diagonal() = Gamma;
+}
+
+bool CompliantPositionTask::isCompliant(void)
+{
+  return Gamma_.diagonal().norm() > 0;
+}
+
+Eigen::Vector3d CompliantPositionTask::getComplianceVector(void)
+{
+  return Gamma_.diagonal();
+}
+
+void CompliantPositionTask::addToSolver(mc_solver::QPSolver & solver)
+{
+  PositionTask::addToSolver(solver);
+  jac_ = new rbd::Jacobian(robots.robot(rIdx_).mb(), frame_.body());
+}
+
+void CompliantPositionTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
+{
+  PositionTask::addToGUI(gui);
+  gui.addElement(
+      {"Tasks", name_, "Compliance"},
+      mc_rtc::gui::Checkbox(
+          "Compliance is active", [this]() { return isCompliant(); }, [this]() { makeCompliant(!isCompliant()); }),
+      mc_rtc::gui::ArrayInput("Gamma", {"x", "y", "z"}, Gamma_));
+}
+
+} // namespace mc_tasks

--- a/src/mc_tasks/CompliantPositionTask.cpp
+++ b/src/mc_tasks/CompliantPositionTask.cpp
@@ -15,12 +15,19 @@ CompliantPositionTask::CompliantPositionTask(const std::string & bodyName_,
                                              double stiffness,
                                              double weight)
 : PositionTask(robots.robot(robotIndex).frame(bodyName_), stiffness, weight), Gamma_(Eigen::Matrix3d::Zero()),
-  tvm_robot_(robots.robot(robotIndex).tvmRobot()), rIdx_(robotIndex), frame_(robots.robot(robotIndex).frame(bodyName_)),
-  refAccel_(Eigen::Vector3d::Zero())
+  robot_(robots.robot(robotIndex)), tvm_robot_(robots.robot(robotIndex).tvmRobot()), rIdx_(robotIndex),
+  frame_(robots.robot(robotIndex).frame(bodyName_)), refAccel_(Eigen::Vector3d::Zero())
 {
-  if(backend_ != Backend::Tasks)
-    mc_rtc::log::error_and_throw<std::runtime_error>(
-        "[mc_tasks] Can't use CompliantEndEffectorTask with {} backend, please use Tasks backend", backend_);
+  switch(backend_)
+  {
+    case Backend::Tasks:
+    case Backend::TVM:
+      break;
+    default:
+      mc_rtc::log::error_and_throw<std::runtime_error>(
+          "[mc_tasks] Can't use CompliantPositionTask with {} backend, please use Tasks or TVM backend", backend_);
+      break;
+  }
 
   type_ = "compliant_position";
   name_ = std::string("compliant_position_") + frame_.robot().name() + "_" + frame_.name();
@@ -35,7 +42,6 @@ void CompliantPositionTask::refAccel(const Eigen::Vector3d & refAccel) noexcept
 void CompliantPositionTask::update(mc_solver::QPSolver & solver)
 {
   auto J = jac_->jacobian(robots.robot(rIndex).mb(), robots.robot(rIndex).mbc());
-  Eigen::Vector3d disturbance;
   Eigen::VectorXd acc;
   if(backend_ == Backend::Tasks)
   {
@@ -44,13 +50,17 @@ void CompliantPositionTask::update(mc_solver::QPSolver & solver)
     {
       acc = solver.robot().externalTorquesAcc();
     }
-    Eigen::Vector3d frame_acc = (J * acc).tail(3);
-    disturbance = Gamma_ * frame_acc;
   }
   else
   {
-    disturbance.setZero();
+    if(tvm_robot_.alphaDCompensation()) { acc = tvm_robot_.alphaDCompensation().value(); }
+    else
+    {
+      acc = tvm_robot_.alphaDExternal();
+    }
   }
+  Eigen::Vector3d frame_acc = (J * acc).tail(3);
+  Eigen::Vector3d disturbance = Gamma_ * frame_acc;
   // mc_rtc::log::info("Ref accel from disturbance : {}", disturbance.transpose());
   Eigen::Vector3d disturbedAccel = refAccel_ + disturbance;
   PositionTask::refAccel(disturbedAccel);

--- a/src/mc_tasks/CompliantPostureTask.cpp
+++ b/src/mc_tasks/CompliantPostureTask.cpp
@@ -14,13 +14,20 @@ CompliantPostureTask::CompliantPostureTask(const mc_solver::QPSolver & solver,
                                            double stiffness,
                                            double weight)
 : PostureTask(solver, rIndex, stiffness, weight),
-  gamma_(Eigen::VectorXd::Zero(solver.robots().robot(rIndex).mb().nrDof())),
+  gamma_(Eigen::VectorXd::Zero(solver.robots().robot(rIndex).mb().nrDof())), robot_(solver.robots().robot(rIndex)),
   tvm_robot_(solver.robots().robot(rIndex).tvmRobot()),
   refAccel_(Eigen::VectorXd::Zero(solver.robots().robot(rIndex).mb().nrDof()))
 {
-  if(backend_ != Backend::Tasks)
-    mc_rtc::log::error_and_throw<std::runtime_error>(
-        "[mc_tasks] Can't use CompliantEndEffectorTask with {} backend, please use Tasks backend", backend_);
+  switch(backend_)
+  {
+    case Backend::Tasks:
+    case Backend::TVM:
+      break;
+    default:
+      mc_rtc::log::error_and_throw<std::runtime_error>(
+          "[mc_tasks] Can't use CompliantPostureTask with {} backend, please use Tasks or TVM backend", backend_);
+      break;
+  }
   name_ = std::string("compliant_posture_") + solver.robots().robot(rIndex).name();
   type_ = "compliant_posture";
 }
@@ -36,17 +43,21 @@ void CompliantPostureTask::update(mc_solver::QPSolver & solver)
   Eigen::VectorXd acc;
   if(backend_ == Backend::Tasks)
   {
-    if(solver.robot().compensationTorquesAcc()) { acc = solver.robot().compensationTorquesAcc().value(); }
+    if(robot_.compensationTorquesAcc()) { acc = robot_.compensationTorquesAcc().value(); }
     else
     {
-      acc = solver.robot().externalTorquesAcc();
+      acc = robot_.externalTorquesAcc();
     }
-    disturbance = gamma_.asDiagonal() * acc;
   }
   else
   {
-    disturbance.setZero();
+    if(tvm_robot_.alphaDCompensation()) { acc = tvm_robot_.alphaDCompensation().value(); }
+    else
+    {
+      acc = tvm_robot_.alphaDExternal();
+    }
   }
+  disturbance = gamma_.asDiagonal() * acc;
 
   // mc_rtc::log::info("Ref accel from disturbance : {}", disturbance.transpose());
   // mc_rtc::log::info("Ref accel : {}", refAccel_.transpose());

--- a/src/mc_tasks/CompliantPostureTask.cpp
+++ b/src/mc_tasks/CompliantPostureTask.cpp
@@ -1,0 +1,88 @@
+#include <mc_tasks/CompliantPostureTask.h>
+
+#include <mc_rtc/gui/Checkbox.h>
+#include <mc_tvm/Robot.h>
+#include "mc_rtc/gui/ArrayInput.h"
+#include "mc_rtc/logging.h"
+#include <Eigen/src/Core/Matrix.h>
+
+namespace mc_tasks
+{
+
+CompliantPostureTask::CompliantPostureTask(const mc_solver::QPSolver & solver,
+                                           unsigned int rIndex,
+                                           double stiffness,
+                                           double weight)
+: PostureTask(solver, rIndex, stiffness, weight),
+  gamma_(Eigen::VectorXd::Zero(solver.robots().robot(rIndex).mb().nrDof())),
+  tvm_robot_(solver.robots().robot(rIndex).tvmRobot()),
+  refAccel_(Eigen::VectorXd::Zero(solver.robots().robot(rIndex).mb().nrDof()))
+{
+  if(backend_ != Backend::Tasks)
+    mc_rtc::log::error_and_throw<std::runtime_error>(
+        "[mc_tasks] Can't use CompliantEndEffectorTask with {} backend, please use Tasks backend", backend_);
+  name_ = std::string("compliant_posture_") + solver.robots().robot(rIndex).name();
+  type_ = "compliant_posture";
+}
+
+void CompliantPostureTask::refAccel(const Eigen::VectorXd & refAccel) noexcept
+{
+  refAccel_ = refAccel;
+}
+
+void CompliantPostureTask::update(mc_solver::QPSolver & solver)
+{
+  Eigen::VectorXd disturbance;
+  Eigen::VectorXd acc;
+  if(backend_ == Backend::Tasks)
+  {
+    if(solver.robot().compensationTorquesAcc()) { acc = solver.robot().compensationTorquesAcc().value(); }
+    else
+    {
+      acc = solver.robot().externalTorquesAcc();
+    }
+    disturbance = gamma_.asDiagonal() * acc;
+  }
+  else
+  {
+    disturbance.setZero();
+  }
+
+  // mc_rtc::log::info("Ref accel from disturbance : {}", disturbance.transpose());
+  // mc_rtc::log::info("Ref accel : {}", refAccel_.transpose());
+  Eigen::VectorXd disturbedAccel = refAccel_ + disturbance;
+  PostureTask::refAccel(disturbedAccel);
+  PostureTask::update(solver);
+}
+
+void CompliantPostureTask::makeCompliant(bool compliance)
+{
+  if(compliance) { gamma_.setOnes(); }
+  else
+  {
+    gamma_.setZero();
+  }
+}
+
+void CompliantPostureTask::makeCompliant(Eigen::VectorXd gamma)
+{
+  gamma_ = gamma;
+}
+
+bool CompliantPostureTask::isCompliant(void)
+{
+  return gamma_.norm() > 0;
+}
+
+void CompliantPostureTask::addToGUI(mc_rtc::gui::StateBuilder & gui)
+{
+  PostureTask::addToGUI(gui);
+  gui.addElement(
+      {"Tasks", name_, "Compliance"},
+      mc_rtc::gui::Checkbox(
+          "Compliance is active", [this]() { return isCompliant(); }, [this]() { makeCompliant(!isCompliant()); }),
+      mc_rtc::gui::ArrayInput("Gamma", {"Joint_1", "Joint_2", "Joint_3", "Joint_4", "Joint_5", "Joint_6", "Joint_7"},
+                              gamma_));
+}
+
+} // namespace mc_tasks

--- a/src/mc_tasks/CompliantPostureTask.cpp
+++ b/src/mc_tasks/CompliantPostureTask.cpp
@@ -63,7 +63,7 @@ void CompliantPostureTask::update(mc_solver::QPSolver & solver)
   // mc_rtc::log::info("Ref accel : {}", refAccel_.transpose());
   Eigen::VectorXd disturbedAccel = refAccel_ + disturbance;
   PostureTask::refAccel(disturbedAccel);
-  PostureTask::update(solver);
+  // PostureTask::update(solver);
 }
 
 void CompliantPostureTask::makeCompliant(bool compliance)

--- a/src/mc_tvm/DynamicFunction.cpp
+++ b/src/mc_tvm/DynamicFunction.cpp
@@ -10,8 +10,9 @@
 namespace mc_tvm
 {
 
-DynamicFunction::DynamicFunction(const mc_rbdyn::Robot & robot)
-: tvm::function::abstract::LinearFunction(robot.mb().nrDof()), robot_(robot)
+DynamicFunction::DynamicFunction(const mc_rbdyn::Robot & robot, bool compensateExternalForces)
+: tvm::function::abstract::LinearFunction(robot.mb().nrDof()), robot_(robot),
+  compensateExternalForces_(compensateExternalForces)
 {
   registerUpdates(Update::B, &DynamicFunction::updateb);
   registerUpdates(Update::Jacobian, &DynamicFunction::updateJacobian);
@@ -20,6 +21,10 @@ DynamicFunction::DynamicFunction(const mc_rbdyn::Robot & robot)
   auto & tvm_robot = robot.tvmRobot();
   addInputDependency<DynamicFunction>(Update::Jacobian, tvm_robot, Robot::Output::H);
   addInputDependency<DynamicFunction>(Update::B, tvm_robot, Robot::Output::C);
+  if(compensateExternalForces_)
+  {
+    addInputDependency<DynamicFunction>(Update::B, tvm_robot, Robot::Output::ExternalForces);
+  }
   addVariable(tvm::dot(tvm_robot.q(), 2), true);
   addVariable(tvm_robot.tau(), true);
   jacobian_[tvm_robot.tau().get()] = -Eigen::MatrixXd::Identity(robot_.mb().nrDof(), robot_.mb().nrDof());
@@ -103,6 +108,14 @@ sva::ForceVecd DynamicFunction::contactForce(const mc_rbdyn::RobotFrame & frame)
 void DynamicFunction::updateb()
 {
   b_ = robot_.tvmRobot().C();
+  if(compensateExternalForces_)
+  {
+    if(robot_.tvmRobot().tauCompensation()) { b_ -= robot_.tvmRobot().tauCompensation().value(); }
+    else
+    {
+      b_ -= robot_.tvmRobot().tauExternal();
+    }
+  }
 }
 
 void DynamicFunction::updateJacobian()

--- a/src/mc_tvm/Robot.cpp
+++ b/src/mc_tvm/Robot.cpp
@@ -136,6 +136,8 @@ Robot::Robot(NewRobotToken, const mc_rbdyn::Robot & robot)
   dq_->setZero();
   ddq_->setZero();
   tau_->setZero();
+  tau_ext_ = Eigen::VectorXd::Zero(robot.mb().nrDof());
+  ddq_ext_ = Eigen::VectorXd::Zero(robot.mb().nrDof());
 
   const auto & rjo = robot.refJointOrder();
   refJointIndexToQIndex_.resize(rjo.size());
@@ -159,7 +161,7 @@ Robot::Robot(NewRobotToken, const mc_rbdyn::Robot & robot)
   /** Signal setup */
   registerUpdates(Update::FK, &Robot::updateFK, Update::FV, &Robot::updateFV, Update::FA, &Robot::updateFA,
                   Update::NormalAcceleration, &Robot::updateNormalAcceleration, Update::H, &Robot::updateH, Update::C,
-                  &Robot::updateC);
+                  &Robot::updateC, Update::ExternalForces, &Robot::updateExternalForces);
   /** Output dependencies setup */
   addOutputDependency(Output::FK, Update::FK);
   addOutputDependency(Output::FV, Update::FV);
@@ -168,12 +170,15 @@ Robot::Robot(NewRobotToken, const mc_rbdyn::Robot & robot)
   addOutputDependency(Output::H, Update::H);
   addOutputDependency(Output::C, Update::C);
   addOutputDependency(Output::FV, Update::FV);
+  addOutputDependency(Output::ExternalForces, Update::ExternalForces);
   /** Internal dependencies setup */
   addInternalDependency(Update::FV, Update::FK);
   addInternalDependency(Update::H, Update::FV);
   addInternalDependency(Update::C, Update::FV);
   addInternalDependency(Update::FA, Update::FV);
   addInternalDependency(Update::NormalAcceleration, Update::FV);
+  addInternalDependency(Update::ExternalForces, Update::H);
+  addInternalDependency(Update::ExternalForces, Update::FA);
 }
 
 void Robot::updateFK()
@@ -236,6 +241,19 @@ tvm::VariablePtr Robot::qJoint(size_t jIdx)
   const auto & j = mb.joints()[jIdx];
   return q_->subvariable(tvm::Space(j.dof(), j.params(), j.dof()), j.name(),
                          tvm::Space(offsetDof, offsetParam, offsetDof));
+}
+
+void Robot::updateExternalForces()
+{
+  tau_ext_ = robot_.externalTorques();
+  tau_comp_ = robot_.compensationTorques();
+  auto H_inv = H().ldlt();
+  ddq_ext_ = H_inv.solve(tau_ext_);
+  if(tau_comp_)
+  {
+    if(ddq_comp_->size() != tau_comp_->size()) { ddq_comp_->resize(tau_comp_->size()); }
+    ddq_comp_ = H_inv.solve(tau_comp_.value());
+  }
 }
 
 } // namespace mc_tvm


### PR DESCRIPTION
This PR introduces Control Barrier Function (CBF) constraints for collision avoidance and joint position/velocity limits, targeting closed-loop torque-controlled robots.

The standard velocity damper formulation can become fragile in closed-loop settings, where sensor noise and feedback effects may lead to constraint violations.
This PR reformulates these constraints using a CBF-based approach, improving robustness and safety during execution.

This includes:
* CBF-based formulation of:
  * collision constraints
  * joint position constraints
  * joint velocity constraints
* Additional logging for collision constraints

The implementation follows the approach described in:
[Safe Execution of RL Policies via Acceleration-based CBF-QP Constraint Enforcement for Real-World Robotic Deployments](https://hal.science/hal-05362571)

The CBF formulation is only supported by the TVM backend and requires the following PR to be merged first:
[Add closed-loop velocity damper#59](https://github.com/jrl-umi3218/mc_rtc/pull/502)

This PR builds upon and extends the work from #500, #501, and #502.