### PR TITLE
compatibility with Ubuntu Resolue and ROS Lyrical

### DIFF
--- a/binding/python/mc_control/fsm/fsm.pyx
+++ b/binding/python/mc_control/fsm/fsm.pyx
@@ -12,6 +12,7 @@ cimport mc_rtc.mc_rtc as mc_rtc
 cimport mc_rbdyn.c_mc_rbdyn as c_mc_rbdyn
 cimport mc_rbdyn.mc_rbdyn as mc_rbdyn
 cimport mc_solver.mc_solver as mc_solver
+cimport mc_control.c_mc_control as c_mc_control
 
 from mc_control.mc_control cimport MCController
 cimport mc_control.mc_control as mc_control
@@ -29,7 +30,8 @@ cdef class Controller(MCController):
   def __cinit__(self):
     self.impl = self.base = NULL
   def contactConstraint(self):
-    return mc_solver.ContactConstraintFromPtr(&(self.impl.contactConstraint()))
+    return mc_solver.ContactConstraintFromPtr((<c_mc_control.MCController*>self.impl).contactConstraint.get())
+
 
 cdef Controller ControllerFromPtr(c_fsm.Controller * ctl):
   cdef Controller ret = Controller()

--- a/binding/python/mc_rtc/gui/c_gui.pxd
+++ b/binding/python/mc_rtc/gui/c_gui.pxd
@@ -75,7 +75,7 @@ cdef extern from "<mc_rtc/gui.h>" namespace "mc_rtc::gui":
   cdef LabelImpl[T] Label[T](const string&, T)
 
   cdef ArrayLabelImpl[T] ArrayLabel[T](const string&, T)
-  cdef ArrayLabelImpl[T] ArrayLabel[T](const string&, const vector[string]&, T)
+  cdef ArrayLabelImpl[T] ArrayLabelWithLabels "mc_rtc::gui::ArrayLabel" [T](const string&, const vector[string]&, T)
 
   cdef ButtonImpl[T] Button[T](const string&, T)
 
@@ -90,7 +90,7 @@ cdef extern from "<mc_rtc/gui.h>" namespace "mc_rtc::gui":
   cdef NumberSliderImpl[GetT, SetT] NumberSlider[GetT, SetT](const string&, GetT, SetT, double, double)
 
   cdef ArrayInputImpl[GetT, SetT] ArrayInput[GetT, SetT](const string&, GetT, SetT)
-  cdef ArrayInputImpl[GetT, SetT] ArrayInput[GetT, SetT](const string&, const vector[string]&, GetT, SetT)
+  cdef ArrayInputImpl[GetT, SetT] ArrayInputWithLabels "mc_rtc::gui::ArrayInput" [GetT, SetT](const string&, const vector[string]&, GetT, SetT)
 
   cdef ComboInputImpl[GetT, SetT] ComboInput[GetT, SetT](const string&, const vector[string]&, GetT, SetT)
 

--- a/binding/python/mc_rtc/gui/gui.pyx
+++ b/binding/python/mc_rtc/gui/gui.pyx
@@ -56,7 +56,7 @@ cdef class ArrayLabel(Element):
     if isinstance(name, unicode):
       name = name.encode(u'ascii')
     self._get_fn = get_fn
-    self.impl = c_gui.ArrayLabel[c_gui.get_fn](name, py2cpp(labels), c_gui.make_getter(python_to_conf, get_fn))
+    self.impl = c_gui.ArrayLabelWithLabels[c_gui.get_fn](name, py2cpp(labels), c_gui.make_getter(python_to_conf, get_fn))
     self.base = &self.impl
 
 cdef class Button(Element):
@@ -140,7 +140,7 @@ cdef class ArrayInput(Element):
     self._get_fn = get_fn
     self._set_fn = set_fn
     self._cb_ret_type = [float]
-    self.impl = c_gui.ArrayInput[c_gui.get_fn, c_gui.set_fn](name, py2cpp(labels), c_gui.make_getter(python_to_conf, get_fn), c_gui.make_setter(conf_to_python_list, set_fn, self._cb_ret_type))
+    self.impl = c_gui.ArrayInputWithLabels[c_gui.get_fn, c_gui.set_fn](name, py2cpp(labels), c_gui.make_getter(python_to_conf, get_fn), c_gui.make_setter(conf_to_python_list, set_fn, self._cb_ret_type))
     self.base = &self.impl
 
 cdef class ComboInput(Element):

--- a/binding/python/mc_rtc/mc_rtc.pyx
+++ b/binding/python/mc_rtc/mc_rtc.pyx
@@ -171,23 +171,23 @@ cdef class Configuration(object):
       return self
     if t is bool:
       if default is not None:
-        return c_mc_rtc.get_config_as[cppbool](deref(self.impl), default)
+        return c_mc_rtc.get_config_as[cppbool](deref(self.impl), <cppbool>default)
       else:
         return c_mc_rtc.get_config_as[cppbool](deref(self.impl))
     if isinstance(t(), numbers.Integral):
       if default is not None:
-        return c_mc_rtc.get_config_as[int](deref(self.impl), default)
+        return c_mc_rtc.get_config_as[int](deref(self.impl), <int>default)
       else:
         return c_mc_rtc.get_config_as[int](deref(self.impl))
     if isinstance(t(), numbers.Number):
       if default is not None:
-        return c_mc_rtc.get_config_as[double](deref(self.impl), default)
+        return c_mc_rtc.get_config_as[double](deref(self.impl), <double>default)
       else:
         return c_mc_rtc.get_config_as[double](deref(self.impl))
     if t is str or t is unicode:
       if default is not None:
         default = default.encode(u'ascii')
-        return c_mc_rtc.get_config_as[string](deref(self.impl), default).decode(u'ascii')
+        return c_mc_rtc.get_config_as[string](deref(self.impl), <string>default).decode(u'ascii')
       else:
         return c_mc_rtc.get_config_as[string](deref(self.impl)).decode(u'ascii')
     if t is eigen.Vector2d:

--- a/include/mc_rtc/logging.h
+++ b/include/mc_rtc/logging.h
@@ -36,50 +36,79 @@ MC_RTC_UTILS_DLLAPI void disable_notifications();
 
 } // namespace details
 
-template<typename ExceptionT = std::runtime_error, typename... Args>
-void error_and_throw [[noreturn]] (Args &&... args)
+template<typename ExceptionT = std::runtime_error, typename S, typename... Args>
+void error_and_throw [[noreturn]] (const S & format, Args &&... args)
 {
-  auto message = fmt::format(std::forward<Args>(args)...);
+  std::string message;
+  if constexpr(sizeof...(Args) == 0) { message = fmt::format("{}", format); }
+  else
+  {
+    message = fmt::format(fmt::runtime(format), std::forward<Args>(args)...);
+  }
   details::notify(message);
   details::cerr().critical(message);
   details::cerr().critical("=== Backtrace ===\n{}", MC_FMT_STREAMED(boost::stacktrace::stacktrace()));
   throw ExceptionT(message);
 }
 
-template<typename... Args>
-void critical(Args &&... args)
+template<typename S, typename... Args>
+void critical(const S & format, Args &&... args)
 {
-  details::cerr().critical(std::forward<Args>(args)...);
+  if constexpr(sizeof...(Args) == 0) { details::cerr().critical(format); }
+  else
+  {
+    details::cerr().critical(fmt::runtime(format), std::forward<Args>(args)...);
+  }
 }
 
-template<typename... Args>
-void error(Args &&... args)
+template<typename S, typename... Args>
+void error(const S & format, Args &&... args)
 {
-  details::cerr().error(std::forward<Args>(args)...);
+  if constexpr(sizeof...(Args) == 0) { details::cerr().error(format); }
+  else
+  {
+    details::cerr().error(fmt::runtime(format), std::forward<Args>(args)...);
+  }
 }
 
-template<typename... Args>
-void warning(Args &&... args)
+template<typename S, typename... Args>
+void warning(const S & format, Args &&... args)
 {
-  details::cerr().warn(std::forward<Args>(args)...);
+  if constexpr(sizeof...(Args) == 0) { details::cerr().warn(format); }
+  else
+  {
+    details::cerr().warn(fmt::runtime(format), std::forward<Args>(args)...);
+  }
 }
 
-template<typename... Args>
-void info(Args &&... args)
+template<typename S, typename... Args>
+void info(const S & format, Args &&... args)
 {
-  details::info().info(std::forward<Args>(args)...);
+  if constexpr(sizeof...(Args) == 0) { details::info().info(format); }
+  else
+  {
+    details::info().info(fmt::runtime(format), std::forward<Args>(args)...);
+  }
 }
 
-template<typename... Args>
-void success(Args &&... args)
+template<typename S, typename... Args>
+void success(const S & format, Args &&... args)
 {
-  details::success().info(std::forward<Args>(args)...);
+  if constexpr(sizeof...(Args) == 0) { details::success().info(format); }
+  else
+  {
+    details::success().info(fmt::runtime(format), std::forward<Args>(args)...);
+  }
 }
 
-template<typename... Args>
-void notify(Args &&... args)
+template<typename S, typename... Args>
+void notify(const S & format, Args &&... args)
 {
-  details::notify(fmt::format(std::forward<Args>(args)...));
+  if constexpr(sizeof...(Args) == 0) { details::notify(fmt::format("{}", format)); }
+  else
+  {
+    details::notify(fmt::format(fmt::runtime(format), std::forward<Args>(args)...));
+  }
 }
 
 } // namespace log

--- a/src/mc_control/ControllerClient.cpp
+++ b/src/mc_control/ControllerClient.cpp
@@ -1055,7 +1055,7 @@ void ControllerClient::handle_table(const ElementId & id,
     {
       try
       {
-        return fmt::format(f, entry.at(i, entry[i].dump()));
+        return fmt::format(fmt::runtime(f), entry.at(i, entry[i].dump()));
       }
       catch(const fmt::format_error & error)
       {
@@ -1067,14 +1067,14 @@ void ControllerClient::handle_table(const ElementId & id,
     {
       try
       {
-        return fmt::format(f, static_cast<double>(entry[i]));
+        return fmt::format(fmt::runtime(f), static_cast<double>(entry[i]));
       }
       catch(mc_rtc::Configuration::Exception & exc)
       {
         exc.silence();
         try
         {
-          return fmt::format(f, entry[i].dump());
+          return fmt::format(fmt::runtime(f), entry[i].dump());
         }
         catch(const fmt::format_error & error)
         {


### PR DESCRIPTION
- fix: since fmt 8.0.0 format string must be wrapped with fmt::runtime while compiling with c++20; this was not a issue before but, from what I understand, Lyrical [forces c++20](https://github.com/ros2/ament_cmake_ros/blob/lyrical/ament_cmake_ros_core/cmake/ament_ros_defaults.cmake)
- Resolute ships with newer Cython that throws compilation errors when building python bindings