### PR TITLE
Correctly apply collision transforms in case of multiple convexes

### DIFF
--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -390,7 +390,16 @@ Robot::Robot(NewRobotToken,
     for(const auto & b : mb().bodies()) { collisionTransforms_[b.name()] = sva::PTransformd::Identity(); }
     for(const auto & [body, visuals] : module_._visual)
     {
-      if(visuals.size() && hasBody(body)) { collisionTransforms_[body] = visuals[0].origin; }
+      if(visuals.size() == 1 && hasBody(body)) { collisionTransforms_[body] = visuals[0].origin; }
+      else if(visuals.size() > 1 && hasBody(body))
+      {
+        size_t added = 0;
+        for(const auto & visual : visuals)
+        {
+          collisionTransforms_[body + "_" + std::to_string(added)] = visual.origin;
+          added++;
+        }
+      }
     }
     for(const auto & p : module_.collisionTransforms()) { collisionTransforms_[p.first] = p.second; }
     fixCollisionTransforms();


### PR DESCRIPTION
This fixes the edge case where there are several collision meshes per body and have an offset from the body origin: the collision transform was not properly applied.

There are other possible places on where to handle this, for example in [VisualToConvex](https://github.com/Hugo-L3174/mc_rtc/blob/c0e98c6e82a2d153e91216d87f1a80f8154968a7/src/mc_rbdyn/Robot.cpp#L189) where not returning in case of a pre existing mesh would also correctly apply the transform in the collisionTransforms map.

I am also worried that the current way of loading the convexes loads the transforms from the visual element, which means it might be wrong in case of a different offset in the urdf between visual and collision (highly unlikely but still).