### PR TITLE
MacOs support

### DIFF
--- a/include/mc_rtc/log/utils.h
+++ b/include/mc_rtc/log/utils.h
@@ -169,10 +169,18 @@ struct callback_is_serializable
   static constexpr bool value = false;
 };
 
+// template<typename T>
+// struct callback_is_serializable<T, std::void_t<std::invoke_result_t<T()>>>
+// {
+//   using ret_type = std::invoke_result_t<T()>;
+//   using base_type = std::decay_t<ret_type>;
+//   static constexpr LogType log_type = is_serializable<base_type>::type;
+//   static constexpr bool value = is_serializable<base_type>::value;
+// };
 template<typename T>
-struct callback_is_serializable<T, void_t<typename std::result_of<T()>::type>>
+struct callback_is_serializable<T, std::void_t<decltype(std::declval<T>()())>>
 {
-  using ret_type = typename std::result_of<T()>::type;
+  using ret_type = decltype(std::declval<T>()());
   using base_type = typename std::decay<ret_type>::type;
   static constexpr LogType log_type = is_serializable<base_type>::type;
   static constexpr bool value = is_serializable<base_type>::value;


### PR DESCRIPTION
Fixes for building on MacOS. In particular supports building in C++20 (but default build remains C++17 for now).
