### PR TITLE
ci: package for noble and resolute (as-is)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,7 +39,7 @@ jobs:
       latest-cmake: true
       matrix: |
           {
-            "dist": ["jammy"],
+            "dist": ["jammy", "noble", "resolute"],
             "arch": ["amd64"]
           }
     secrets:

--- a/debian/rules
+++ b/debian/rules
@@ -27,7 +27,7 @@ TMP = $(CURDIR)/debian/tmp
 	dh $@ --no-parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DPYTHON_DEB_ROOT=$(TMP) -DMC_LOG_UI_PYTHON_EXECUTABLE=${MC_LOG_UI_PYTHON_EXECUTABLE}
+	dh_auto_configure -- -DPYTHON_DEB_ROOT=$(TMP) -DMC_LOG_UI_PYTHON_EXECUTABLE=${MC_LOG_UI_PYTHON_EXECUTABLE} -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
 
 override_dh_auto_install:
 	dh_auto_install


### PR DESCRIPTION
This generates mc-rtc packages for resolute as-is.
Technically this is wrong, as it has path.cpp now depends on
ament_cmake, so we need a separate ros/non-ros package.
See #543 for a follow-up
