### PR TITLE
RobotModule controller/observer per-robot configuration

### DIFF
--- a/doc/_i18n/en/tutorials/introduction/configuration.html
+++ b/doc/_i18n/en/tutorials/introduction/configuration.html
@@ -153,8 +153,10 @@ publish:
 <p>For a given controller {% ihighlight bash %}NAME{% endihighlight %} and a given robot's module named {% ihighlight bash %}ROBOT{% endihighlight %}, the following configuration files are loaded:</p>
 
 <ol>
-  <li>{% ihighlight bash %}${NAME_RUNTIME_LOCATION}/${NAME}/${ROBOT}.yaml{% endihighlight %}</li>
+  <li>One provided by the robot module: {% ihighlight bash %}${ROBOT_MODULE_RUNTIME_LOCATION}/etc/controllers/${NAME}/${ROBOT}.yaml{% endihighlight %}</li>
+  <li>One provided by the controller: {% ihighlight bash %}${NAME_RUNTIME_LOCATION}/${NAME}/${ROBOT}.yaml{% endihighlight %}</li>
   <li>
+    A user-specific configuration:
     <ul>
       <li>Linux/MacOS: {% ihighlight bash %}${HOME}/.config/mc_rtc/controllers/${NAME}/${ROBOT}.yaml{% endihighlight %}</li>
       <li>Windows: {% ihighlight msshell %}%APPDATA%/mc_rtc/controllers/%NAME%/%ROBOT%.yaml{% endihighlight %}</li>

--- a/doc/_i18n/en/tutorials/recipes/observers.md
+++ b/doc/_i18n/en/tutorials/recipes/observers.md
@@ -16,16 +16,30 @@ To represent the robots, the framework provides two sets of robot instances ({% 
 
 # Configuring the observer pipelines
 
-State observation pipelines can be configured in your controller configuration (each pipeline configuration superseeds the previous one):
-
+Your controller's configuration configures the whole pipeline by merging configurations from the following files (in order):
 - Global configuration: {% ihighlight bash %}$INSTALL_PREFIX/etc/mc_rtc.yaml{% endihighlight %}
 - User configuration: {% ihighlight bash %}$HOME/.config/mc_rtc/mc_rtc.yaml{% endihighlight %}
 - Controller-specific configuration: {% ihighlight bash %}$HOME/.config/mc_rtc/mc_controllers/YourController.yaml{% endihighlight %}
 - The FSM configuration of your controller: {% ihighlight bash %} YouController.yaml{% endihighlight %} (recommended)
 
-The configuration format is fully documented in the [Observers JSON schema](../../json.html#Observers/ObserverPipelines).
+
+In order to provide sensible default values for each observer, they are configured by merging the following configurations (in order):
+
+- The observer's author:
+  - The observer's runtime directory where its library is loaded from {% ihighlight bash %}$MC_OBSERVERS_RUNTIME_INSTALL_PREFIX/etc/<ObserverType>.yaml{% endihighlight %}
+- The observer's author for a pre-defined set of robot's:
+  - The observer's robot-specific runtime directory {% ihighlight bash %}$OBSERVERS_RUNTIME_INSTALL_PREFIX/etc/<ObserverType>/<robot>.yaml{% endihighlight %}
+- The robot module's author (for extensibility to additional robots)
+  - The robot module's observer configuration {% ihighlight bash %}$OBSERVERS_RUNTIME_INSTALL_PREFIX/etc/observers/<ObserverType>.yaml{% endihighlight %}
+- You:
+  - User configuration: {% ihighlight bash %}$HOME/.config/mc_rtc/observers/<ObserverType>.yaml{% endihighlight %}
+  - User robot-specific configuration: {% ihighlight bash %}$HOME/.config/mc_rtc/observers/<ObserverType>/<robot>.yaml{% endihighlight %}
+- Lastly, the configuration provided in your pipeline above.
+
+With these, you can be assured that even without providing detailed configuration for each observer, it will have default values meaningful to your robot.
 
 Let's look first at a simple representative example to estimate the state of a floating-base robot from encoder position measurements and a sensor providing roll and pitch orientation of the floating base.
+The configuration format is fully documented in the [Observers JSON schema](../../json.html#Observers/ObserverPipelines).
 
 ```yaml
 ---

--- a/flake.lock
+++ b/flake.lock
@@ -49,11 +49,11 @@
     "flake-compat_2": {
       "flake": false,
       "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
+        "lastModified": 1696426674,
+        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
+        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
     "flake-compat_3": {
       "flake": false,
       "locked": {
-        "lastModified": 1696426674,
-        "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
+        "lastModified": 1767039857,
+        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
         "owner": "edolstra",
         "repo": "flake-compat",
-        "rev": "0f9255e01c2351cc7d116c072cb317785dd33b33",
+        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
         "type": "github"
       },
       "original": {
@@ -113,22 +113,6 @@
     "flake-compat_6": {
       "flake": false,
       "locked": {
-        "lastModified": 1767039857,
-        "narHash": "sha256-vNpUSpF5Nuw8xvDLj2KCwwksIbjua2LZCqhV1LNRDns=",
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "rev": "5edf11c44bc78a0d334f6334cdaf7d60d732daab",
-        "type": "github"
-      },
-      "original": {
-        "owner": "edolstra",
-        "repo": "flake-compat",
-        "type": "github"
-      }
-    },
-    "flake-compat_7": {
-      "flake": false,
-      "locked": {
         "lastModified": 1696426674,
         "narHash": "sha256-kvjfFW7WAETZlt09AgDn1MrtKzP7t90Vf7vypd3OL1U=",
         "owner": "edolstra",
@@ -152,32 +136,6 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_10": {
-      "inputs": {
-        "nixpkgs-lib": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "system-manager",
-          "userborn",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1768135262,
-        "narHash": "sha256-PVvu7OqHBGWN16zSi6tEmPwwHQ4rLPU9Plvs8/1TUBY=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
         "type": "github"
       },
       "original": {
@@ -215,11 +173,11 @@
         "nixpkgs-lib": "nixpkgs-lib_2"
       },
       "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
         "type": "github"
       },
       "original": {
@@ -231,8 +189,8 @@
     "flake-parts_4": {
       "inputs": {
         "nixpkgs-lib": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "system-manager",
           "userborn",
@@ -275,7 +233,7 @@
       "inputs": {
         "nixpkgs-lib": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "system-manager",
           "userborn",
@@ -301,11 +259,11 @@
         "nixpkgs-lib": "nixpkgs-lib_4"
       },
       "locked": {
-        "lastModified": 1778716662,
-        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -319,6 +277,7 @@
         "nixpkgs-lib": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "system-manager",
           "userborn",
@@ -331,24 +290,6 @@
         "owner": "hercules-ci",
         "repo": "flake-parts",
         "rev": "80daad04eddbbf5a4d883996a73f3f542fa437ac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "type": "github"
-      }
-    },
-    "flake-parts_9": {
-      "inputs": {
-        "nixpkgs-lib": "nixpkgs-lib_5"
-      },
-      "locked": {
-        "lastModified": 1775087534,
-        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
-        "owner": "hercules-ci",
-        "repo": "flake-parts",
-        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -429,24 +370,6 @@
         "type": "github"
       }
     },
-    "flake-utils_5": {
-      "inputs": {
-        "systems": "systems_9"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "flakoboros": {
       "inputs": {
         "flake-parts": "flake-parts",
@@ -489,8 +412,8 @@
         "flake-parts": "flake-parts_3",
         "nix-ros-overlay": "nix-ros-overlay_2",
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -498,8 +421,8 @@
           "nixpkgs"
         ],
         "systems": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -510,11 +433,11 @@
         "treefmt-nix": "treefmt-nix_2"
       },
       "locked": {
-        "lastModified": 1776113076,
-        "narHash": "sha256-rQp/6mgQc4szevay50RbGXOXwL3xC7oHktywFPrmbAM=",
+        "lastModified": 1782042109,
+        "narHash": "sha256-oDCl/rcvJVTcf6G2ag3YdZSMHDVBBmoXTysY5yzq+Dk=",
         "owner": "gepetto",
         "repo": "flakoboros",
-        "rev": "07a89fe2a47f2f0364e795cf3e69c045de14a3b2",
+        "rev": "fc7d44063fa05f1a78c97c63b124c1da2862331c",
         "type": "github"
       },
       "original": {
@@ -529,7 +452,7 @@
         "nix-ros-overlay": "nix-ros-overlay_3",
         "nixpkgs": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -538,7 +461,7 @@
         ],
         "systems": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -569,6 +492,7 @@
         "nixpkgs": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -578,6 +502,7 @@
         "systems": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -586,47 +511,6 @@
           "systems"
         ],
         "treefmt-nix": "treefmt-nix_4"
-      },
-      "locked": {
-        "lastModified": 1782042109,
-        "narHash": "sha256-oDCl/rcvJVTcf6G2ag3YdZSMHDVBBmoXTysY5yzq+Dk=",
-        "owner": "gepetto",
-        "repo": "flakoboros",
-        "rev": "fc7d44063fa05f1a78c97c63b124c1da2862331c",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gepetto",
-        "repo": "flakoboros",
-        "type": "github"
-      }
-    },
-    "flakoboros_5": {
-      "inputs": {
-        "flake-parts": "flake-parts_9",
-        "nix-ros-overlay": "nix-ros-overlay_5",
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nix-ros-overlay",
-          "nixpkgs"
-        ],
-        "systems": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nix-ros-overlay",
-          "flake-utils",
-          "systems"
-        ],
-        "treefmt-nix": "treefmt-nix_5"
       },
       "locked": {
         "lastModified": 1776113076,
@@ -708,8 +592,8 @@
     "gazebros2nix_2": {
       "inputs": {
         "flake-parts": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -717,16 +601,16 @@
         ],
         "flakoboros": "flakoboros_2",
         "nix-ros-overlay": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
           "nix-ros-overlay"
         ],
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -734,67 +618,6 @@
         ],
         "pyproject-build-systems": "pyproject-build-systems_2",
         "pyproject-nix": "pyproject-nix_2",
-        "systems": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "systems"
-        ],
-        "treefmt-nix": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "treefmt-nix"
-        ],
-        "uv2nix": "uv2nix_2"
-      },
-      "locked": {
-        "lastModified": 1777754176,
-        "narHash": "sha256-bnR2Aor+qSLVCcUUV/IjjHM5AnJR6cpf0AljUSiUuco=",
-        "owner": "gepetto",
-        "repo": "gazebros2nix",
-        "rev": "29d82bf45d91a5e9ca9f8c40f963ad20168e6ae1",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gepetto",
-        "repo": "gazebros2nix",
-        "type": "github"
-      }
-    },
-    "gazebros2nix_3": {
-      "inputs": {
-        "flake-parts": [
-          "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "flake-parts"
-        ],
-        "flakoboros": "flakoboros_3",
-        "nix-ros-overlay": [
-          "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nix-ros-overlay"
-        ],
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nixpkgs"
-        ],
-        "pyproject-build-systems": "pyproject-build-systems_3",
-        "pyproject-nix": "pyproject-nix_3",
         "rosdistro": [
           "mc-rtc-ros-compat",
           "jrl-cmakemodules",
@@ -814,6 +637,75 @@
         "treefmt-nix": [
           "mc-rtc-ros-compat",
           "jrl-cmakemodules",
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "treefmt-nix"
+        ],
+        "uv2nix": "uv2nix_2"
+      },
+      "locked": {
+        "lastModified": 1782566589,
+        "narHash": "sha256-vXVLP31bnnk8KUBUV88Ms2R6P06wdQPZzsXgR6iZ5FI=",
+        "owner": "gepetto",
+        "repo": "gazebros2nix",
+        "rev": "6e51068e9e9fec8e960f68911127ad64b417bf6b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gepetto",
+        "repo": "gazebros2nix",
+        "type": "github"
+      }
+    },
+    "gazebros2nix_3": {
+      "inputs": {
+        "flake-parts": [
+          "mc-rtc-ros-compat",
+          "mc-rtc-nix",
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "flake-parts"
+        ],
+        "flakoboros": "flakoboros_3",
+        "nix-ros-overlay": [
+          "mc-rtc-ros-compat",
+          "mc-rtc-nix",
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "nix-ros-overlay"
+        ],
+        "nixpkgs": [
+          "mc-rtc-ros-compat",
+          "mc-rtc-nix",
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "nixpkgs"
+        ],
+        "pyproject-build-systems": "pyproject-build-systems_3",
+        "pyproject-nix": "pyproject-nix_3",
+        "rosdistro": [
+          "mc-rtc-ros-compat",
+          "mc-rtc-nix",
+          "gepetto",
+          "gazebros2nix",
+          "nix-ros-overlay",
+          "rosdistro"
+        ],
+        "systems": [
+          "mc-rtc-ros-compat",
+          "mc-rtc-nix",
+          "gepetto",
+          "gazebros2nix",
+          "flakoboros",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "mc-rtc-ros-compat",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -840,6 +732,7 @@
         "flake-parts": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -849,6 +742,7 @@
         "nix-ros-overlay": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -857,6 +751,7 @@
         "nixpkgs": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -864,17 +759,10 @@
         ],
         "pyproject-build-systems": "pyproject-build-systems_4",
         "pyproject-nix": "pyproject-nix_4",
-        "rosdistro": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "gepetto",
-          "gazebros2nix",
-          "nix-ros-overlay",
-          "rosdistro"
-        ],
         "systems": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
@@ -883,78 +771,13 @@
         "treefmt-nix": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "flakoboros",
           "treefmt-nix"
         ],
         "uv2nix": "uv2nix_4"
-      },
-      "locked": {
-        "lastModified": 1782566589,
-        "narHash": "sha256-vXVLP31bnnk8KUBUV88Ms2R6P06wdQPZzsXgR6iZ5FI=",
-        "owner": "gepetto",
-        "repo": "gazebros2nix",
-        "rev": "6e51068e9e9fec8e960f68911127ad64b417bf6b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gepetto",
-        "repo": "gazebros2nix",
-        "type": "github"
-      }
-    },
-    "gazebros2nix_5": {
-      "inputs": {
-        "flake-parts": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "flake-parts"
-        ],
-        "flakoboros": "flakoboros_5",
-        "nix-ros-overlay": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nix-ros-overlay"
-        ],
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nixpkgs"
-        ],
-        "pyproject-build-systems": "pyproject-build-systems_5",
-        "pyproject-nix": "pyproject-nix_5",
-        "systems": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "systems"
-        ],
-        "treefmt-nix": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "treefmt-nix"
-        ],
-        "uv2nix": "uv2nix_5"
       },
       "locked": {
         "lastModified": 1777754176,
@@ -1030,15 +853,15 @@
     "gepetto_2": {
       "inputs": {
         "flake-parts": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "flake-parts"
         ],
         "flakoboros": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "flakoboros"
@@ -1046,42 +869,42 @@
         "gazebros2nix": "gazebros2nix_2",
         "home-manager": "home-manager_2",
         "nix-ros-overlay": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "nix-ros-overlay"
         ],
         "nix-system-graphics": "nix-system-graphics_2",
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "nixpkgs"
         ],
         "system-manager": "system-manager_2",
         "systems": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "systems"
         ],
         "treefmt-nix": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "treefmt-nix"
         ]
       },
       "locked": {
-        "lastModified": 1777773493,
-        "narHash": "sha256-6zivX47/UVo1dR9iGNRBETvz7/igFrc2SrqCbJqxtWY=",
+        "lastModified": 1783001154,
+        "narHash": "sha256-kPrfWL8YePlBRv0Sz2J4Uwn6C/HlhM3WZG96Y6TEqeU=",
         "owner": "gepetto",
         "repo": "nix",
-        "rev": "506ba63b0f3f7f1b1ac5e215f957feb4b12013d6",
+        "rev": "7a2bf9834c160a05872d0f77eeadc9362cb6f014",
         "type": "github"
       },
       "original": {
@@ -1094,14 +917,14 @@
       "inputs": {
         "flake-parts": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "flake-parts"
         ],
         "flakoboros": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "flakoboros"
@@ -1110,7 +933,7 @@
         "home-manager": "home-manager_3",
         "nix-ros-overlay": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "nix-ros-overlay"
@@ -1118,7 +941,7 @@
         "nix-system-graphics": "nix-system-graphics_3",
         "nixpkgs": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "nixpkgs"
@@ -1126,14 +949,14 @@
         "system-manager": "system-manager_3",
         "systems": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "systems"
         ],
         "treefmt-nix": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "treefmt-nix"
@@ -1158,6 +981,7 @@
         "flake-parts": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "flake-parts"
@@ -1165,6 +989,7 @@
         "flakoboros": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "flakoboros"
@@ -1174,6 +999,7 @@
         "nix-ros-overlay": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "nix-ros-overlay"
@@ -1182,78 +1008,12 @@
         "nixpkgs": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "gazebros2nix",
           "nixpkgs"
         ],
         "system-manager": "system-manager_4",
-        "systems": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "gepetto",
-          "gazebros2nix",
-          "systems"
-        ],
-        "treefmt-nix": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "gepetto",
-          "gazebros2nix",
-          "treefmt-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1783001154,
-        "narHash": "sha256-kPrfWL8YePlBRv0Sz2J4Uwn6C/HlhM3WZG96Y6TEqeU=",
-        "owner": "gepetto",
-        "repo": "nix",
-        "rev": "7a2bf9834c160a05872d0f77eeadc9362cb6f014",
-        "type": "github"
-      },
-      "original": {
-        "owner": "gepetto",
-        "repo": "nix",
-        "type": "github"
-      }
-    },
-    "gepetto_5": {
-      "inputs": {
-        "flake-parts": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flake-parts"
-        ],
-        "flakoboros": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros"
-        ],
-        "gazebros2nix": "gazebros2nix_5",
-        "home-manager": "home-manager_5",
-        "nix-ros-overlay": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "nix-ros-overlay"
-        ],
-        "nix-system-graphics": "nix-system-graphics_5",
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ],
-        "system-manager": "system-manager_5",
         "systems": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
@@ -1313,8 +1073,8 @@
     "gitignore_2": {
       "inputs": {
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "system-manager",
           "userborn",
@@ -1340,32 +1100,6 @@
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
-          "gepetto",
-          "system-manager",
-          "userborn",
-          "pre-commit-hooks-nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1709087332,
-        "narHash": "sha256-HG2cCnktfHsKV0s4XW83gU3F57gaTljL9KNSuG6bnQs=",
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "rev": "637db329424fd7e46cf4185293b9cc8c88c95394",
-        "type": "github"
-      },
-      "original": {
-        "owner": "hercules-ci",
-        "repo": "gitignore.nix",
-        "type": "github"
-      }
-    },
-    "gitignore_4": {
-      "inputs": {
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
           "mc-rtc-nix",
           "gepetto",
           "system-manager",
@@ -1388,7 +1122,7 @@
         "type": "github"
       }
     },
-    "gitignore_5": {
+    "gitignore_4": {
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
@@ -1441,30 +1175,6 @@
     "home-manager_2": {
       "inputs": {
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1777771528,
-        "narHash": "sha256-YycygK6n7KeW1YCobdFJcORWzkmrvNcp6xT+IovA0d4=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "0585fbf645640973e3398863bbaf3bd1ddce4a51",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "ref": "release-25.11",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
-    "home-manager_3": {
-      "inputs": {
-        "nixpkgs": [
           "mc-rtc-ros-compat",
           "jrl-cmakemodules",
           "gepetto",
@@ -1486,7 +1196,7 @@
         "type": "github"
       }
     },
-    "home-manager_4": {
+    "home-manager_3": {
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
@@ -1510,7 +1220,7 @@
         "type": "github"
       }
     },
-    "home-manager_5": {
+    "home-manager_4": {
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
@@ -1537,7 +1247,7 @@
     },
     "jrl-cmakemodules": {
       "inputs": {
-        "gepetto": "gepetto_3"
+        "gepetto": "gepetto_2"
       },
       "locked": {
         "lastModified": 1783244775,
@@ -1555,26 +1265,28 @@
     },
     "jrl-cmakemodulesv2": {
       "inputs": {
-        "gepetto": "gepetto_2"
+        "gepetto": [
+          "mc-rtc-nix",
+          "gepetto"
+        ]
       },
       "locked": {
-        "lastModified": 1782668743,
-        "narHash": "sha256-nHyHqmL/b31tO4/S+lyf9yNL8tYYX2HxNFlvAfb/0k4=",
-        "owner": "ahoarau",
+        "lastModified": 1783605492,
+        "narHash": "sha256-CJPPNoyLYZJkaC0X8yxxY+jw7fUpN67tWQ7mdZlMvNc=",
+        "owner": "jrl-umi3218",
         "repo": "jrl-cmakemodules",
-        "rev": "49e8e570d630abf6e978c4ff2b5edab4a0f46d28",
+        "rev": "e33225ea9330bf7217a2e38852d8a38ae028085f",
         "type": "github"
       },
       "original": {
-        "owner": "ahoarau",
-        "ref": "jrl-next",
+        "owner": "jrl-umi3218",
         "repo": "jrl-cmakemodules",
         "type": "github"
       }
     },
     "jrl-cmakemodulesv2_2": {
       "inputs": {
-        "gepetto": "gepetto_5"
+        "gepetto": "gepetto_4"
       },
       "locked": {
         "lastModified": 1782668743,
@@ -1593,7 +1305,7 @@
     },
     "make-shell": {
       "inputs": {
-        "flake-compat": "flake-compat_3"
+        "flake-compat": "flake-compat_2"
       },
       "locked": {
         "lastModified": 1733933815,
@@ -1611,7 +1323,7 @@
     },
     "make-shell_2": {
       "inputs": {
-        "flake-compat": "flake-compat_7"
+        "flake-compat": "flake-compat_6"
       },
       "locked": {
         "lastModified": 1733933815,
@@ -1658,11 +1370,11 @@
         "with-ros-trigger": "with-ros-trigger"
       },
       "locked": {
-        "lastModified": 1783341505,
-        "narHash": "sha256-+eGGzarWHP9HUoKQxNI9hadiO0zmp3HncJ+x7ZK/S28=",
+        "lastModified": 1784046811,
+        "narHash": "sha256-3YuUJQ6jWLVH5Uvz6/ph5bMT0CRSQufKvULYKab01ZI=",
         "owner": "mc-rtc",
         "repo": "nixpkgs",
-        "rev": "12e25cb776b7456821a6bd57179b0b354fb2fd5b",
+        "rev": "ead67425b49f5ea2522774042c31e1934e7422ff",
         "type": "github"
       },
       "original": {
@@ -1686,7 +1398,7 @@
           "gepetto",
           "flakoboros"
         ],
-        "gepetto": "gepetto_4",
+        "gepetto": "gepetto_3",
         "jrl-cmakemodulesv2": "jrl-cmakemodulesv2_2",
         "make-shell": "make-shell_2",
         "nixpkgs": [
@@ -1731,11 +1443,11 @@
         "with-ros-trigger": "with-ros-trigger_3"
       },
       "locked": {
-        "lastModified": 1783496603,
-        "narHash": "sha256-hOMnkjBtIzGvjVYwYvPgXgtclw0bESt1mInQHoksu5g=",
+        "lastModified": 1784050251,
+        "narHash": "sha256-c9/fBGbFQ61Na7kDWJNf0VEvpXc+ZGjXj+Uaw9fjbhc=",
         "owner": "jrl-umi3218",
         "repo": "mc_rtc_ros_compat",
-        "rev": "41ce7a328ed431f2209360e729f0dbd1928d7ec1",
+        "rev": "d294d5d7a7526db1c2d5ab4605569255dc3a459e",
         "type": "github"
       },
       "original": {
@@ -1768,14 +1480,15 @@
     "nix-ros-overlay_2": {
       "inputs": {
         "flake-utils": "flake-utils_2",
-        "nixpkgs": "nixpkgs_2"
+        "nixpkgs": "nixpkgs_2",
+        "rosdistro": "rosdistro_2"
       },
       "locked": {
-        "lastModified": 1775764892,
-        "narHash": "sha256-l1UbHppd5KaU4K/TQPIXf9wnVifH4Tgrx5z2GFoq/bw=",
+        "lastModified": 1781900693,
+        "narHash": "sha256-4KFk+S9ZbMonItYsdPtZjwESsgrCEpXGDa6rosDxLGs=",
         "owner": "lopsided98",
         "repo": "nix-ros-overlay",
-        "rev": "0a4e8cf51001d2d1c613f95dadd3853da42c0164",
+        "rev": "fb296510db68c2e760980ab8c6daf6ded9060213",
         "type": "github"
       },
       "original": {
@@ -1789,7 +1502,7 @@
       "inputs": {
         "flake-utils": "flake-utils_3",
         "nixpkgs": "nixpkgs_3",
-        "rosdistro": "rosdistro_2"
+        "rosdistro": "rosdistro_3"
       },
       "locked": {
         "lastModified": 1781900693,
@@ -1809,28 +1522,7 @@
     "nix-ros-overlay_4": {
       "inputs": {
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_4",
-        "rosdistro": "rosdistro_3"
-      },
-      "locked": {
-        "lastModified": 1781900693,
-        "narHash": "sha256-4KFk+S9ZbMonItYsdPtZjwESsgrCEpXGDa6rosDxLGs=",
-        "owner": "lopsided98",
-        "repo": "nix-ros-overlay",
-        "rev": "fb296510db68c2e760980ab8c6daf6ded9060213",
-        "type": "github"
-      },
-      "original": {
-        "owner": "lopsided98",
-        "ref": "develop",
-        "repo": "nix-ros-overlay",
-        "type": "github"
-      }
-    },
-    "nix-ros-overlay_5": {
-      "inputs": {
-        "flake-utils": "flake-utils_5",
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1775764892,
@@ -1872,8 +1564,8 @@
     "nix-system-graphics_2": {
       "inputs": {
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "nixpkgs"
         ]
@@ -1896,29 +1588,6 @@
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
-          "gepetto",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1763296639,
-        "narHash": "sha256-K9JBscC7ApwCnl0wR0sVkxrKFsoDYVqXN5fOujvyBWA=",
-        "owner": "soupglasses",
-        "repo": "nix-system-graphics",
-        "rev": "ac37f0f3ec0cb15d63a520918433c794d01d9dac",
-        "type": "github"
-      },
-      "original": {
-        "owner": "soupglasses",
-        "repo": "nix-system-graphics",
-        "type": "github"
-      }
-    },
-    "nix-system-graphics_4": {
-      "inputs": {
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
           "mc-rtc-nix",
           "gepetto",
           "nixpkgs"
@@ -1938,7 +1607,7 @@
         "type": "github"
       }
     },
-    "nix-system-graphics_5": {
+    "nix-system-graphics_4": {
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
@@ -1995,11 +1664,11 @@
     },
     "nixpkgs-lib_2": {
       "locked": {
-        "lastModified": 1774748309,
-        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "lastModified": 1777168982,
+        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
         "owner": "nix-community",
         "repo": "nixpkgs.lib",
-        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
         "type": "github"
       },
       "original": {
@@ -2025,21 +1694,6 @@
     },
     "nixpkgs-lib_4": {
       "locked": {
-        "lastModified": 1777168982,
-        "narHash": "sha256-GOkGPcboWE9BmGCRMLX3worL4EMnsnG8MyKmXNeYuhQ=",
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "rev": "f5901329dade4a6ea039af1433fb087bd9c1fe14",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "nixpkgs.lib",
-        "type": "github"
-      }
-    },
-    "nixpkgs-lib_5": {
-      "locked": {
         "lastModified": 1774748309,
         "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
         "owner": "nix-community",
@@ -2055,11 +1709,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1771369470,
-        "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
+        "lastModified": 1778869304,
+        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "0182a361324364ae3f436a63005877674cf45efb",
+        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
         "type": "github"
       },
       "original": {
@@ -2086,22 +1740,6 @@
       }
     },
     "nixpkgs_4": {
-      "locked": {
-        "lastModified": 1778869304,
-        "narHash": "sha256-30sZNZoA1cqF5JNO9fVX+wgiQYjB7HJqqJ4ztCDeBZE=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "d233902339c02a9c334e7e593de68855ad26c4cb",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-unstable",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
-    "nixpkgs_5": {
       "locked": {
         "lastModified": 1771369470,
         "narHash": "sha256-0NBlEBKkN3lufyvFegY4TYv5mCNHbi5OmBDrzihbBMQ=",
@@ -2152,8 +1790,8 @@
     "pre-commit-hooks-nix_2": {
       "inputs": {
         "flake-compat": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "system-manager",
           "userborn",
@@ -2161,8 +1799,8 @@
         ],
         "gitignore": "gitignore_2",
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "system-manager",
           "userborn",
@@ -2187,7 +1825,7 @@
       "inputs": {
         "flake-compat": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "system-manager",
           "userborn",
@@ -2196,7 +1834,7 @@
         "gitignore": "gitignore_3",
         "nixpkgs": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "system-manager",
           "userborn",
@@ -2222,47 +1860,13 @@
         "flake-compat": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
-          "gepetto",
-          "system-manager",
-          "userborn",
-          "flake-compat"
-        ],
-        "gitignore": "gitignore_4",
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "gepetto",
-          "system-manager",
-          "userborn",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1769069492,
-        "narHash": "sha256-Efs3VUPelRduf3PpfPP2ovEB4CXT7vHf8W+xc49RL/U=",
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "rev": "a1ef738813b15cf8ec759bdff5761b027e3e1d23",
-        "type": "github"
-      },
-      "original": {
-        "owner": "cachix",
-        "repo": "pre-commit-hooks.nix",
-        "type": "github"
-      }
-    },
-    "pre-commit-hooks-nix_5": {
-      "inputs": {
-        "flake-compat": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
           "jrl-cmakemodulesv2",
           "gepetto",
           "system-manager",
           "userborn",
           "flake-compat"
         ],
-        "gitignore": "gitignore_5",
+        "gitignore": "gitignore_4",
         "nixpkgs": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
@@ -2355,33 +1959,33 @@
     "pyproject-build-systems_2": {
       "inputs": {
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "nixpkgs"
         ],
         "pyproject-nix": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "pyproject-nix"
         ],
         "uv2nix": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "uv2nix"
         ]
       },
       "locked": {
-        "lastModified": 1776659114,
-        "narHash": "sha256-qapCOQmR++yZSY43dzrp3wCrkOTLpod+ONtJWBk6iKU=",
+        "lastModified": 1782093830,
+        "narHash": "sha256-6gmEVe69+KlRkZD4PEEV5xAlB9CB0Y9TiuEgQjDrKTQ=",
         "owner": "pyproject-nix",
         "repo": "build-system-pkgs",
-        "rev": "ffaa2161dd5d63e0e94591f86b54fc239660fb2e",
+        "rev": "430680a19bc85a3bda55f12e4cc1a1aadcf2e478",
         "type": "github"
       },
       "original": {
@@ -2394,21 +1998,21 @@
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "nixpkgs"
         ],
         "pyproject-nix": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "pyproject-nix"
         ],
         "uv2nix": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "uv2nix"
@@ -2429,44 +2033,6 @@
       }
     },
     "pyproject-build-systems_4": {
-      "inputs": {
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "gepetto",
-          "gazebros2nix",
-          "pyproject-nix"
-        ],
-        "uv2nix": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "gepetto",
-          "gazebros2nix",
-          "uv2nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1782093830,
-        "narHash": "sha256-6gmEVe69+KlRkZD4PEEV5xAlB9CB0Y9TiuEgQjDrKTQ=",
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "rev": "430680a19bc85a3bda55f12e4cc1a1aadcf2e478",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "build-system-pkgs",
-        "type": "github"
-      }
-    },
-    "pyproject-build-systems_5": {
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
@@ -2533,30 +2099,6 @@
     "pyproject-nix_2": {
       "inputs": {
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1776715674,
-        "narHash": "sha256-Gs1VnEkCkkRZxJQAC/Dhz0Jbfi22mFXChbtNg9w/Ybg=",
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "rev": "69f57f27e52a87c54e28138a75ec741cd46663c9",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "pyproject.nix",
-        "type": "github"
-      }
-    },
-    "pyproject-nix_3": {
-      "inputs": {
-        "nixpkgs": [
           "mc-rtc-ros-compat",
           "jrl-cmakemodules",
           "gepetto",
@@ -2578,7 +2120,7 @@
         "type": "github"
       }
     },
-    "pyproject-nix_4": {
+    "pyproject-nix_3": {
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
@@ -2602,7 +2144,7 @@
         "type": "github"
       }
     },
-    "pyproject-nix_5": {
+    "pyproject-nix_4": {
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
@@ -2715,21 +2257,21 @@
     },
     "system-manager_2": {
       "inputs": {
-        "flake-compat": "flake-compat_2",
+        "flake-compat": "flake-compat_3",
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "nixpkgs"
         ],
         "userborn": "userborn_2"
       },
       "locked": {
-        "lastModified": 1777545354,
-        "narHash": "sha256-T3u9Ixg0SX6bYYXHYEZ7O+MW0pQ1qxnjIQKCPM+irN4=",
+        "lastModified": 1778508009,
+        "narHash": "sha256-mp63mt+EwfKiVZX+4BC/59g5oTbsXNtSYESVci3opso=",
         "owner": "numtide",
         "repo": "system-manager",
-        "rev": "6eac5ac077960363d3807b1c74f47103d1f62efd",
+        "rev": "dc1baae12eed1758755e73f8aff7fca5502c6e9f",
         "type": "github"
       },
       "original": {
@@ -2743,7 +2285,7 @@
         "flake-compat": "flake-compat_4",
         "nixpkgs": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "nixpkgs"
         ],
@@ -2769,36 +2311,11 @@
         "nixpkgs": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
-          "gepetto",
-          "nixpkgs"
-        ],
-        "userborn": "userborn_4"
-      },
-      "locked": {
-        "lastModified": 1778508009,
-        "narHash": "sha256-mp63mt+EwfKiVZX+4BC/59g5oTbsXNtSYESVci3opso=",
-        "owner": "numtide",
-        "repo": "system-manager",
-        "rev": "dc1baae12eed1758755e73f8aff7fca5502c6e9f",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "system-manager",
-        "type": "github"
-      }
-    },
-    "system-manager_5": {
-      "inputs": {
-        "flake-compat": "flake-compat_6",
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
           "jrl-cmakemodulesv2",
           "gepetto",
           "nixpkgs"
         ],
-        "userborn": "userborn_5"
+        "userborn": "userborn_4"
       },
       "locked": {
         "lastModified": 1777545354,
@@ -2815,21 +2332,6 @@
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_10": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -2949,21 +2451,6 @@
         "type": "github"
       }
     },
-    "systems_9": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
     "treefmt-nix": {
       "inputs": {
         "nixpkgs": [
@@ -2991,31 +2478,6 @@
     "treefmt-nix_2": {
       "inputs": {
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "gazebros2nix",
-          "flakoboros",
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1775636079,
-        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "treefmt-nix",
-        "type": "github"
-      }
-    },
-    "treefmt-nix_3": {
-      "inputs": {
-        "nixpkgs": [
           "mc-rtc-ros-compat",
           "jrl-cmakemodules",
           "gepetto",
@@ -3038,7 +2500,7 @@
         "type": "github"
       }
     },
-    "treefmt-nix_4": {
+    "treefmt-nix_3": {
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
@@ -3063,7 +2525,7 @@
         "type": "github"
       }
     },
-    "treefmt-nix_5": {
+    "treefmt-nix_4": {
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
@@ -3125,16 +2587,16 @@
     "userborn_2": {
       "inputs": {
         "flake-compat": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "system-manager",
           "flake-compat"
         ],
         "flake-parts": "flake-parts_4",
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "system-manager",
           "nixpkgs"
@@ -3161,7 +2623,7 @@
       "inputs": {
         "flake-compat": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "system-manager",
           "flake-compat"
@@ -3169,7 +2631,7 @@
         "flake-parts": "flake-parts_6",
         "nixpkgs": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "system-manager",
           "nixpkgs"
@@ -3197,6 +2659,7 @@
         "flake-compat": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "system-manager",
           "flake-compat"
@@ -3205,49 +2668,13 @@
         "nixpkgs": [
           "mc-rtc-ros-compat",
           "mc-rtc-nix",
+          "jrl-cmakemodulesv2",
           "gepetto",
           "system-manager",
           "nixpkgs"
         ],
         "pre-commit-hooks-nix": "pre-commit-hooks-nix_4",
         "systems": "systems_8"
-      },
-      "locked": {
-        "lastModified": 1770377964,
-        "narHash": "sha256-q2pnlX2IW0kg80GLFnwWd/GigIpkuZnyKPLhrgJql3E=",
-        "owner": "jfroche",
-        "repo": "userborn",
-        "rev": "55c2cd7952c207a62736a5bbd9499ea73da18d24",
-        "type": "github"
-      },
-      "original": {
-        "owner": "jfroche",
-        "ref": "system-manager",
-        "repo": "userborn",
-        "type": "github"
-      }
-    },
-    "userborn_5": {
-      "inputs": {
-        "flake-compat": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "system-manager",
-          "flake-compat"
-        ],
-        "flake-parts": "flake-parts_10",
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
-          "gepetto",
-          "system-manager",
-          "nixpkgs"
-        ],
-        "pre-commit-hooks-nix": "pre-commit-hooks-nix_5",
-        "systems": "systems_10"
       },
       "locked": {
         "lastModified": 1770377964,
@@ -3296,26 +2723,26 @@
     "uv2nix_2": {
       "inputs": {
         "nixpkgs": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "nixpkgs"
         ],
         "pyproject-nix": [
-          "mc-rtc-nix",
-          "jrl-cmakemodulesv2",
+          "mc-rtc-ros-compat",
+          "jrl-cmakemodules",
           "gepetto",
           "gazebros2nix",
           "pyproject-nix"
         ]
       },
       "locked": {
-        "lastModified": 1777463177,
-        "narHash": "sha256-1PcD0+IZPQXyvmXJ1OYH+23sRc9IyOKrUUBYZonVBm8=",
+        "lastModified": 1781810314,
+        "narHash": "sha256-PQfvfKWaBvCysdHFUO5GewwvwIqI/WL6OcrJhDSUdbc=",
         "owner": "pyproject-nix",
         "repo": "uv2nix",
-        "rev": "6c53dcf4d3f63240f57e0b0c826cb15eda61f249",
+        "rev": "14aa44100859a44144878fe079f8089d3fa4dc4e",
         "type": "github"
       },
       "original": {
@@ -3328,14 +2755,14 @@
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "nixpkgs"
         ],
         "pyproject-nix": [
           "mc-rtc-ros-compat",
-          "jrl-cmakemodules",
+          "mc-rtc-nix",
           "gepetto",
           "gazebros2nix",
           "pyproject-nix"
@@ -3356,37 +2783,6 @@
       }
     },
     "uv2nix_4": {
-      "inputs": {
-        "nixpkgs": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "gepetto",
-          "gazebros2nix",
-          "nixpkgs"
-        ],
-        "pyproject-nix": [
-          "mc-rtc-ros-compat",
-          "mc-rtc-nix",
-          "gepetto",
-          "gazebros2nix",
-          "pyproject-nix"
-        ]
-      },
-      "locked": {
-        "lastModified": 1781810314,
-        "narHash": "sha256-PQfvfKWaBvCysdHFUO5GewwvwIqI/WL6OcrJhDSUdbc=",
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "rev": "14aa44100859a44144878fe079f8089d3fa4dc4e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "pyproject-nix",
-        "repo": "uv2nix",
-        "type": "github"
-      }
-    },
-    "uv2nix_5": {
       "inputs": {
         "nixpkgs": [
           "mc-rtc-ros-compat",

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -739,9 +739,13 @@ public:
   /** Load a robot specific configuration (if any)
    *
    * The following files are loaded (in that order):
-   * - ${loading_location}/${name()}/${robot_name}.conf|yaml
-   * - ${HOME}/.config/mc_rtc/controllers/${name()}/${robot_name}.conf|yaml (Linux/macOS)
-   * - ${APPDATA}/mc_rtc/controllers/${name()}/${robot_name}.conf|yaml (Windows)
+   * - Robot module's per-robot controller configuration:
+   *    ${robot_module loading_location}/etc/controllers/${name()}/${robot_name}.conf|yaml|yml
+   * - Controller's per-robot configuration:
+   *    ${loading_location}/${name()}/${robot_name}.conf|yaml|yml
+   * - User's configuration:
+   *   - ${HOME}/.config/mc_rtc/controllers/${name()}/${robot_name}.conf|yaml (Linux/macOS)
+   *   - ${APPDATA}/mc_rtc/controllers/${name()}/${robot_name}.conf|yaml (Windows)
    */
   mc_rtc::Configuration robot_config(const std::string & robot_name) const;
 

--- a/include/mc_observers/Observer.h
+++ b/include/mc_observers/Observer.h
@@ -49,7 +49,7 @@ namespace mc_observers
  */
 struct MC_OBSERVERS_DLLAPI Observer
 {
-  Observer(const std::string & type, double dt) : type_(type), dt_(dt) {}
+  Observer(const std::string & type, double dt);
   virtual ~Observer() = default;
 
   /**
@@ -153,6 +153,15 @@ struct MC_OBSERVERS_DLLAPI Observer
   /*! Controller timestep */
   inline double dt() const noexcept { return dt_; }
 
+  /** Called by \ref mc_rtc::ObjectLoader to inform the robot module of its loading location
+   * For example, if the JVRC1 module is loaded from the library in /usr/local/lib/mc_robots/jvrc1.so then this is
+   * /usr/local/lib/mc_robots/
+   *
+   * The value is stored in a thread_local variable and is meant to be used in the constructor of RobotModule
+   */
+  static void set_loading_location(std::string_view location);
+  inline const std::string & get_loading_location() const noexcept { return loading_location_; }
+
 protected:
   /*! \brief Add observer from logger
    *
@@ -195,6 +204,7 @@ protected:
   virtual void removeFromGUI(mc_rtc::gui::StateBuilder &, const std::vector<std::string> & category);
 
 protected:
+  std::string loading_location_; ///< Path to the folder containing the observer library
   std::string name_; ///< Observer name
   std::string type_; ///< Observer type
   std::string desc_; ///< Short description of the observer and its configuration

--- a/include/mc_rbdyn/RobotModule.h
+++ b/include/mc_rbdyn/RobotModule.h
@@ -776,7 +776,7 @@ public:
    * The value is stored in a thread_local variable and is meant to be used in the constructor of RobotModule
    */
   static void set_loading_location(std::string_view location);
-  inline std::string_view get_loading_location() const noexcept { return loading_location_; }
+  inline const std::string & get_loading_location() const noexcept { return loading_location_; }
 
   /* Path to the folder containing the robot module library */
   std::string loading_location_;

--- a/include/mc_rbdyn/RobotModule.h
+++ b/include/mc_rbdyn/RobotModule.h
@@ -251,11 +251,7 @@ struct MC_RBDYN_DLLAPI RobotModule
    *
    * \param urdf_path Path to the robot URDF
    */
-  RobotModule(const std::string & path, const std::string & name, const std::string & urdf_path)
-  : path(path), name(name), urdf_path(urdf_path), convex_dir(""), rsdf_dir(path + "/rsdf/" + name),
-    calib_dir(path + "/calib/" + name), _real_urdf(urdf_path)
-  {
-  }
+  RobotModule(const std::string & path, const std::string & name, const std::string & urdf_path);
 
   /** Construct from a parser result */
   RobotModule(const std::string & name, const rbd::parsers::ParserResult & res);
@@ -773,6 +769,17 @@ struct MC_RBDYN_DLLAPI RobotModule
   inline const std::vector<FrameDescription> & frames() const noexcept { return _frames; }
 
 public:
+  /** Called by \ref mc_rtc::ObjectLoader to inform the robot module of its loading location
+   * For example, if the JVRC1 module is loaded from the library in /usr/local/lib/mc_robots/jvrc1.so then this is
+   * /usr/local/lib/mc_robots/
+   *
+   * The value is stored in a thread_local variable and is meant to be used in the constructor of RobotModule
+   */
+  static void set_loading_location(std::string_view location);
+  inline std::string_view get_loading_location() const noexcept { return loading_location_; }
+
+  /* Path to the folder containing the robot module library */
+  std::string loading_location_;
   /** Path to the robot's description package */
   std::string path;
   /** (default) Name of the robot */

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -1105,14 +1105,17 @@ mc_rtc::Configuration MCController::robot_config(const std::string & robot) cons
 {
   mc_rtc::Configuration result;
 
-  // First try to load robot-specific path from the robot module's folder
+  // Controller's per-robot controller configuration
+  // These are installed under
+  //    <controller library folder>/etc/<controller name>/<robot name>.[conf|yaml|yml]
+  fs::path controller_system_path = fs::path(loading_location_) / this->name_ / (robot + ".conf");
+
+  // Robot module's per-robot controller configuration
+  // These are installed by the robot module under
+  //    <robot module library folder>/etc/controllers/<controller name>/<robot name>.[conf|yaml|yml]
   const auto & rm = this->robot(robot).module();
   auto robot_module_system_path =
       fs::path{rm.get_loading_location()} / "etc" / "controllers" / this->name_ / (robot + ".conf");
-  // Legacy fallback: look for the controller-specific configuration file in the controller's library's install folder.
-  // This is impossible in Nix as it would imply that the robot module installs the robot-specific controller
-  // configurations into the controller's install path (forbidden).
-  fs::path controller_system_path = fs::path(loading_location_) / this->name_ / (robot + ".conf");
   fs::path user_path = mc_rtc::user_config_directory_path("controllers");
   user_path = user_path / name_ / (robot + ".conf");
   auto load_conf = [&result](const std::string & path)
@@ -1141,16 +1144,11 @@ mc_rtc::Configuration MCController::robot_config(const std::string & robot) cons
     }
     return false;
   };
-  if(!load_conf_or_yaml(robot_module_system_path))
-  {
-    // Try fallback if we did not find it in the robot module path
-    if(load_conf_or_yaml(controller_system_path))
-    {
-      mc_rtc::log::deprecated(
-          "MCController::robot_config", "Loading robot configuration from controller's install path is deprecated.",
-          fmt::format("Please move the configuration to the robot module's etc/controllers/{} folder.", name_));
-    }
-  }
+  // Load per-robot controller config from the robot module
+  load_conf_or_yaml(robot_module_system_path);
+  // Merge with controller's per-robot config
+  load_conf_or_yaml(controller_system_path);
+  // Merge with user config
   load_conf_or_yaml(user_path);
   return result;
 }

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -1104,7 +1104,15 @@ mc_rtc::Configuration MCController::robot_config(const mc_rbdyn::Robot & robot) 
 mc_rtc::Configuration MCController::robot_config(const std::string & robot) const
 {
   mc_rtc::Configuration result;
-  fs::path system_path = fs::path(loading_location_) / this->name_ / (robot + ".conf");
+
+  // First try to load robot-specific path from the robot module's folder
+  const auto & rm = this->robot(robot).module();
+  auto robot_module_system_path =
+      fs::path{rm.get_loading_location()} / "etc" / "controllers" / this->name_ / (robot + ".conf");
+  // Legacy fallback: look for the controller-specific configuration file in the controller's library's install folder.
+  // This is impossible in Nix as it would imply that the robot module installs the robot-specific controller
+  // configurations into the controller's install path (forbidden).
+  fs::path controller_system_path = fs::path(loading_location_) / this->name_ / (robot + ".conf");
   fs::path user_path = mc_rtc::user_config_directory_path("controllers");
   user_path = user_path / name_ / (robot + ".conf");
   auto load_conf = [&result](const std::string & path)
@@ -1114,13 +1122,35 @@ mc_rtc::Configuration MCController::robot_config(const std::string & robot) cons
   };
   auto load_conf_or_yaml = [&load_conf](fs::path & in)
   {
-    if(fs::exists(in)) { return load_conf(in.string()); }
+    if(fs::exists(in))
+    {
+      load_conf(in.string());
+      return true;
+    }
     in.replace_extension(".yaml");
-    if(fs::exists(in)) { return load_conf(in.string()); }
+    if(fs::exists(in))
+    {
+      load_conf(in.string());
+      return true;
+    }
     in.replace_extension(".yml");
-    if(fs::exists(in)) { return load_conf(in.string()); }
+    if(fs::exists(in))
+    {
+      load_conf(in.string());
+      return true;
+    }
+    return false;
   };
-  load_conf_or_yaml(system_path);
+  if(!load_conf_or_yaml(robot_module_system_path))
+  {
+    // Try fallback if we did not find it in the robot module path
+    if(load_conf_or_yaml(controller_system_path))
+    {
+      mc_rtc::log::deprecated(
+          "MCController::robot_config", "Loading robot configuration from controller's install path is deprecated.",
+          fmt::format("Please move the configuration to the robot module's etc/controllers/{} folder.", name_));
+    }
+  }
   load_conf_or_yaml(user_path);
   return result;
 }

--- a/src/mc_observers/Observer.cpp
+++ b/src/mc_observers/Observer.cpp
@@ -1,11 +1,23 @@
 /*
- * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ * Copyright 2015-2026 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
 #include <mc_observers/Observer.h>
 
 namespace mc_observers
 {
+
+static thread_local std::string MC_OBSERVER_MODULE_LOADING_LOCATION = "";
+
+void Observer::set_loading_location(std::string_view location)
+{
+  MC_OBSERVER_MODULE_LOADING_LOCATION = location;
+}
+
+Observer::Observer(const std::string & type, double dt)
+: loading_location_(MC_OBSERVER_MODULE_LOADING_LOCATION), type_(type), dt_(dt)
+{
+}
 
 void Observer::removeFromGUI(mc_rtc::gui::StateBuilder & gui, const std::vector<std::string> & category)
 {

--- a/src/mc_observers/ObserverPipeline.cpp
+++ b/src/mc_observers/ObserverPipeline.cpp
@@ -35,18 +35,30 @@ static inline void load_config(mc_rtc::Configuration & out, const std::string & 
 }
 
 static inline mc_rtc::Configuration get_observer_config(const std::string & observerType,
-                                                        const std::string & robot,
+                                                        const mc_observers::Observer & observer,
+                                                        const mc_rbdyn::RobotModule & rm,
                                                         mc_rtc::Configuration config)
 {
+  const auto & robot = rm.name;
   mc_rtc::Configuration out;
   // Load observer configuration
-  auto runtime_dir = mc_observers::ObserverLoader::get_observer_runtime_directory(observerType);
-  if(!runtime_dir.empty()) { load_config(out, runtime_dir + "/etc", observerType); }
+  auto observers_runtime_dir = observer.get_loading_location();
+  // Load default observer's configuration
+  load_config(out, observers_runtime_dir + "/etc", observerType);
+
+  // Load robot specific configuration in the observer's runtime path
+  load_config(out, observers_runtime_dir + "/" + observerType, robot);
+
+  const auto & rm_runtime_dir = rm.get_loading_location();
+  // Load robot specific configuration in the robot module's runtime path
+  load_config(out, rm_runtime_dir + "/etc/observers", observerType);
+
+  // Load user configuration
   fs::path user_path = mc_rtc::user_config_directory_path("observers");
   load_config(out, user_path.string(), observerType);
-  // Load robot specific configuration
-  if(!runtime_dir.empty()) { load_config(out, runtime_dir + "/" + observerType, robot); }
+  // Load user's per-robot configuration
   load_config(out, (user_path / observerType).string(), robot);
+
   // Finally load the configuration provided in the pipeline
   out.load(config);
   return out;
@@ -96,8 +108,13 @@ void ObserverPipeline::create(const mc_rtc::Configuration & config, double dt)
       // override deprecated "config" object if provided in the new format
       config.load(observerConf);
       std::string robot = config("robot", ctl_.robot().name());
-      if(ctl_.hasRobot(robot)) { robot = ctl_.robot(robot).module().name; }
-      observer->configure(ctl_, get_observer_config(observerType, robot, config));
+      if(!ctl_.hasRobot(robot))
+      {
+        mc_rtc::log::error_and_throw("[ObserverPipeline::{}] Observer {} requires robot {} but it is not available",
+                                     name_, observerName, robot);
+      }
+      auto & rm = ctl_.robot(robot).module();
+      observer->configure(ctl_, get_observer_config(observerType, *observer, rm, config));
       pipelineObservers_.emplace_back(observer, observerConf);
     }
     else if(!observerConf("required", true))

--- a/src/mc_rbdyn/RobotModule.cpp
+++ b/src/mc_rbdyn/RobotModule.cpp
@@ -15,6 +15,13 @@ namespace fs = std::filesystem;
 namespace mc_rbdyn
 {
 
+static thread_local std::string MC_ROBOT_MODULE_LOADING_LOCATION = "";
+
+void RobotModule::set_loading_location(std::string_view location)
+{
+  MC_ROBOT_MODULE_LOADING_LOCATION = location;
+}
+
 // Repeat static constexpr declarations
 // See also https://stackoverflow.com/q/8016780
 constexpr double RobotModule::Gripper::Safety::DEFAULT_PERCENT_VMAX;
@@ -42,6 +49,12 @@ RobotModule::RobotModule(const std::string & name, const rbd::parsers::ParserRes
   rsdf_dir = "";
   convex_dir = "";
   init(res);
+}
+
+RobotModule::RobotModule(const std::string & path, const std::string & name, const std::string & urdf_path)
+: loading_location_(MC_ROBOT_MODULE_LOADING_LOCATION), path(path), name(name), urdf_path(urdf_path), convex_dir(""),
+  rsdf_dir(path + "/rsdf/" + name), calib_dir(path + "/calib/" + name), _real_urdf(urdf_path)
+{
 }
 
 void RobotModule::init(const rbd::parsers::ParserResult & res)

--- a/src/mc_rtcMacros.in.cmake
+++ b/src/mc_rtcMacros.in.cmake
@@ -251,7 +251,7 @@ endif()
 #
 # For each controller or observer subfolder, if <ROBOT>.yaml exists, it will be
 # installed to the appropriate destination under the install prefix.
-macro(install_robot_specific_configurations ROBOT ETC_FOLDER)
+macro(install_robot_specific_configurations ROBOT)
   if(${ARGC} GREATER 1)
     set(ETC_FOLDER "${ARGV1}")
   else()

--- a/src/mc_rtcMacros.in.cmake
+++ b/src/mc_rtcMacros.in.cmake
@@ -236,6 +236,62 @@ else()
   set(MC_ROBOTS_USER_ALIASES_DIRECTORY "$ENV{HOME}/.config/mc_rtc/aliases/")
 endif()
 
+# Macro: install_robot_specific_configurations
+# ----------------------------------------
+# Installs a robot-specific config files (named <ROBOT>.yaml) from controllers/ and observers/
+# subfolders located in the specified ETC_FOLDER. If ETC_FOLDER is not provided or is
+# empty, defaults to the current source directory (${CMAKE_CURRENT_SOURCE_DIR}).
+#
+# Usage:
+#   install_config_files(ROBOT [ETC_FOLDER])
+#
+# Example:
+#   install_config_files(hrp4)                       # Installs hrp4.yaml from current source directory
+#   install_config_files(jvrc1 path/to/etc)          # Installs jvrc1.yaml from specified etc folder
+#
+# For each controller or observer subfolder, if <ROBOT>.yaml exists, it will be
+# installed to the appropriate destination under the install prefix.
+macro(install_robot_specific_configurations ROBOT ETC_FOLDER)
+  if(${ARGC} GREATER 1)
+    set(ETC_FOLDER "${ARGV1}")
+  else()
+    set(ETC_FOLDER "${CMAKE_CURRENT_SOURCE_DIR}")
+  endif()
+  set(CONFIG_FILE "${ROBOT}.yaml")
+  if(EXISTS "${ETC_FOLDER}/controllers")
+    file(
+      GLOB CONTROLLERS
+      RELATIVE "${ETC_FOLDER}/controllers"
+      "${ETC_FOLDER}/controllers/*"
+    )
+    foreach(CTL ${CONTROLLERS})
+      if(EXISTS "${ETC_FOLDER}/controllers/${CTL}/${CONFIG_FILE}")
+        install(
+          FILES "${ETC_FOLDER}/controllers/${CTL}/${CONFIG_FILE}"
+          DESTINATION
+            "${MC_ROBOTS_RUNTIME_INSTALL_PREFIX}$<$<CONFIG:debug>:${MC_RTC_LOADER_DEBUG_SUFFIX}>/etc/controllers/${CTL}"
+        )
+      endif()
+    endforeach()
+  endif()
+  if(EXISTS "${ETC_FOLDER}/observers")
+    file(
+      GLOB OBSERVERS
+      RELATIVE "${ETC_FOLDER}/observers"
+      "${ETC_FOLDER}/observers/*"
+    )
+    foreach(OBS ${OBSERVERS})
+      if(EXISTS "${ETC_FOLDER}/observers/${OBS}/${CONFIG_FILE}")
+        install(
+          FILES "${ETC_FOLDER}/observers/${OBS}/${CONFIG_FILE}"
+          DESTINATION
+            "${MC_ROBOTS_RUNTIME_INSTALL_PREFIX}$<$<CONFIG:debug>:${MC_RTC_LOADER_DEBUG_SUFFIX}>/etc/observers/${OBS}"
+        )
+      endif()
+    endforeach()
+  endif()
+endmacro()
+
 # -- Observers --
 mc_rtc_set_prefix(OBSERVERS mc_observers)
 


### PR DESCRIPTION
The core of the issue is that currently, robot-specific configurations for the controller and observers are installed in
- `<MC_RTC_RUNTIME_INSTALL_PREFIX>/mc_controllers/<controller name>/<robot>.yaml`
- `<MC_RTC_RUNTIME_INSTALL_PREFIX>/mc_observers/<observer name>/<robot>.yaml`

Currently these files are installed either by:
- mc_rtc itself
- a controller's repository (e.g lipm_walking_controller)
- an observers's repository (e.g mc_state_observation)
- a robot module can install both the controller's and observer's robot-specific configurations.

So far we have always relied on the fact that we have a single global install tree such that `MC_RTC_RUNTIME_INSTALL_PREFIX` always point to where mc_rtc was installed (e.g `/usr/local/lib/mc_controllers|mc_observers`). This is what happens with `MC_RTC_HONOUR_INSTALL_PREFIX=OFF` (the default).

**However Nix changes that**.  By definition each package is built in isolation, and cannot be installed into the install path of another library (mc_rtc's). This is why we introduced `MC_RTC_HONOUR_INSTALL_PREFIX=ON` that installs each runtime dependency (plugin/controller/observer/robot module) into it's own install prefix. This means that :
- a robot-specific controller file created in a controller/observer's repository will be installed in that controller/observer install prefix (as opposed to mc_rtc's)
- a robot module installs its robot-specific controller/observer configuration in its own prefix.

Thus we need mc_rtc to load, robot-specific configuration provided in the robot module/controller/observer's install prefixes. This PR:
- adds a mechanism to get the path to the installed library folder for both observers and robot modules.
- and load robot-specific configuration from there.
- adds a convenience macro to install both controller/observer specific configuration from a robot module.
- Paths loading order is documented in the tutorials/doxygen.