### PR TITLE
feat: include specific frames, links, and transformation for connect()

### DIFF
--- a/doc/_data/schemas/mc_rbdyn/RobotModule.json
+++ b/doc/_data/schemas/mc_rbdyn/RobotModule.json
@@ -156,6 +156,23 @@
         "$ref": "../mc_rbdyn/RobotModule.FrameDescription.json"
       }
     },
+    "baseFrame": {
+      "type": "string"
+    },
+    "mountFrame": {
+      "type": "string"
+    },
+    "collisionLinks": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "List of links that should be considered for collision checking"
+    },
+    "defaultMountingTransform": {
+      "$ref": "../SpaceVecAlg/PTransformd.json",
+      "description": "Default transform to apply to the robot when mounted on a another robot"
+    },
     "flexibilities":
     {
       "type": "array",

--- a/include/mc_rbdyn/RobotModule.h
+++ b/include/mc_rbdyn/RobotModule.h
@@ -772,6 +772,18 @@ struct MC_RBDYN_DLLAPI RobotModule
   /** Returns a list of robot frames supported by this module */
   inline const std::vector<FrameDescription> & frames() const noexcept { return _frames; }
 
+  /** Return base frame of this module to be connected to the parent robot */
+  inline const std::string & baseFrame() const noexcept { return _baseFrame; }
+
+  /** Return mounting frame of this module used for further downstream attachments */
+  inline const std::string & mountFrame() const noexcept { return _mountFrame; }
+
+  /** Return list of links to add to collision pairs */
+  inline const std::vector<std::string> & collisionLinks() const noexcept { return _collisionLinks; }
+
+  /** Return default mounting transform when attached to a parent robot */
+  inline const sva::PTransformd & defaultMountingTransform() const noexcept { return _defaultMountingTransform; }
+
 public:
   /** Path to the robot's description package */
   std::string path;
@@ -849,6 +861,14 @@ public:
   DevicePtrVector _devices;
   /** \see frames() */
   std::vector<FrameDescription> _frames;
+  /** \see baseFrame() */
+  std::string _baseFrame{};
+  /** \see mountFrame() */
+  std::string _mountFrame{};
+  /** \see collisionLinks() */
+  std::vector<std::string> _collisionLinks{};
+  /** \see defaultMountingTransform() */
+  sva::PTransformd _defaultMountingTransform{sva::PTransformd::Identity()};
 };
 
 typedef std::shared_ptr<RobotModule> RobotModulePtr;

--- a/src/mc_rbdyn/configuration_io.cpp
+++ b/src/mc_rbdyn/configuration_io.cpp
@@ -1126,6 +1126,14 @@ mc_rbdyn::RobotModule ConfigurationLoader<mc_rbdyn::RobotModule>::load(const mc_
 
   rm._frames = config("frames", std::vector<mc_rbdyn::RobotModule::FrameDescription>{});
 
+  rm._baseFrame = config("baseFrame", std::string{});
+
+  rm._mountFrame = config("mountFrame", std::string{});
+
+  rm._collisionLinks = config("collisionLinks", std::vector<std::string>{});
+
+  rm._defaultMountingTransform = config("defaultMountingTransform", sva::PTransformd::Identity());
+
   rm._compoundJoints = config("compoundJoints", mc_rbdyn::CompoundJointConstraintDescriptionVector{});
 
   return rm;
@@ -1156,6 +1164,10 @@ mc_rtc::Configuration ConfigurationLoader<mc_rbdyn::RobotModule>::save(const mc_
     config.add("fixed", fixed);
   }
   config.add("frames", rm._frames);
+  config.add("baseFrame", rm._baseFrame);
+  config.add("mountFrame", rm._mountFrame);
+  config.add("collisionLinks", rm._collisionLinks);
+  config.add("defaultMountingTransform", rm._defaultMountingTransform);
   if(rm._bounds.size() != 6)
   {
     mc_rtc::log::error_and_throw("Wrong number ({}) of _bounds entries in RobotModule", rm._bounds.size());


### PR DESCRIPTION
Hello, 

Here I am trying to address a part of https://github.com/isri-aist/mc_robot_tools/issues/3.

In https://github.com/isri-aist/mc_robot_tools, `ConnectableRobotModule` is introduce as a `RobotModule` wrapper to exposed some specifics frames and links that would be useful when multiple `RobotModule` are combine together with `RobotModule::connect()`. After some discussion, `ConnectableRobotModule` are suggested to merge with `RobotModule`.

Currently the changes made here are demonstrated in https://github.com/isri-aist/mc_robot_tools/pull/9 and https://github.com/isri-aist/mc_kinova/pull/4.

Please let me know if there is other functions that might be useful. 