### PR TITLE
Handle collision convexes for multiple convexes per body

### DIFF
--- a/src/mc_rbdyn/RobotModule.cpp
+++ b/src/mc_rbdyn/RobotModule.cpp
@@ -181,7 +181,7 @@ void RobotModule::bind_convexes()
           continue;
         }
 
-        _convexHull[b.name() + "_" + std::to_string(added)] = {b.name() + "_" + std::to_string(added), convex_path};
+        _convexHull[b.name() + "_" + std::to_string(added)] = {b.name(), convex_path};
         added++;
       }
     }


### PR DESCRIPTION
This fixes the case where multiple collision convexes are present in the same URDF link: 
`RobotModule::bind_convexes()` emplaced the `RobotModule::_convexHull` map correctly using "_0" and so on, but the first element of the emplaced pair is used by [loadSCH](https://github.com/jrl-umi3218/mc_rtc/blob/ab96dff9e95fc315bb2e3de9760bc81ae5e7fec7/src/mc_rbdyn/Robot.cpp#L157) to check the parent body name so it should keep the same name without the added number.

However this shows another problem introduced by https://github.com/jrl-umi3218/mc_rtc/pull/480 : in case there are multiple convexes per link, each body collision must be built between the convexes individually, using their names "bodyName + _ + number".

Either we consider that this is by design, or there needs to be a way to handle all convexes associated to the body.
Changing `RobotModule::_convexHull` and other associated collision elements to maps of vectors would be very involved.
Maybe the convexes could be fused together in `RobotModule::generate_convexes()` to keep a single collision convex for each body?