### PR TITLE
fix: request filesystem as an explicit Boost component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,7 +184,7 @@ if(BOOST_STACKTRACE STREQUAL "")
   )
 endif()
 
-add_project_dependency(Boost REQUIRED COMPONENTS timer ${BOOST_STACKTRACE})
+add_project_dependency(Boost REQUIRED COMPONENTS filesystem timer ${BOOST_STACKTRACE})
 add_project_dependency(Tasks REQUIRED)
 add_project_dependency(TVM REQUIRED)
 if(NOT TARGET RBDyn::Parsers)


### PR DESCRIPTION
\`src/mc_rtc/path.cpp\` and \`include/mc_rtc/path.h\` use \`boost::filesystem\` directly, but it's never requested as a Boost component — only \`timer\`/\`stacktrace_*\` are.

This worked by accident under the legacy \`FindBoost\` CMake module, which tended to pull \`filesystem\` in regardless. Boost's own CMake config package (used now that \`FindBoost\` is removed, CMake policy \`CMP0167\`) doesn't do that implicitly: downstream builds get undefined \`boost::filesystem::detail::dir_itr_imp\` symbols at final link time instead of mc_rtc itself failing to build.

Fix: add \`filesystem\` to the requested components.