### PR TITLE
python: drop python2/user/system install, use venv

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,17 +47,19 @@ else()
     include(FetchContent)
     FetchContent_Declare(
       "jrl-cmakemodules"
-      GIT_REPOSITORY "https://github.com/jrl-umi3218/jrl-cmakemodules.git"
+      GIT_REPOSITORY "https://github.com/arntanguy/jrl-cmakemodules.git"
+      GIT_TAG 98c3f2676abcd84775863f27a8eabcd864115b49
     )
     FetchContent_MakeAvailable("jrl-cmakemodules")
     FetchContent_GetProperties("jrl-cmakemodules" SOURCE_DIR JRL_CMAKE_MODULES)
   endif()
 endif()
-
 include(${JRL_CMAKE_MODULES}/base.cmake)
-include(${JRL_CMAKE_MODULES}/cython/cython.cmake)
 include(${JRL_CMAKE_MODULES}/msvc-specific.cmake)
 include(${JRL_CMAKE_MODULES}/version-script.cmake)
+if(${PYTHON_BINDING})
+  include(${JRL_CMAKE_MODULES}/cython/cython.cmake)
+endif()
 
 set_property(GLOBAL PROPERTY USE_FOLDERS ON)
 


### PR DESCRIPTION
Same patch as RBDyn, Tasks and SpaceVecAlg
