### PR TITLE
Fix schema path preventing task creation from GUI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -339,7 +339,7 @@ mc_rtc_set_prefix(CONTROLLER mc_controller)
 
 set(MC_RTC_BINDIR "${CMAKE_INSTALL_FULL_BINDIR}")
 set(MC_RTC_LIBDIR "${CMAKE_INSTALL_FULL_LIBDIR}")
-set(MC_RTC_JSON_SCHEMA_PATH "${CMAKE_INSTALL_DOCDIR}/json/schemas")
+set(MC_RTC_JSON_SCHEMA_PATH "${CMAKE_INSTALL_FULL_DOCDIR}/json/schemas")
 
 find_package(mc_rtc_3rd_party_ros QUIET)
 if(TARGET mc_rtc_3rd_party::ROS)

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -21,7 +21,7 @@ install(FILES _plugins/include_raw.rb _plugins/link.rb _plugins/pretty_json.rb
 )
 
 install(
-  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/_data/schemas
+  DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/_data/schemas/
   DESTINATION ${MC_RTC_JSON_SCHEMA_PATH}
   FILES_MATCHING
   PATTERN "*.json"


### PR DESCRIPTION
Hello @arntanguy,

Here is a fix because the schema could no longer be read correctly after the recent changes. As a result, users were no longer able to add tasks from the GUI.

I couldn’t check it with Nix due to an incomplete clone. Could you confirm that it still works when using the Nix packages?