### PR TITLE
Typo in new controller script recommended vscode extensions

### DIFF
--- a/utils/mc_rtc_new_controller.in.py
+++ b/utils/mc_rtc_new_controller.in.py
@@ -254,7 +254,8 @@ void {controller_class_name}::reset(const mc_control::ControllerResetData & rese
     # VSCode extension recommendations
     vscode_extensions = {
         "recommendations": [
-            "redhat.vscode-yaml" "twxs.cmake",
+            "redhat.vscode-yaml",
+            "twxs.cmake",
             "ms-vscode.cmake-tools",
             "josetr.cmake-language-support-vscode",
             "ms-vscode.cpptools",

--- a/utils/mc_rtc_new_fsm_controller.in.py
+++ b/utils/mc_rtc_new_fsm_controller.in.py
@@ -241,7 +241,8 @@ EXPORT_SINGLE_STATE("{controller_name}_Initial", {controller_name}_Initial)
     # VSCode extension recommendations
     vscode_extensions = {
         "recommendations": [
-            "redhat.vscode-yaml" "twxs.cmake",
+            "redhat.vscode-yaml",
+            "twxs.cmake",
             "ms-vscode.cmake-tools",
             "josetr.cmake-language-support-vscode",
             "ms-vscode.cpptools",


### PR DESCRIPTION
This fixes a forgotten comma in the recommended vscode extensions list generated by `mc_rtc_new_controller` and `mc_rtc_new_fsm_controller` scripts.