### PR TITLE
debian: fully split ros/non-ros packages + noble

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -39,7 +39,7 @@ jobs:
       latest-cmake: true
       matrix: |
           {
-            "dist": ["jammy"],
+            "dist": ["jammy", "noble"],
             "arch": ["amd64"]
           }
     secrets:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,15 @@ else()
   endif()
 endif()
 
+# Force override jrl-cmakemodule default
+set(PYTHON_BINDING_FORCE_PYTHON3
+    ON
+    CACHE BOOL "Force use of Python 3 for bindings" FORCE
+)
+set(PYTHON_BINDING_BUILD_PYTHON2_AND_PYTHON3
+    OFF
+    CACHE BOOL "Force use of Python 3 for bindings" FORCE
+)
 include(${JRL_CMAKE_MODULES}/base.cmake)
 include(${JRL_CMAKE_MODULES}/cython/cython.cmake)
 include(${JRL_CMAKE_MODULES}/msvc-specific.cmake)

--- a/CMakeModules/Findmc_rtc_3rd_party_ros.cmake
+++ b/CMakeModules/Findmc_rtc_3rd_party_ros.cmake
@@ -36,9 +36,9 @@ if(NOT TARGET mc_rtc_3rd_party::ROS)
       OFF
       CACHE BOOL "" FORCE
   )
+  # sets rclcpp_FOUND and rclcpp::rclcpp target if found
   find_package(rclcpp QUIET)
   if(NOT TARGET rclcpp::rclcpp)
-    set(ROSCPP_FOUND False)
     return()
   endif()
   add_library(mc_rtc_3rd_party::ROS INTERFACE IMPORTED)
@@ -51,5 +51,6 @@ if(NOT TARGET mc_rtc_3rd_party::ROS)
   target_compile_definitions(
     mc_rtc_3rd_party::ROS INTERFACE MC_RTC_HAS_ROS_SUPPORT MC_RTC_ROS_IS_ROS2
   )
+  # Legacy, we should use rclcpp_FOUND instead
   set(ROSCPP_FOUND True)
 endif()

--- a/debian/control
+++ b/debian/control
@@ -1,6 +1,6 @@
 Source: mc-rtc
 Priority: optional
-Maintainer: Pierre Gergondet <pierre.gergondet+ppa@gmail.com>
+Maintainer: Arnaud Tanguy <arn.tanguy+ppa@gmail.com>
 Standards-Version: 3.9.5
 Section: libs
 Homepage: https://github.com/jrl-umi3218/mc_rtc
@@ -8,6 +8,7 @@ Vcs-Git: https://github.com/jrl-umi3218/mc_rtc
 Vcs-Browser: https://github.com/jrl-umi3218/mc_rtc
 Build-Depends: debhelper (>= 9),
                cmake,
+               ninja-build,
                doxygen,
                graphviz,
                libboost-filesystem-dev,
@@ -21,7 +22,7 @@ Build-Depends: debhelper (>= 9),
                libtasks-qld-dev|libtasks-dev,
                libtvm-dev,
                libmesh-sampling-dev,
-               libmc-rtc-ros-compat-dev,
+               libmc-rtc-ros-compat-dev | ros-@ROS_DISTRO@-mc-rtc-ros-compat,
                libeigen-quadprog-dev,
                libstate-observation-dev,
                libgeos++-inline-dev|libgeos++-dev,
@@ -37,13 +38,14 @@ Build-Depends: debhelper (>= 9),
                libyaml-cpp-dev,
                libspdlog-dev,
                libnotify-dev,
-# ros-@ROS_DISTRO@-ros-base,
-# ros-@ROS_DISTRO@-roscpp | ros-@ROS_DISTRO@-rclcpp,
-# ros-@ROS_DISTRO@-sensor-msgs,
-# ros-@ROS_DISTRO@-common-msgs | ros-@ROS_DISTRO@-common-interfaces,
-# ros-@ROS_DISTRO@-tf2-ros,
-# ros-@ROS_DISTRO@-rosbag | ros-@ROS_DISTRO@-rosbag2,
-# ros-@ROS_DISTRO@-mc-rtc-msgs,
+                ros-@ROS_DISTRO@-ros-base,
+                ros-@ROS_DISTRO@-rclcpp,
+                ros-@ROS_DISTRO@-sensor-msgs,
+                ros-@ROS_DISTRO@-common-interfaces,
+                ros-@ROS_DISTRO@-tf2-ros,
+                ros-@ROS_DISTRO@-rosbag2,
+                ros-@ROS_DISTRO@-mc-rtc-msgs,
+                ros-@ROS_DISTRO@-ament-package,
                libltdl-dev
 
 Package: libmc-rtc-dev
@@ -58,7 +60,7 @@ Depends: cmake,
          libtasks-qld-dev|libtasks-dev,
          libtvm-dev,
          libmesh-sampling-dev,
-         libmc-rtc-ros-compat-dev,
+         libmc-rtc-ros-compat-dev | ros-@ROS_DISTRO@-mc-rtc-ros-compat,
          libeigen-quadprog-dev,
          libstate-observation-dev,
          libgeos++-dev,
@@ -84,7 +86,8 @@ Package: libmc-rtc
 Section: libs
 Architecture: any
 Replaces: libmc-rtc1
-Depends: ${shlibs:Depends},
+Depends: libmc-rtc-ros-compat | ros-@ROS_DISTRO@-mc-rtc-ros-compat,
+         ${shlibs:Depends},
          ${misc:Depends},
          mc-rtc-data
 Description: mc-rtc - Real-time control of robots

--- a/debian/control
+++ b/debian/control
@@ -26,14 +26,6 @@ Build-Depends: debhelper (>= 9),
                libstate-observation-dev,
                libgeos++-inline-dev|libgeos++-dev,
                mc-rtc-data,
-#PYTHON2                python-is-python3|python,
-#PYTHON2                python-all,
-#PYTHON2                python-dev,
-#PYTHON2                python-enum34,
-#PYTHON2                python-pytest,
-#PYTHON2                python-setuptools,
-#PYTHON2                python-tasks,
-#PYTHON2                cython,
                python3-all,
                python3-dev,
                python3-pytest,
@@ -108,11 +100,10 @@ Package: mc-rtc-utils
 Section: science
 Architecture: any
 Depends: libmc-rtc (= ${binary:Version}),
-         python-git | python3-git,
-#PYTHON2         python-mc-rtc,
+         python3-git,
          python3-mc-rtc,
-         python-matplotlib | python3-matplotlib,
-         python-pyqt5 | python3-pyqt5,
+         python3-matplotlib,
+         python3-pyqt5,
          ${shlibs:Depends},
          ${misc:Depends}
 Description: mc-rtc - Utilities
@@ -136,18 +127,6 @@ Description: mc-rtc - API documentation
  said controllers.
  .
  This package provides the complete API documentation in HTML format.
-
-#PYTHON2 Package: python-mc-rtc
-#PYTHON2 Section: python
-#PYTHON2 Architecture: any
-#PYTHON2 Depends: ${python:Depends}, ${misc:Depends}, ${shlibs:Depends}, python-all, python-tasks
-#PYTHON2 Description: mc_rtc - Python bindings
-#PYTHON2  mc_rtc is an interface for simulated and real robotic systems suitable for
-#PYTHON2  real-time control.  It provides programmers with a simple interface to build
-#PYTHON2  versatile controllers as well as a set of tools to help with the development of
-#PYTHON2  said controllers.
-#PYTHON2  .
-#PYTHON2  Python bindings for the mc_rtc libraries. Compatible with Python 2.
 
 Package: python3-mc-rtc
 Section: python

--- a/debian/control.ros
+++ b/debian/control.ros
@@ -2,11 +2,11 @@
 Package: ros-@ROS_DISTRO@-mc-rtc-plugin
 Section: libs
 Architecture: any
-Depends: libmc-rtc-dev,
-         ros-@ROS_DISTRO@-roscpp | ros-@ROS_DISTRO@-rclcpp,
-         ros-@ROS_DISTRO@-common-msgs | ros-@ROS_DISTRO@-common-interfaces,
+Depends: libmc-rtc,
+         ros-@ROS_DISTRO@-rclcpp,
+         ros-@ROS_DISTRO@-common-interfaces,
          ros-@ROS_DISTRO@-tf2-ros,
-         ros-@ROS_DISTRO@-rosbag | ros-@ROS_DISTRO@-rosbag2,
+         ros-@ROS_DISTRO@-rosbag2,
          ros-@ROS_DISTRO@-mc-rtc-data,
          ros-@ROS_DISTRO@-mc-rtc-msgs,
          ros-@ROS_DISTRO@-mc-rtc-ros-compat,

--- a/debian/control.ros
+++ b/debian/control.ros
@@ -19,3 +19,16 @@ Description: mc_rtc - ROS plugin
  .
  ROS plugin for mc_rtc. It will enable the publication of the robot's state by
  mc_rtc controllers
+
+Package: ros-@ROS_DISTRO@-mc-rtc-utils
+Section: science
+Architecture: any
+Depends: mc-rtc-utils (= ${binary:Version}),
+         ros-@ROS_DISTRO@-mc-rtc-plugin,
+         ${shlibs:Depends},
+         ${misc:Depends}
+Description: mc-rtc - ROS-enabled Utilities (@ROS_DISTRO@)
+ This package provides the ROS-enabled utilities for mc_rtc, built with ROS @ROS_DISTRO@
+ support. It includes executables with ROS integration (e.g., *_ros variants).
+ .
+ These utilities complement the standard mc-rtc-utils with ROS-specific features.

--- a/debian/ros-ROS_DISTRO-mc-rtc-utils.install
+++ b/debian/ros-ROS_DISTRO-mc-rtc-utils.install
@@ -1,0 +1,3 @@
+usr/bin/mc_surfaces_visualization_ros
+usr/bin/mc_convex_visualization_ros
+usr/bin/mc_robot_visualization_ros

--- a/debian/rules
+++ b/debian/rules
@@ -2,19 +2,12 @@
 # -*- makefile -*-
 
 export ROS_DISTRO:=@ROS_DISTRO@
-export ROS_PYTHON_VERSION:=$(shell . /opt/ros/${ROS_DISTRO}/setup.sh && echo $$ROS_PYTHON_VERSION)
-ifeq (${ROS_PYTHON_VERSION}, 3)
-	export PYTHONPATH:=/opt/ros/${ROS_DISTRO}/lib/python3/dist-packages:${PYTHONPATH}
-	export PYTHONPATH:=/opt/ros/${ROS_DISTRO}/lib/python$(shell python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}');")/site-packages:${PYTHONPATH}
-	export PYTHONPATH:=/opt/ros/${ROS_DISTRO}/local/lib/python$(shell python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}');")/dist-packages:${PYTHONPATH}
-	export MC_LOG_UI_PYTHON_EXECUTABLE:=python3
-else
-	export PYTHONPATH:=/opt/ros/${ROS_DISTRO}/lib/python2.7/dist-packages:${PYTHONPATH}
-	export MC_LOG_UI_PYTHON_EXECUTABLE:=python
-endif
-export PKG_CONFIG_PATH:=/opt/ros/${ROS_DISTRO}/lib/pkgconfig:$PKG_CONFIG_PATH
-export ROS_MASTER_URI:=http://localhost:11311
+export PYTHONPATH:=/opt/ros/${ROS_DISTRO}/lib/python3/dist-packages:${PYTHONPATH}
+export PYTHONPATH:=/opt/ros/${ROS_DISTRO}/lib/python$(shell python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}');")/site-packages:${PYTHONPATH}
+export PYTHONPATH:=/opt/ros/${ROS_DISTRO}/local/lib/python$(shell python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}');")/dist-packages:${PYTHONPATH}
+export PKG_CONFIG_PATH:=/opt/ros/${ROS_DISTRO}/lib/pkgconfig:${PKG_CONFIG_PATH}
 export AMENT_PREFIX_PATH:=/opt/ros/${ROS_DISTRO}
+export CMAKE_PREFIX_PATH:=/opt/ros/${ROS_DISTRO}:$(CMAKE_PREFIX_PATH)
 
 TMP = $(CURDIR)/debian/tmp
 

--- a/debian/rules
+++ b/debian/rules
@@ -12,10 +12,14 @@ export CMAKE_PREFIX_PATH:=/opt/ros/${ROS_DISTRO}:$(CMAKE_PREFIX_PATH)
 TMP = $(CURDIR)/debian/tmp
 
 %:
-	dh $@ --no-parallel
+	dh $@ --parallel
 
 override_dh_auto_configure:
-	dh_auto_configure -- -DPYTHON_DEB_ROOT=$(TMP) -DMC_LOG_UI_PYTHON_EXECUTABLE=${MC_LOG_UI_PYTHON_EXECUTABLE} -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
+	if ! command -v ninja >/dev/null 2>&1; then \
+		echo "Ninja is required. Please install it with: sudo apt-get install ninja-build"; \
+		exit 1; \
+	fi
+	dh_auto_configure --buildsystem=cmake+ninja -- -DPYTHON_DEB_ROOT=$(TMP) -DFETCHCONTENT_FULLY_DISCONNECTED=OFF
 
 override_dh_auto_install:
 	dh_auto_install

--- a/debian/shlibs.local
+++ b/debian/shlibs.local
@@ -1,0 +1,1 @@
+libmc_rtc_ros_compat 1

--- a/doc/_i18n/en.yml
+++ b/doc/_i18n/en.yml
@@ -75,7 +75,7 @@ tutorials:
             # Install packages
             sudo apt install libmc-rtc-dev mc-rtc-utils
             # Assuming you have a ROS distribution mirror setup
-            sudo apt install ros-${ROS_DISTRO}-mc-rtc-plugin ros-${ROS_DISTRO}-mc-rtc-tools
+            sudo apt install ros-${ROS_DISTRO}-mc-rtc-plugin ros-${ROS_DISTRO}-mc-rtc-utils
         - name: Install head version
           lang: bash
           source: |
@@ -84,7 +84,7 @@ tutorials:
             # Install packages
             sudo apt install libmc-rtc-dev mc-rtc-utils
             # Assuming you have a ROS distribution mirror setup
-            sudo apt install ros-${ROS_DISTRO}-mc-rtc-plugin ros-${ROS_DISTRO}-mc-rtc-tools
+            sudo apt install ros-${ROS_DISTRO}-mc-rtc-plugin ros-${ROS_DISTRO}-mc-rtc-utils
     configuration:
       title: Configuring mc_rtc and its components
     running-a-controller:

--- a/doc/_i18n/jp.yml
+++ b/doc/_i18n/jp.yml
@@ -75,7 +75,7 @@ tutorials:
             # パッケージをインストールする
             sudo apt install libmc-rtc-dev mc-rtc-utils
             # ROSディストリビューションのミラーがセットアップされているものと仮定
-            sudo apt install ros-${ROS_DISTRO}-mc-rtc-plugin ros-${ROS_DISTRO}-mc-rtc-tools
+            sudo apt install ros-${ROS_DISTRO}-mc-rtc-plugin ros-${ROS_DISTRO}-mc-rtc-utils
         - name: 最新版のインストール
           lang: bash
           source: |
@@ -84,7 +84,7 @@ tutorials:
             # パッケージをインストールする
             sudo apt install libmc-rtc-dev mc-rtc-utils
             # ROSディストリビューションのミラーがセットアップされているものと仮定
-            sudo apt install ros-${ROS_DISTRO}-mc-rtc-plugin ros-${ROS_DISTRO}-mc-rtc-tools
+            sudo apt install ros-${ROS_DISTRO}-mc-rtc-plugin ros-${ROS_DISTRO}-mc-rtc-utils
     configuration:
       # FIXME Outdated translation
       title: 設定

--- a/plugins/ROS/CMakeLists.txt
+++ b/plugins/ROS/CMakeLists.txt
@@ -26,7 +26,10 @@ endif()
 set(TARGETS_EXPORT_NAME "mc_rtc_rosTargets")
 
 find_package(mc_rtc_3rd_party_ros REQUIRED)
-if(NOT ${ROSCPP_FOUND})
+if(NOT rclcpp_FOUND)
+  if(NOT DISABLE_ROS)
+    message(STATUS "ROS2 not found, skipping mc_rtc_ros plugin")
+  endif()
   return()
 endif()
 

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -38,19 +38,36 @@ if(BUILD_MC_RTC_CPP_UTILS)
 
   add_mc_rtc_utils(mc_json_to_yaml)
 
+  # Build RobotVisualizer without ROS
   add_library(RobotVisualizer OBJECT RobotVisualizer.h RobotVisualizer.cpp)
   target_link_libraries(RobotVisualizer PUBLIC mc_rtc::mc_control)
+
+  # Build RobotVisualizer with ROS if available
   if(TARGET mc_rtc::mc_rtc_ros)
-    target_link_libraries(RobotVisualizer PUBLIC mc_rtc::mc_rtc_ros)
-    target_compile_definitions(RobotVisualizer PUBLIC MC_RTC_HAS_ROS)
+    add_library(RobotVisualizer_ros OBJECT RobotVisualizer.h RobotVisualizer.cpp)
+    target_link_libraries(
+      RobotVisualizer_ros PUBLIC mc_rtc::mc_control mc_rtc::mc_rtc_ros
+    )
+    target_compile_definitions(RobotVisualizer_ros PUBLIC MC_RTC_HAS_ROS)
   endif()
 
+  # Non-ROS executables
   add_mc_rtc_utils(mc_convex_visualization)
   target_link_libraries(mc_convex_visualization PRIVATE RobotVisualizer)
   add_mc_rtc_utils(mc_robot_visualization)
   target_link_libraries(mc_robot_visualization PRIVATE RobotVisualizer)
   add_mc_rtc_utils(mc_surfaces_visualization)
   target_link_libraries(mc_surfaces_visualization PRIVATE RobotVisualizer)
+
+  # ROS executables (with _ros suffix)
+  if(TARGET mc_rtc::mc_rtc_ros)
+    add_mc_rtc_utils(mc_convex_visualization_ros mc_convex_visualization.cpp)
+    target_link_libraries(mc_convex_visualization_ros PRIVATE RobotVisualizer_ros)
+    add_mc_rtc_utils(mc_robot_visualization_ros mc_robot_visualization.cpp)
+    target_link_libraries(mc_robot_visualization_ros PRIVATE RobotVisualizer_ros)
+    add_mc_rtc_utils(mc_surfaces_visualization_ros mc_surfaces_visualization.cpp)
+    target_link_libraries(mc_surfaces_visualization_ros PRIVATE RobotVisualizer_ros)
+  endif()
 
   add_mc_rtc_utils(mc_rtc_ticker)
   target_link_libraries(
@@ -80,18 +97,8 @@ endif() # MC_RTC_BUILD_CPP_UTILS
 # ######################################################################################
 
 if(BUILD_MC_RTC_PYTHON_UTILS)
-  message(STATUS "Building Python utilities (because MC_RTC_BUILD_PYTHON_UTILS is ON)")
-  if(NOT DEFINED MC_LOG_UI_PYTHON_EXECUTABLE)
-    if(PYTHON_BINDING_FORCE_PYTHON3)
-      set(MC_LOG_UI_PYTHON_EXECUTABLE "python3")
-    elseif(PYTHON_BINDING_FORCE_PYTHON2)
-      set(MC_LOG_UI_PYTHON_EXECUTABLE "python2")
-    else()
-      set(MC_LOG_UI_PYTHON_EXECUTABLE "python")
-    endif()
-  endif()
-
-  find_program(PYTHON_PGM ${MC_LOG_UI_PYTHON_EXECUTABLE})
+  message(STATUS "Building Python3 utilities (because MC_RTC_BUILD_PYTHON_UTILS is ON)")
+  find_program(PYTHON_PGM python3)
   if(NOT PYTHON_PGM)
     return()
   endif()

--- a/utils/mc_log_gui/CMakeLists.txt
+++ b/utils/mc_log_gui/CMakeLists.txt
@@ -8,7 +8,7 @@ if(MC_RTC_BUILD_IN_NIX)
 else()
   execute_process(
     COMMAND
-      ${MC_LOG_UI_PYTHON_EXECUTABLE} -c
+      python3 -c
       "from distutils import sysconfig; print(sysconfig.get_python_lib(prefix = '${CMAKE_INSTALL_PREFIX}', plat_specific = True))"
     RESULT_VARIABLE PYTHON_INSTALL_DIR_FOUND
     OUTPUT_VARIABLE PYTHON_INSTALL_DIR


### PR DESCRIPTION
debian packaging:
- drop ROS1 support
- drop python2 support
- split mc-rtc-utils into mc-rtc-utils and ros-jazzy-mc-rtc-utils. This installs a `_ros` variant of `mc_[convex,surfaces,robot]_visualization`. This is the simplest way to avoid having to compile mc-rtc with and without ros for packaging
- fix: setup `shlibs.local` rule to avoid injecting `libmc-rtc-ros-compat` into `libmc-rtc` dependencies. We want to support `libmc-rtc-ros-compat-dev | ros-jazzy-mc-rtc-ros-compat` explicitely here.