### PR TITLE
DistanceConstraint

### DIFF
--- a/binding/python/mc_control/c_mc_control.pxd
+++ b/binding/python/mc_control/c_mc_control.pxd
@@ -78,7 +78,7 @@ cdef extern from "<mc_control/mc_controller.h>" namespace "mc_control":
     unique_ptr[ContactConstraint] contactConstraint
     unique_ptr[DynamicsConstraint] dynamicsConstraint
     unique_ptr[KinematicsConstraint] kinematicsConstraint
-    unique_ptr[CollisionsConstraint] selfCollisionConstraint
+    unique_ptr[DistanceConstraint] selfCollisionConstraint
     shared_ptr[c_mc_tasks.PostureTask] postureTask
     QPSolver & solver()
 

--- a/binding/python/mc_control/c_mc_control.pxd
+++ b/binding/python/mc_control/c_mc_control.pxd
@@ -88,10 +88,10 @@ cdef extern from "<mc_control/mc_controller.h>" namespace "mc_control":
     vector[c_mc_observers.ObserverPipeline] & observerPipelines()
 
     void addCollisions(const string&, const string&,
-                       const vector[Collision] &)
+                       const vector[DistanceLimit] &)
     void removeCollisions(const string&, const string&)
     void removeCollisions(const string&, const string&,
-                          const vector[Collision] &)
+                          const vector[DistanceLimit] &)
     cppbool hasRobot(const string&)
     Robot& robot(const string&)
     void addContact(const Contact&)

--- a/binding/python/mc_control/mc_control.pyx
+++ b/binding/python/mc_control/mc_control.pyx
@@ -183,17 +183,17 @@ cdef class MCController(object):
       preinc(it)
     return ret
   def addCollisions(self, r1, r2, collisions):
-    assert(all([isinstance(col, mc_rbdyn.Collision) for col in collisions]))
-    cdef vector[c_mc_rbdyn.Collision] cols
+    assert(all([isinstance(col, mc_rbdyn.DistanceLimit) for col in collisions]))
+    cdef vector[c_mc_rbdyn.DistanceLimit] cols
     if isinstance(r1, unicode):
       r1 = r1.encode(u'ascii')
     if isinstance(r2, unicode):
       r2 = r2.encode(u'ascii')
     for col in collisions:
-      cols.push_back((<mc_rbdyn.Collision>col).impl)
+      cols.push_back((<mc_rbdyn.DistanceLimit>col).impl)
     self.base.addCollisions(r1, r2, cols)
   def removeCollisions(self, r1, r2, collisions = None):
-    cdef vector[c_mc_rbdyn.Collision] cols
+    cdef vector[c_mc_rbdyn.DistanceLimit] cols
     if isinstance(r1, unicode):
       r1 = r1.encode(u'ascii')
     if isinstance(r2, unicode):
@@ -202,7 +202,7 @@ cdef class MCController(object):
       self.base.removeCollisions(r1, r2)
     else:
       for col in collisions:
-        cols.push_back((<mc_rbdyn.Collision>col).impl)
+        cols.push_back((<mc_rbdyn.DistanceLimit>col).impl)
       self.base.removeCollisions(r1, r2, cols)
   def hasRobot(self, name):
     if isinstance(name, unicode):

--- a/binding/python/mc_control/mc_control.pyx
+++ b/binding/python/mc_control/mc_control.pyx
@@ -156,7 +156,7 @@ cdef class MCController(object):
       return mc_solver.KinematicsConstraintFromPtr(self.base.kinematicsConstraint.get())
   property selfCollisionConstraint:
     def __get__(self):
-      return mc_solver.CollisionsConstraintFromPtr(self.base.selfCollisionConstraint.get())
+      return mc_solver.DistanceConstraintFromPtr(self.base.selfCollisionConstraint.get())
   property postureTask:
     def __get__(self):
       return mc_tasks.PostureTaskFromPtr(self.base.postureTask.get())

--- a/binding/python/mc_rbdyn/c_mc_rbdyn.pxd
+++ b/binding/python/mc_rbdyn/c_mc_rbdyn.pxd
@@ -39,6 +39,23 @@ cdef extern from "<mc_rbdyn/Collision.h>" namespace "mc_rbdyn":
     cppbool operator==(const Collision&)
     cppbool operator!=(const Collision&)
 
+cdef extern from "<mc_rbdyn/DistanceLimit.h>" namespace "mc_rbdyn":
+  cdef cppclass DistanceLimit:
+    DistanceLimit()
+    DistanceLimit(const string&, const string&, double, double, double)
+    DistanceLimit(const DistanceLimit&)
+
+    cppbool isNone()
+
+    string body1
+    string body2
+    double iDist
+    double sDist
+    double damping
+
+    cppbool operator==(const DistanceLimit&)
+    cppbool operator!=(const DistanceLimit&)
+
 cdef extern from "<mc_rbdyn/BodySensor.h>" namespace "mc_rbdyn":
   cdef cppclass BodySensor:
     BodySensor()
@@ -106,8 +123,8 @@ cdef extern from "<mc_rbdyn/RobotModule.h>" namespace "mc_rbdyn":
     vector[Flexibility] _flexibility
     vector[ForceSensor] _forceSensors
     const Springs & springs()
-    vector[Collision] _minimalSelfCollisions
-    vector[Collision] _commonSelfCollisions
+    vector[DistanceLimit] _minimalSelfCollisions
+    vector[DistanceLimit] _commonSelfCollisions
     const vector[string]& ref_joint_order()
     map[string, vector[Visual]] _visual
     map[string, vector[Visual]] _collision

--- a/binding/python/mc_rbdyn/c_mc_rbdyn.pxd
+++ b/binding/python/mc_rbdyn/c_mc_rbdyn.pxd
@@ -119,7 +119,7 @@ cdef extern from "<mc_rbdyn/RobotModule.h>" namespace "mc_rbdyn":
     const map[string, vector[double]] & stance()
     const map[string, pair[string, string]] & convexHull()
     const map[string, pair[string, string]] & stpbvHull()
-    map[string, PTransformd] _collisionTransforms
+    map[string, PTransformd] _convexTransforms
     vector[Flexibility] _flexibility
     vector[ForceSensor] _forceSensors
     const Springs & springs()
@@ -225,7 +225,7 @@ cdef extern from "<mc_rbdyn/Robot.h>" namespace "mc_rbdyn":
 
     const PTransformd& bodyTransform(const string&)
 
-    const PTransformd& collisionTransform(const string&)
+    const PTransformd& convexTransform(const string&)
 
     void loadRSDFFromDir(string)
 

--- a/binding/python/mc_rbdyn/mc_rbdyn.pxd
+++ b/binding/python/mc_rbdyn/mc_rbdyn.pxd
@@ -18,6 +18,11 @@ cdef class Collision(object):
 
 cdef Collision CollisionFromC(const c_mc_rbdyn.Collision&)
 
+cdef class DistanceLimit(object):
+  cdef c_mc_rbdyn.DistanceLimit impl
+
+cdef DistanceLimit DistanceLimitFromC(const c_mc_rbdyn.DistanceLimit&)
+
 cdef class BodySensor(object):
   cdef cppbool own_impl__
   cdef const c_mc_rbdyn.BodySensor * impl

--- a/binding/python/mc_rbdyn/mc_rbdyn.pyx
+++ b/binding/python/mc_rbdyn/mc_rbdyn.pyx
@@ -110,6 +110,11 @@ cdef Collision CollisionFromC(const c_mc_rbdyn.Collision & col):
   ret.impl = c_mc_rbdyn.Collision(col)
   return ret
 
+cdef DistanceLimit DistanceLimitFromC(const c_mc_rbdyn.DistanceLimit & col):
+  cdef DistanceLimit ret = DistanceLimit()
+  ret.impl = c_mc_rbdyn.DistanceLimit(col)
+  return ret
+
 cdef class Flexibility(object):
   def __cinit__(self, *args):
     if len(args) == 4:
@@ -351,7 +356,7 @@ cdef class RobotModule(object):
     it = deref(self.impl)._minimalSelfCollisions.begin()
     ret = []
     while it != end:
-      ret.append(CollisionFromC(deref(it)))
+      ret.append(DistanceLimitFromC(deref(it)))
       preinc(it)
     return ret
   def commonSelfCollisions(self):
@@ -360,7 +365,7 @@ cdef class RobotModule(object):
     it = deref(self.impl)._commonSelfCollisions.begin()
     ret = []
     while it != end:
-      ret.append(CollisionFromC(deref(it)))
+      ret.append(DistanceLimitFromC(deref(it)))
       preinc(it)
     return ret
   def ref_joint_order(self):

--- a/binding/python/mc_rbdyn/mc_rbdyn.pyx
+++ b/binding/python/mc_rbdyn/mc_rbdyn.pyx
@@ -313,10 +313,10 @@ cdef class RobotModule(object):
   def stpbvHull(self):
     assert(self.impl.get())
     return deref(self.impl).stpbvHull()
-  def collisionTransforms(self):
+  def convexTransforms(self):
     assert(self.impl.get())
-    end = deref(self.impl)._collisionTransforms.end()
-    it = deref(self.impl)._collisionTransforms.begin()
+    end = deref(self.impl)._convexTransforms.end()
+    it = deref(self.impl)._convexTransforms.begin()
     ret = {}
     while it != end:
       ret[deref(it).first] = sva.PTransformdFromC(deref(it).second)
@@ -812,11 +812,11 @@ cdef class Robot(object):
       bName = bName.encode(u'ascii')
     return sva.PTransformdFromC(self.impl.bodyTransform(bName), False)
 
-  def collisionTransform(self, bName):
+  def convexTransform(self, bName):
     self.__is_valid()
     if isinstance(bName, unicode):
       bName = bName.encode(u'ascii')
-    return sva.PTransformdFromC(self.impl.collisionTransform(bName), False)
+    return sva.PTransformdFromC(self.impl.convexTransform(bName), False)
 
   def loadRSDFFromDir(self, surfaceDir):
     self.__is_valid()

--- a/binding/python/mc_solver/c_mc_solver.pxd
+++ b/binding/python/mc_solver/c_mc_solver.pxd
@@ -7,7 +7,7 @@ from sva.c_sva cimport *
 from rbdyn.c_rbdyn cimport *
 cimport sch.c_sch as sch
 cimport tasks.qp.c_qp as c_qp
-from mc_rbdyn.c_mc_rbdyn cimport Robots, Collision
+from mc_rbdyn.c_mc_rbdyn cimport Robots, Collision, DistanceLimit
 cimport mc_rbdyn.c_mc_rbdyn as c_mc_rbdyn
 cimport mc_tasks.c_mc_tasks as c_mc_tasks
 
@@ -62,13 +62,13 @@ cdef extern from "<mc_solver/CollisionsConstraint.h>" namespace "mc_solver":
 
     cppbool removeCollision(const QPSolver&, string, string)
     cppbool removeCollisionByBody(const QPSolver&, string, string)
-    void addCollision(const QPSolver&, const Collision&) except+
-    void addCollisions(const QPSolver& robots, const vector[Collision]&)
+    void addCollision(const QPSolver&, const DistanceLimit&) except+
+    void addCollisions(const QPSolver& robots, const vector[DistanceLimit]&)
     void reset()
 
     unsigned int r1Index
     unsigned int r2Index
-    vector[Collision] cols
+    vector[DistanceLimit] cols
 
 cdef extern from "<mc_solver/DistanceConstraint.h>" namespace "mc_solver":
   cdef double DistanceConstraintDefaultDampingOffset "mc_solver::DistanceConstraint::defaultDampingOffset"
@@ -76,15 +76,15 @@ cdef extern from "<mc_solver/DistanceConstraint.h>" namespace "mc_solver":
   cdef cppclass DistanceConstraint(ConstraintSet):
     DistanceConstraint(const Robots&, unsigned int, unsigned int, double)
 
-    cppbool removeCollision(const QPSolver&, const Collision&)
-    cppbool removeCollisionByBody(const QPSolver&, string, string)
-    void addCollision(const QPSolver&, const Collision&) except+
-    void addCollisions(const QPSolver& robots, const vector[Collision]&)
+    cppbool removeDistanceLimit(const QPSolver&, const DistanceLimit&)
+    cppbool removeDistanceLimitByBody(const QPSolver&, string, string)
+    void addDistanceLimit(const QPSolver&, const DistanceLimit&) except+
+    void addDistanceLimits(const QPSolver& robots, const vector[DistanceLimit]&)
     void reset()
 
     unsigned int r1Index
     unsigned int r2Index
-    vector[Collision] cols
+    vector[DistanceLimit] dls
 
 cdef extern from "<mc_solver/TasksQPSolver.h>" namespace "mc_solver":
   cdef cppclass QPSolver:

--- a/binding/python/mc_solver/c_mc_solver.pxd
+++ b/binding/python/mc_solver/c_mc_solver.pxd
@@ -70,6 +70,22 @@ cdef extern from "<mc_solver/CollisionsConstraint.h>" namespace "mc_solver":
     unsigned int r2Index
     vector[Collision] cols
 
+cdef extern from "<mc_solver/DistanceConstraint.h>" namespace "mc_solver":
+  cdef double DistanceConstraintDefaultDampingOffset "mc_solver::DistanceConstraint::defaultDampingOffset"
+
+  cdef cppclass DistanceConstraint(ConstraintSet):
+    DistanceConstraint(const Robots&, unsigned int, unsigned int, double)
+
+    cppbool removeCollision(const QPSolver&, const Collision&)
+    cppbool removeCollisionByBody(const QPSolver&, string, string)
+    void addCollision(const QPSolver&, const Collision&) except+
+    void addCollisions(const QPSolver& robots, const vector[Collision]&)
+    void reset()
+
+    unsigned int r1Index
+    unsigned int r2Index
+    vector[Collision] cols
+
 cdef extern from "<mc_solver/TasksQPSolver.h>" namespace "mc_solver":
   cdef cppclass QPSolver:
     void addConstraintSet(const ConstraintSet&)

--- a/binding/python/mc_solver/mc_solver.pxd
+++ b/binding/python/mc_solver/mc_solver.pxd
@@ -32,6 +32,12 @@ cdef class CollisionsConstraint(ConstraintSet):
 
 cdef CollisionsConstraint CollisionsConstraintFromPtr(c_mc_solver.CollisionsConstraint*)
 
+cdef class DistanceConstraint(ConstraintSet):
+  cdef c_mc_solver.DistanceConstraint * impl
+  cdef cppbool own_impl__
+
+cdef DistanceConstraint DistanceConstraintFromPtr(c_mc_solver.DistanceConstraint*)
+
 cdef class QPSolver(object):
   cdef c_mc_solver.QPSolver * impl
   cdef cppbool own_impl__

--- a/binding/python/mc_solver/mc_solver.pyx
+++ b/binding/python/mc_solver/mc_solver.pyx
@@ -152,6 +152,52 @@ cdef CollisionsConstraint CollisionsConstraintFromPtr(c_mc_solver.CollisionsCons
     ret.impl = ret.cs_base = p
     return ret
 
+cdef class DistanceConstraint(ConstraintSet):
+  defaultDampingOffset = c_mc_solver.DistanceConstraintDefaultDampingOffset
+  def __dealloc__(self):
+    if self.own_impl__:
+      del self.impl
+  def __cinit__(self, mc_rbdyn.Robots robots, r1Index, r2Index, timeStep, skip_alloc = False):
+    self.own_impl__ = True
+    if not skip_alloc:
+      self.impl = self.cs_base = new c_mc_solver.DistanceConstraint(deref(robots.impl), r1Index, r2Index, timeStep)
+  def removeCollision(self, QPSolver solver, mc_rbdyn.Collision col):
+    return self.impl.removeCollision(deref(solver.impl), col.impl)
+  def removeCollisionByBody(self, QPSolver solver, b1Name, b2Name):
+    if isinstance(b1Name, unicode):
+        b1Name = b1Name.encode(u'ascii')
+    if isinstance(b2Name, unicode):
+        b2Name = b2Name.encode(u'ascii')
+    return self.impl.removeCollisionByBody(deref(solver.impl), b1Name, b2Name)
+  def addCollision(self, QPSolver solver, mc_rbdyn.Collision col):
+    self.impl.addCollision(deref(solver.impl), col.impl)
+  def addCollisions(self, QPSolver solver, cols):
+    for c in cols:
+      self.addCollision(solver, c)
+  def reset(self):
+    self.impl.reset()
+  property r1Index:
+    def __get__(self):
+      return self.impl.r1Index
+  property r2Index:
+    def __get__(self):
+      return self.impl.r2Index
+  property cols:
+    def __get__(self):
+      end = deref(self.impl).cols.end()
+      it = deref(self.impl).cols.begin()
+      ret = []
+      while it != end:
+        ret.append(mc_rbdyn.CollisionFromC(deref(it)))
+        preinc(it)
+      return ret
+
+cdef DistanceConstraint DistanceConstraintFromPtr(c_mc_solver.DistanceConstraint * p):
+    cdef DistanceConstraint ret = DistanceConstraint(None, None, None, None, skip_alloc = True)
+    ret.own_impl__ = False
+    ret.impl = ret.cs_base = p
+    return ret
+
 cdef qp.BilateralContact BilateralContactFromC(const c_qp.BilateralContact & bc):
   cdef qp.BilateralContact ret = qp.BilateralContact()
   ret.impl = bc

--- a/binding/python/mc_solver/mc_solver.pyx
+++ b/binding/python/mc_solver/mc_solver.pyx
@@ -123,7 +123,7 @@ cdef class CollisionsConstraint(ConstraintSet):
     if isinstance(b2Name, unicode):
         b2Name = b2Name.encode(u'ascii')
     return self.impl.removeCollisionByBody(deref(solver.impl), b1Name, b2Name)
-  def addCollision(self, QPSolver solver, mc_rbdyn.Collision col):
+  def addCollision(self, QPSolver solver, mc_rbdyn.DistanceLimit col):
     self.impl.addCollision(deref(solver.impl), col.impl)
   def addCollisions(self, QPSolver solver, cols):
     for c in cols:
@@ -142,7 +142,7 @@ cdef class CollisionsConstraint(ConstraintSet):
       it = deref(self.impl).cols.begin()
       ret = []
       while it != end:
-        ret.append(mc_rbdyn.CollisionFromC(deref(it)))
+        ret.append(mc_rbdyn.DistanceLimitFromC(deref(it)))
         preinc(it)
       return ret
 
@@ -161,19 +161,19 @@ cdef class DistanceConstraint(ConstraintSet):
     self.own_impl__ = True
     if not skip_alloc:
       self.impl = self.cs_base = new c_mc_solver.DistanceConstraint(deref(robots.impl), r1Index, r2Index, timeStep)
-  def removeCollision(self, QPSolver solver, mc_rbdyn.Collision col):
-    return self.impl.removeCollision(deref(solver.impl), col.impl)
-  def removeCollisionByBody(self, QPSolver solver, b1Name, b2Name):
+  def removeDistanceLimit(self, QPSolver solver, mc_rbdyn.DistanceLimit col):
+    return self.impl.removeDistanceLimit(deref(solver.impl), col.impl)
+  def removeDistanceLimitByBody(self, QPSolver solver, b1Name, b2Name):
     if isinstance(b1Name, unicode):
         b1Name = b1Name.encode(u'ascii')
     if isinstance(b2Name, unicode):
         b2Name = b2Name.encode(u'ascii')
-    return self.impl.removeCollisionByBody(deref(solver.impl), b1Name, b2Name)
-  def addCollision(self, QPSolver solver, mc_rbdyn.Collision col):
-    self.impl.addCollision(deref(solver.impl), col.impl)
-  def addCollisions(self, QPSolver solver, cols):
+    return self.impl.removeDistanceLimitByBody(deref(solver.impl), b1Name, b2Name)
+  def addDistanceLimit(self, QPSolver solver, mc_rbdyn.DistanceLimit col):
+    self.impl.addDistanceLimit(deref(solver.impl), col.impl)
+  def addDistanceLimits(self, QPSolver solver, cols):
     for c in cols:
-      self.addCollision(solver, c)
+      self.addDistanceLimits(solver, c)
   def reset(self):
     self.impl.reset()
   property r1Index:
@@ -182,13 +182,13 @@ cdef class DistanceConstraint(ConstraintSet):
   property r2Index:
     def __get__(self):
       return self.impl.r2Index
-  property cols:
+  property dls:
     def __get__(self):
-      end = deref(self.impl).cols.end()
-      it = deref(self.impl).cols.begin()
+      end = deref(self.impl).dls.end()
+      it = deref(self.impl).dls.begin()
       ret = []
       while it != end:
-        ret.append(mc_rbdyn.CollisionFromC(deref(it)))
+        ret.append(mc_rbdyn.DistanceLimitFromC(deref(it)))
         preinc(it)
       return ret
 

--- a/doc/_data/schemas/ConstraintSet/DistanceConstraint.json
+++ b/doc/_data/schemas/ConstraintSet/DistanceConstraint.json
@@ -1,0 +1,38 @@
+{
+  "title": "mc_solver::DistanceConstraint",
+  "type": "object",
+  "properties":
+  {
+    "type": { "const": "distance" },
+    "r1": { "type": "string", "default": "MainRobot", "description": "Name of the first robot involved in the distance constraint" },
+    "r2": { "type": "string", "default": "MainRobot", "description": "Name of the second robot involved in the distance constraint" },
+    "automaticMonitor":
+    {
+      "type": "boolean",
+      "default": true,
+      "description": "If true automatically display distance constraint monitors as constraints get activated. Otherwise those monitors are managed manually"
+    },
+    "useCommon":
+    {
+      "type": "boolean",
+      "default": false,
+      "description": "If true and r1Index == r2Index, add the common distance constraint set"
+    },
+    "useMinimal":
+    {
+      "type": "boolean",
+      "default": false,
+      "description": "If true and r1Index == r2Index, add the minimal distance constraint set"
+    },
+    "distances":
+    {
+      "type": "array",
+      "description": "List of distance limits in the constraint",
+      "items":
+      {
+        "$ref": "../mc_rbdyn/DistanceLimit.json"
+      }
+    }
+  },
+  "required": ["type"]
+}

--- a/doc/_data/schemas/mc_rbdyn/DistanceLimit.json
+++ b/doc/_data/schemas/mc_rbdyn/DistanceLimit.json
@@ -1,0 +1,18 @@
+{
+  "title": "mc_rbdyn::DistanceLimit",
+  "type": "object",
+  "properties":
+  {
+    "body1": { "type": "string", "description": "First convex body used, wildcards can be used" },
+    "body2": { "type": "string", "description": "Second convex body used, wildcards can be used" },
+    "r1ActiveJoints": { "type": "array", "items": { "type": "string" }, "description": "Active joints used in distance constraint (default: none, unspecified: all)" },
+    "r2ActiveJoints": { "type": "array", "items": { "type": "string" }, "description": "Active joints used in distance constraint (default: none, unspecified: all)" },
+    "r1InactiveJoints": { "type": "array", "items": { "type": "string" }, "description": "Joints not used in distance constraint (default: none). Has no effect if r1ActiveJoints is specified." },
+    "r2InactiveJoints": { "type": "array", "items": { "type": "string" }, "description": "Joints not used in distance constraint (default: none). Has no effect if r2ActiveJoints is specified." },
+    "iDist": { "type": "number", "default": 0.05, "description": "Interaction distance" },
+    "sDist": { "type": "number", "default": 0.01, "description": "Safety distance" },
+    "damping": { "type": "number", "default": 0.0, "description": "Damping, 0 enables automatic computation" }
+  },
+  "required": ["body1", "body2", "iDist", "sDist", "damping"],
+  "additionalProperties": false
+}

--- a/doc/_examples/json/ConstraintSet/DistanceConstraint.json
+++ b/doc/_examples/json/ConstraintSet/DistanceConstraint.json
@@ -1,0 +1,21 @@
+{
+  "type": "distanceLimit",
+  "r1": "jvrc1",
+  "r2": "otherRobot",
+  "distanceLimits": [
+    {
+      "body1": "b1",
+      "body2": "b2",
+      "iDist": 0.05,
+      "sDist": 0.01,
+      "damping": 0
+    },
+    {
+      "body1": "b2",
+      "body2": "b3",
+      "iDist": 0.05,
+      "sDist": 0.01,
+      "damping": 0
+    }
+  ]
+}

--- a/doc/_examples/json/mc_rbdyn/DistanceLimit.json
+++ b/doc/_examples/json/mc_rbdyn/DistanceLimit.json
@@ -1,0 +1,7 @@
+{
+  "body1": "b1",
+  "body2", "b2",
+  "iDist": 0.05,
+  "sDist": 0.01,
+  "damping": 0
+}

--- a/doc/_examples/yaml/ConstraintSet/DistanceConstraint.yaml
+++ b/doc/_examples/yaml/ConstraintSet/DistanceConstraint.yaml
@@ -1,0 +1,14 @@
+type: distanceLimit
+r1Index: 0
+r2Index: 0
+distanceLimits:
+  - body1: b1
+    body2: b2
+    iDist: 0.05
+    sDist: 0.01
+    damping: 0
+  - body1: b2
+    body2: b3
+    iDist: 0.05
+    sDist: 0.01
+    damping: 0

--- a/doc/_examples/yaml/mc_rbdyn/DistanceLimit.yaml
+++ b/doc/_examples/yaml/mc_rbdyn/DistanceLimit.yaml
@@ -1,0 +1,5 @@
+body1: b1
+body2: b2
+iDist: 0.05
+sDist: 0.01
+damping: 0

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -20,6 +20,7 @@
 #include <mc_solver/CollisionsConstraint.h>
 #include <mc_solver/CompoundJointConstraint.h>
 #include <mc_solver/ContactConstraint.h>
+#include <mc_solver/DistanceConstraint.h>
 #include <mc_solver/DynamicsConstraint.h>
 #include <mc_solver/KinematicsConstraint.h>
 #include <mc_solver/QPSolver.h>
@@ -701,7 +702,7 @@ protected:
 
   /** Collision managers for robot-pair (r1, r2), if r1 == r2 this is
    * effectively a self-collision manager */
-  std::map<std::pair<std::string, std::string>, std::shared_ptr<mc_solver::CollisionsConstraint>> collision_constraints_;
+  std::map<std::pair<std::string, std::string>, std::shared_ptr<mc_solver::DistanceConstraint>> collision_constraints_;
 
   /** FSM contacts */
   ContactSet contacts_;
@@ -726,7 +727,7 @@ public:
   /** Kinematics constraints for the main robot */
   mc_rtc::unique_ptr<mc_solver::KinematicsConstraint> kinematicsConstraint;
   /** Self collisions constraint for the main robot */
-  mc_rtc::unique_ptr<mc_solver::CollisionsConstraint> selfCollisionConstraint;
+  mc_rtc::unique_ptr<mc_solver::DistanceConstraint> selfCollisionConstraint;
   /** Compound joint constraint for the main robot */
   mc_rtc::unique_ptr<mc_solver::CompoundJointConstraint> compoundJointConstraint;
   /** Posture task for the main robot */

--- a/include/mc_control/MCController.h
+++ b/include/mc_control/MCController.h
@@ -26,6 +26,7 @@
 #include <mc_solver/QPSolver.h>
 
 #include <mc_tasks/PostureTask.h>
+#include "mc_rbdyn/DistanceLimit.h"
 
 namespace mc_rbdyn
 {
@@ -236,10 +237,10 @@ public:
    */
   void addCollisions(const std::string & r1,
                      const std::string & r2,
-                     const std::vector<mc_rbdyn::Collision> & collisions);
+                     const std::vector<mc_rbdyn::DistanceLimit> & collisions);
 
   /** Returns true if the given collision is active */
-  bool hasCollision(const std::string & r1, const std::string & r2, const mc_rbdyn::Collision & col) const noexcept;
+  bool hasCollision(const std::string & r1, const std::string & r2, const mc_rbdyn::DistanceLimit & col) const noexcept;
 
   /** Returns true if the given collision is active */
   bool hasCollision(const std::string & r1,
@@ -254,7 +255,7 @@ public:
    */
   void removeCollisions(const std::string & r1,
                         const std::string & r2,
-                        const std::vector<mc_rbdyn::Collision> & collisions);
+                        const std::vector<mc_rbdyn::DistanceLimit> & collisions);
 
   /** Remove all collision-pair between two robots
    *

--- a/include/mc_rbdyn/DistanceLimit.h
+++ b/include/mc_rbdyn/DistanceLimit.h
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_rbdyn/api.h>
+
+#include <optional>
+#include <string>
+#include <vector>
+
+/** \class DistanceLimit
+ * \brief Used to define a distance constraint between two bodies
+ */
+
+namespace mc_rbdyn
+{
+
+struct MC_RBDYN_DLLAPI DistanceLimit
+{
+  DistanceLimit() : body1("NONE"), body2("NONE") {}
+  DistanceLimit(const std::string & b1,
+                const std::string & b2,
+                double i,
+                double s,
+                double d,
+                const std::optional<std::vector<std::string>> & r1Joints = {},
+                const std::optional<std::vector<std::string>> & r2Joints = {},
+                bool r1JointsInactive = false,
+                bool r2JointsInactive = false)
+  : body1(b1), body2(b2), iDist(i), sDist(s), damping(d), r1Joints(r1Joints), r2Joints(r2Joints),
+    r1JointsInactive(r1JointsInactive), r2JointsInactive(r2JointsInactive)
+  {
+  }
+  std::string body1; /** First body in the constraint */
+  std::string body2; /** Second body in the constraint */
+  double iDist; /** Interaction distance */
+  double sDist; /** Security distance */
+  double damping; /** Damping (0 is automatic) */
+  /**
+   * Active/Inactive joints in the first robot:
+   * - no value specified = all joints selected
+   * - value specified:
+   *   - if r1JointsInactive = false : specified joints are treated as active
+   *   - if r1JointsInactive = true : specified joints are treated as inactive
+   */
+  std::optional<std::vector<std::string>> r1Joints;
+  std::optional<std::vector<std::string>>
+      r2Joints; /** Active/Inactive joints in the second robot, ignored if r1 == r2 */
+  bool r1JointsInactive = false; /** When true the selected joints in r1ActiveJoints are considered inactive */
+  bool r2JointsInactive = false; /** When true the selected joints in r2ActiveJoints are considered inactive */
+  inline bool isNone() { return body1 == "NONE" && body2 == "NONE"; }
+
+  bool operator==(const DistanceLimit & rhs) const;
+  bool operator!=(const DistanceLimit & rhs) const;
+};
+
+MC_RBDYN_DLLAPI std::ostream & operator<<(std::ostream & os, const DistanceLimit & c);
+
+} // namespace mc_rbdyn

--- a/include/mc_rbdyn/Robot.h
+++ b/include/mc_rbdyn/Robot.h
@@ -988,8 +988,8 @@ public:
   /** Access body transform vector */
   const std::vector<sva::PTransformd> & bodyTransforms() const;
 
-  /** Access transformation between the collision mesh and the body */
-  const sva::PTransformd & collisionTransform(const std::string & cName) const;
+  /** Access transformation between the convex mesh and the body */
+  const sva::PTransformd & convexTransform(const std::string & cName) const;
 
   /** Load surfaces from the directory \p surfaceDir */
   void loadRSDFFromDir(const std::string & surfaceDir);
@@ -1133,7 +1133,7 @@ private:
   std::vector<std::vector<double>> tdl_;
   std::vector<std::vector<double>> tdu_;
   std::map<std::string, convex_pair_t> convexes_;
-  std::map<std::string, sva::PTransformd> collisionTransforms_;
+  std::map<std::string, sva::PTransformd> convexTransforms_;
   std::map<std::string, mc_rbdyn::SurfacePtr> surfaces_;
   std::map<std::string, std::vector<double>> stance_;
   /** Data (optionally) shared with other instances of a similar robot */
@@ -1191,7 +1191,7 @@ protected:
   void fixSurface(Surface & surface);
 
   /** Used to set the collision transforms correctly */
-  void fixCollisionTransforms();
+  void fixConvexTransforms();
 
   /**
    * @brief Finds the name of the body to which a force sensor is attached,

--- a/include/mc_rbdyn/RobotModule.h
+++ b/include/mc_rbdyn/RobotModule.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <mc_rbdyn/BodySensor.h>
-#include <mc_rbdyn/Collision.h>
 #include <mc_rbdyn/CompoundJointConstraintDescription.h>
+#include <mc_rbdyn/DistanceLimit.h>
 #include <mc_rbdyn/Flexibility.h>
 #include <mc_rbdyn/ForceSensor.h>
 #include <mc_rbdyn/JointSensor.h>
@@ -21,6 +21,7 @@
 
 #include <RBDyn/parsers/common.h>
 
+#include "mc_rbdyn/DistanceLimit.h"
 #include <sch/S_Object/S_Object.h>
 
 /* This is an interface designed to provide additionnal information about a robot */
@@ -648,9 +649,9 @@ struct MC_RBDYN_DLLAPI RobotModule
    * This set of collision describe self-collisions that you always want to
    * enable regardless of the application
    *
-   * \see mc_rbdyn::Collision for details on the expected data
+   * \see mc_rbdyn::DistanceLimit for details on the expected data
    */
-  const std::vector<mc_rbdyn::Collision> & minimalSelfCollisions() const { return _minimalSelfCollisions; }
+  const std::vector<mc_rbdyn::DistanceLimit> & minimalSelfCollisions() const { return _minimalSelfCollisions; }
 
   /** Return a common self-collision set
    *
@@ -658,9 +659,9 @@ struct MC_RBDYN_DLLAPI RobotModule
    * general applications. Generally this is a super-set of \ref
    * minimalSelfCollisions
    *
-   * \see mc_rbdyn::Collision for details on the expected data
+   * \see mc_rbdyn::DistanceLimit for details on the expected data
    */
-  const std::vector<mc_rbdyn::Collision> & commonSelfCollisions() const { return _commonSelfCollisions; }
+  const std::vector<mc_rbdyn::DistanceLimit> & commonSelfCollisions() const { return _commonSelfCollisions; }
 
   /** Return the grippers in the robot
    *
@@ -824,9 +825,9 @@ public:
   /** \see springs() */
   Springs _springs;
   /** \see minimalSelfCollisions() */
-  std::vector<mc_rbdyn::Collision> _minimalSelfCollisions;
+  std::vector<mc_rbdyn::DistanceLimit> _minimalSelfCollisions;
   /** \see commonSelfCollisions() */
-  std::vector<mc_rbdyn::Collision> _commonSelfCollisions;
+  std::vector<mc_rbdyn::DistanceLimit> _commonSelfCollisions;
   /** \see grippers() */
   std::vector<Gripper> _grippers;
   /** \see gripperSafety() */

--- a/include/mc_rbdyn/RobotModule.h
+++ b/include/mc_rbdyn/RobotModule.h
@@ -451,7 +451,7 @@ struct MC_RBDYN_DLLAPI RobotModule
    *
    * - Initialize mb, mbc and mbg
    * - Initial limits
-   * - Initialize _collisionTransforms
+   * - Initialize _convexTransforms
    * - Initialize _visual
    * - Create a default joint order
    * - Create a default stance
@@ -571,7 +571,7 @@ struct MC_RBDYN_DLLAPI RobotModule
    * 2. the path to the file containing the convex description
    *
    * The transformation between the convex and the body it's attached to are
-   * provided in a separate map see \ref collisionTransforms()
+   * provided in a separate map see \ref convexTransforms()
    */
   const std::map<std::string, std::pair<std::string, std::string>> & convexHull() const { return _convexHull; }
 
@@ -586,7 +586,7 @@ struct MC_RBDYN_DLLAPI RobotModule
    * 2. the collision object
    *
    * The transformation between the convex and the body it's attached to are
-   * provided in a separate map see \ref collisionTransforms()
+   * provided in a separate map see \ref convexTransforms()
    */
   const std::map<std::string, std::pair<std::string, S_ObjectPtr>> & collisionObjects() const
   {
@@ -602,7 +602,7 @@ struct MC_RBDYN_DLLAPI RobotModule
    * 2. the path to the file containing the STPBV description
    *
    * The transformation between the STPBV and the body it's attached to are
-   * provided in a separate map see \ref collisionTransforms()
+   * provided in a separate map see \ref convexTransforms()
    */
   const std::map<std::string, std::pair<std::string, std::string>> & stpbvHull() const { return _stpbvHull; }
 
@@ -612,7 +612,7 @@ struct MC_RBDYN_DLLAPI RobotModule
    * A key defines the collision name. The value is the transformation between
    * this collision object and its parent body
    */
-  const std::map<std::string, sva::PTransformd> & collisionTransforms() const { return _collisionTransforms; }
+  const std::map<std::string, sva::PTransformd> & convexTransforms() const { return _convexTransforms; }
 
   /** Return the flexibilities of the robot
    *
@@ -812,8 +812,8 @@ public:
   VisualMap _visual;
   /** Holds collision representation of bodies in the robot */
   VisualMap _collision;
-  /** \see collisionTransforms() */
-  std::map<std::string, sva::PTransformd> _collisionTransforms;
+  /** \see convexTransforms() */
+  std::map<std::string, sva::PTransformd> _convexTransforms;
   /** \see flexibility() */
   std::vector<Flexibility> _flexibility;
   /** \see forceSensors() */

--- a/include/mc_rbdyn/configuration_io.h
+++ b/include/mc_rbdyn/configuration_io.h
@@ -11,6 +11,7 @@
 #include <mc_rbdyn/Base.h>
 #include <mc_rbdyn/BodySensor.h>
 #include <mc_rbdyn/Collision.h>
+#include <mc_rbdyn/DistanceLimit.h>
 #include <mc_rbdyn/Flexibility.h>
 #include <mc_rbdyn/ForceSensor.h>
 #include <mc_rbdyn/JointSensor.h>
@@ -33,6 +34,7 @@
 #include <mc_rbdyn/Contact.h>
 #include <mc_rtc/logging.h>
 
+#include "mc_rbdyn/DistanceLimit.h"
 #include <fstream>
 
 namespace mc_rtc
@@ -75,7 +77,8 @@ DECLARE_IO(mc_rbdyn::S_ObjectPtr)
 DECLARE_IO(mc_rbdyn::Base)
 DECLARE_IO(mc_rbdyn::BodySensor)
 DECLARE_IO(mc_rbdyn::JointSensor)
-DECLARE_IO(mc_rbdyn::Collision)
+DECLARE_IO(mc_rbdyn::Collision) // can be omited, replaced by DistanceLimit?
+DECLARE_IO(mc_rbdyn::DistanceLimit)
 DECLARE_IO(std::shared_ptr<mc_rbdyn::Surface>)
 DECLARE_IO(std::shared_ptr<mc_rbdyn::PlanarSurface>)
 DECLARE_IO(std::shared_ptr<mc_rbdyn::CylindricalSurface>)

--- a/include/mc_solver/CollisionsConstraint.h
+++ b/include/mc_solver/CollisionsConstraint.h
@@ -6,7 +6,7 @@
 
 #include <mc_solver/ConstraintSet.h>
 
-#include <mc_rbdyn/Collision.h>
+#include <mc_rbdyn/DistanceLimit.h>
 
 #include <mc_rtc/gui/StateBuilder.h>
 #include <mc_rtc/void_ptr.h>
@@ -52,7 +52,7 @@ public:
    *
    * \param cols List of collisions to remove
    */
-  void removeCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols);
+  void removeCollisions(QPSolver & solver, const std::vector<mc_rbdyn::DistanceLimit> & cols);
 
   /** Remove all collisions between two bodies
    * \param solver The solver into which this constraint was added
@@ -62,7 +62,7 @@ public:
    */
   bool removeCollisionByBody(QPSolver & solver, const std::string & byName, const std::string & b2Name);
 
-  /** Add a collision represented by mc_rbdyn::Collision
+  /** Add a collision represented by mc_rbdyn::DistanceLimit
    *
    * The collision object is allowed to specify wildcard names to add multiple
    * collisions at once, if body1 is named bodyA* and body2 is named bodyB*
@@ -72,7 +72,7 @@ public:
    * \param solver The solver into which this constraint was added \param col
    * The collision that should be added
    */
-  void addCollision(QPSolver & solver, const mc_rbdyn::Collision & col);
+  void addCollision(QPSolver & solver, const mc_rbdyn::DistanceLimit & col);
 
   /** Add a set of collisions
    *
@@ -81,7 +81,7 @@ public:
    * \param solver The solver into which this constraint was added
    * \param cols The set of collisions that should be added
    */
-  void addCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols);
+  void addCollisions(QPSolver & solver, const std::vector<mc_rbdyn::DistanceLimit> & cols);
 
   /** Returns true if the given collision is in this constraint */
   bool hasCollision(const std::string & c1, const std::string & c2) const noexcept;
@@ -121,25 +121,25 @@ public:
   /** Index of the second robot affected by the constraint */
   unsigned int r2Index;
   /** Curent set of collisions */
-  std::vector<mc_rbdyn::Collision> cols;
+  std::vector<mc_rbdyn::DistanceLimit> cols;
 
 private:
   /* Internal sauce to manage collisions */
   int collId;
-  std::map<std::string, std::pair<int, mc_rbdyn::Collision>> collIdDict;
+  std::map<std::string, std::pair<int, mc_rbdyn::DistanceLimit>> collIdDict;
   std::string __keyByNames(const std::string & name1, const std::string & name2);
-  int __createCollId(const mc_rbdyn::Collision & col);
-  std::pair<int, mc_rbdyn::Collision> __popCollId(const std::string & name1, const std::string & name2);
+  int __createCollId(const mc_rbdyn::DistanceLimit & col);
+  std::pair<int, mc_rbdyn::DistanceLimit> __popCollId(const std::string & name1, const std::string & name2);
   /** Actually adds the collision to the constraint, handles id creation and wildcard support */
-  void __addCollision(mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col);
+  void __addCollision(mc_solver::QPSolver & solver, const mc_rbdyn::DistanceLimit & col);
 
   /* Internal management for collision display */
   bool autoMonitor_ = true;
   std::unordered_set<int> monitored_;
   std::shared_ptr<mc_rtc::gui::StateBuilder> gui_;
   std::vector<std::string> category_;
-  void addMonitorButton(int collId, const mc_rbdyn::Collision & col);
-  void toggleCollisionMonitor(int collId, const mc_rbdyn::Collision * col = nullptr);
+  void addMonitorButton(int collId, const mc_rbdyn::DistanceLimit & col);
+  void toggleCollisionMonitor(int collId, const mc_rbdyn::DistanceLimit * col = nullptr);
 };
 
 } // namespace mc_solver

--- a/include/mc_solver/DistanceConstraint.h
+++ b/include/mc_solver/DistanceConstraint.h
@@ -1,0 +1,197 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_solver/ConstraintSet.h>
+
+#include <mc_rbdyn/Collision.h>
+
+#include <mc_rtc/gui/StateBuilder.h>
+#include <mc_rtc/void_ptr.h>
+
+namespace mc_solver
+{
+
+struct QPSolver;
+
+/** \class DistanceConstraint
+ *
+ * Creates a collision constraint manager between two robots.
+ *
+ * If the two robots are the same, this effectively creates a self-collision constraint
+ *
+ * Each collision is assigned an internal identity based on its two convex names and
+ * its distance constraint type. The identity is suffixed with:
+ * - "_min" when iDist > sDist
+ * - "_max" otherwise
+ *
+ * This allows minimum-distance and maximum-distance constraints between the same
+ * pair of convexes to coexist as distinct collisions.
+ */
+struct MC_SOLVER_DLLAPI DistanceConstraint : public ConstraintSet
+{
+public:
+  /** Default value of damping offset */
+  constexpr static double defaultDampingOffset = 0.1;
+
+public:
+  /** Constructor
+   *
+   * \param robots The robots for which the constraint will apply
+   * \param r1Index Index of the first robot affected by the constraint
+   * \param r2Index Index of the second robot affected by the constraint
+   * \param timeStep Time step of the control
+   */
+  DistanceConstraint(const mc_rbdyn::Robots & robots, unsigned int r1Index, unsigned int r2Index, double timeStep);
+
+  /** Remove a collision between two convexes
+   *
+   * The collision identity is determined from the two convex names and the
+   * distance constraint type (see __keyByNames).
+   *
+   * \param solver The solver into which this constraint was added
+   * \param col The collision to remove
+   * \return True if the collision was found and removed, false otherwise
+   */
+  bool removeCollision(QPSolver & solver, const mc_rbdyn::Collision & col);
+
+  /** Remove a set of collisions
+   *
+   * \param solver The solver into which this constraint was added
+   * \param cols List of collisions to remove
+   */
+  void removeCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols);
+
+  /** Remove all collisions between two bodies
+   *
+   * This removes every collision between the specified pair of bodies,
+   * including both minimum-distance and maximum-distance collision constraints.
+   *
+   * \param solver The solver into which this constraint was added
+   * \param b1Name Name of the first body
+   * \param b2Name Name of the second body
+   * \return True if at least one collision was removed, false otherwise
+   */
+  bool removeCollisionByBody(QPSolver & solver, const std::string & b1Name, const std::string & b2Name);
+
+  /** Add a collision represented by mc_rbdyn::Collision
+   *
+   * The collision object is allowed to specify wildcard names to add multiple
+   * collisions at once, if body1 is named bodyA* and body2 is named bodyB*
+   * then collision constraints will be added for all convex objects in robot1
+   * (resp. robot2) that start with bodyA (resp. bodyB)
+   *
+   * The collision identity is based on the two convex names and the distance
+   * constraint type:
+   * - "_min" is appended when iDist > sDist
+   * - "_max" is appended otherwise
+   *
+   * Therefore, two collisions involving the same pair of convexes can coexist
+   * when one is a minimum-distance constraint and the other is a
+   * maximum-distance constraint.
+   *
+   * \param solver The solver into which this constraint was added
+   * \param col The collision that should be added
+   */
+  void addCollision(QPSolver & solver, const mc_rbdyn::Collision & col);
+
+  /** Add a set of collisions
+   *
+   * \see addCollision for details on wildcard collision specification and
+   * collision identity.
+   *
+   * \param solver The solver into which this constraint was added
+   * \param cols The set of collisions that should be added
+   */
+  void addCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols);
+
+  /** Returns true if a collision between the given pair of convexes is in this constraint.
+   *
+   * This checks the convex names only and does not distinguish between
+   * "_min" and "_max" collision identities.
+   */
+  bool hasCollision(const std::string & c1, const std::string & c2) const noexcept;
+
+  /** Remove all collisions from the constraint */
+  void reset();
+
+  /** Get the automated monitoring setting */
+  inline bool automaticMonitor() const noexcept { return autoMonitor_; }
+
+  /** Set the automated monitoring setting
+   *
+   * If true, collision monitors are automatically added/removed depending on the collision activation.
+   *
+   * If false, monitors are managed by the user
+   */
+  inline void automaticMonitor(bool a) noexcept { autoMonitor_ = a; }
+
+  void addToSolverImpl(QPSolver & solver) override;
+
+  void update(QPSolver & solver) override;
+
+  void removeFromSolverImpl(QPSolver & solver) override;
+
+public:
+  /** Holds the constraint implementation
+   *
+   * In Tasks backend:
+   * - tasks::qp::CollisionConstr
+   *
+   * In TVM backend:
+   * - details::TVMCollisionConstraint
+   */
+  mc_rtc::void_ptr constraint_;
+
+  /** Index of the first robot affected by the constraint */
+  unsigned int r1Index;
+
+  /** Index of the second robot affected by the constraint */
+  unsigned int r2Index;
+
+  /** Current set of collisions */
+  std::vector<mc_rbdyn::Collision> cols;
+
+private:
+  /** Internal state used to manage collision identities */
+  int collId;
+
+  /** Maps a collision identity to its internal ID and collision data */
+  std::map<std::string, std::pair<int, mc_rbdyn::Collision>> collIdDict;
+
+  /** Build the unique identity key for a collision.
+   *
+   * The key is composed of the two convex names followed by:
+   * - "_min" when iDist > sDist
+   * - "_max" otherwise
+   */
+  std::string __keyByNames(const mc_rbdyn::Collision & col);
+
+  /** Create an internal ID for a collision.
+   *
+   * Returns -1 if a collision with the same identity already exists.
+   */
+  int __createCollId(const mc_rbdyn::Collision & col);
+
+  /** Remove and return the internal ID and collision data associated with a collision.
+   *
+   * The collision identity is computed using __keyByNames.
+   */
+  std::pair<int, mc_rbdyn::Collision> __popCollId(const mc_rbdyn::Collision & col);
+
+  /** Actually adds the collision to the constraint, handles ID creation and wildcard support */
+  void __addCollision(mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col);
+
+  /* Internal management for collision display */
+  bool autoMonitor_ = true;
+  std::unordered_set<int> monitored_;
+  std::shared_ptr<mc_rtc::gui::StateBuilder> gui_;
+  std::vector<std::string> category_;
+
+  void addMonitorButton(int collId, const mc_rbdyn::Collision & col);
+  void toggleCollisionMonitor(int collId, const mc_rbdyn::Collision * col = nullptr);
+};
+
+} // namespace mc_solver

--- a/include/mc_solver/DistanceConstraint.h
+++ b/include/mc_solver/DistanceConstraint.h
@@ -6,7 +6,7 @@
 
 #include <mc_solver/ConstraintSet.h>
 
-#include <mc_rbdyn/Collision.h>
+#include <mc_rbdyn/DistanceLimit.h>
 
 #include <mc_rtc/gui/StateBuilder.h>
 #include <mc_rtc/void_ptr.h>
@@ -18,17 +18,17 @@ struct QPSolver;
 
 /** \class DistanceConstraint
  *
- * Creates a collision constraint manager between two robots.
+ * Creates a distance constraint manager between two robots.
  *
- * If the two robots are the same, this effectively creates a self-collision constraint
+ * If the two robots are the same, this effectively creates a self-distance constraint (e.g. self-collision).
  *
- * Each collision is assigned an internal identity based on its two convex names and
+ * Each distance limit is assigned an internal identity based on its two convex names and
  * its distance constraint type. The identity is suffixed with:
- * - "_min" when iDist > sDist
- * - "_max" otherwise
+ * - "_min" when iDist > sDist, this is minimum distance constraint mostly used for collision avoidance
+ * - "_max" otherwise, this is maximum distance constraint when two links should not move too far apart
  *
  * This allows minimum-distance and maximum-distance constraints between the same
- * pair of convexes to coexist as distinct collisions.
+ * pair of convexes to coexist as distinct distance constraints.
  */
 struct MC_SOLVER_DLLAPI DistanceConstraint : public ConstraintSet
 {
@@ -46,75 +46,75 @@ public:
    */
   DistanceConstraint(const mc_rbdyn::Robots & robots, unsigned int r1Index, unsigned int r2Index, double timeStep);
 
-  /** Remove a collision between two convexes
+  /** Remove a distance limit between two convexes
    *
-   * The collision identity is determined from the two convex names and the
+   * The distance limit identity is determined from the two convex names and the
    * distance constraint type (see __keyByNames).
    *
    * \param solver The solver into which this constraint was added
-   * \param col The collision to remove
-   * \return True if the collision was found and removed, false otherwise
+   * \param dl The distance limit to remove
+   * \return True if the distance limit was found and removed, false otherwise
    */
-  bool removeCollision(QPSolver & solver, const mc_rbdyn::Collision & col);
+  bool removeDistanceLimit(QPSolver & solver, const mc_rbdyn::DistanceLimit & dl);
 
-  /** Remove a set of collisions
+  /** Remove a set of distance limits
    *
    * \param solver The solver into which this constraint was added
-   * \param cols List of collisions to remove
+   * \param dls List of distance limits to remove
    */
-  void removeCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols);
+  void removeDistanceLimits(QPSolver & solver, const std::vector<mc_rbdyn::DistanceLimit> & dls);
 
-  /** Remove all collisions between two bodies
+  /** Remove all distance limits between two bodies
    *
-   * This removes every collision between the specified pair of bodies,
-   * including both minimum-distance and maximum-distance collision constraints.
+   * This removes every distance limit between the specified pair of bodies,
+   * including both minimum-distance and maximum-distance constraints.
    *
    * \param solver The solver into which this constraint was added
    * \param b1Name Name of the first body
    * \param b2Name Name of the second body
-   * \return True if at least one collision was removed, false otherwise
+   * \return True if at least one distance limit was removed, false otherwise
    */
-  bool removeCollisionByBody(QPSolver & solver, const std::string & b1Name, const std::string & b2Name);
+  bool removeDistanceLimitByBody(QPSolver & solver, const std::string & b1Name, const std::string & b2Name);
 
-  /** Add a collision represented by mc_rbdyn::Collision
+  /** Add a distance limit represented by mc_rbdyn::DistanceLimit
    *
-   * The collision object is allowed to specify wildcard names to add multiple
-   * collisions at once, if body1 is named bodyA* and body2 is named bodyB*
-   * then collision constraints will be added for all convex objects in robot1
+   * The distance limit object is allowed to specify wildcard names to add multiple
+   * distance limits at once, if body1 is named bodyA* and body2 is named bodyB*
+   * then distance constraints will be added for all convex objects in robot1
    * (resp. robot2) that start with bodyA (resp. bodyB)
    *
-   * The collision identity is based on the two convex names and the distance
+   * The distance limit identity is based on the two convex names and the distance
    * constraint type:
    * - "_min" is appended when iDist > sDist
    * - "_max" is appended otherwise
    *
-   * Therefore, two collisions involving the same pair of convexes can coexist
+   * Therefore, two distance limits involving the same pair of convexes can coexist
    * when one is a minimum-distance constraint and the other is a
    * maximum-distance constraint.
    *
    * \param solver The solver into which this constraint was added
-   * \param col The collision that should be added
+   * \param dl The distance limit that should be added
    */
-  void addCollision(QPSolver & solver, const mc_rbdyn::Collision & col);
+  void addDistanceLimit(QPSolver & solver, const mc_rbdyn::DistanceLimit & dl);
 
-  /** Add a set of collisions
+  /** Add a set of distance limits
    *
-   * \see addCollision for details on wildcard collision specification and
-   * collision identity.
+   * \see addDistanceLimit for details on wildcard distance limit specification and
+   * distance limit identity.
    *
    * \param solver The solver into which this constraint was added
-   * \param cols The set of collisions that should be added
+   * \param dls The set of distance limits that should be added
    */
-  void addCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols);
+  void addDistanceLimits(QPSolver & solver, const std::vector<mc_rbdyn::DistanceLimit> & dls);
 
-  /** Returns true if a collision between the given pair of convexes is in this constraint.
+  /** Returns true if a distance limit between the given pair of convexes is in this constraint.
    *
    * This checks the convex names only and does not distinguish between
-   * "_min" and "_max" collision identities.
+   * "_min" and "_max" distance limit identities.
    */
-  bool hasCollision(const std::string & c1, const std::string & c2) const noexcept;
+  bool hasDistanceLimit(const std::string & c1, const std::string & c2) const noexcept;
 
-  /** Remove all collisions from the constraint */
+  /** Remove all distance limits from the constraint */
   void reset();
 
   /** Get the automated monitoring setting */
@@ -122,7 +122,7 @@ public:
 
   /** Set the automated monitoring setting
    *
-   * If true, collision monitors are automatically added/removed depending on the collision activation.
+   * If true, distance limit monitors are automatically added/removed depending on the distance limit activation.
    *
    * If false, monitors are managed by the user
    */
@@ -138,10 +138,10 @@ public:
   /** Holds the constraint implementation
    *
    * In Tasks backend:
-   * - tasks::qp::CollisionConstr
+   * - tasks::qp::DistanceConstr
    *
    * In TVM backend:
-   * - details::TVMCollisionConstraint
+   * - details::TVMDistanceConstraint
    */
   mc_rtc::void_ptr constraint_;
 
@@ -151,47 +151,47 @@ public:
   /** Index of the second robot affected by the constraint */
   unsigned int r2Index;
 
-  /** Current set of collisions */
-  std::vector<mc_rbdyn::Collision> cols;
+  /** Current set of distance limits */
+  std::vector<mc_rbdyn::DistanceLimit> dls;
 
 private:
-  /** Internal state used to manage collision identities */
-  int collId;
+  /** Internal state used to manage distance limit identities */
+  int dlId;
 
-  /** Maps a collision identity to its internal ID and collision data */
-  std::map<std::string, std::pair<int, mc_rbdyn::Collision>> collIdDict;
+  /** Maps a distance limit identity to its internal ID and distance limit data */
+  std::map<std::string, std::pair<int, mc_rbdyn::DistanceLimit>> dlIdDict;
 
-  /** Build the unique identity key for a collision.
+  /** Build the unique identity key for a distance limit.
    *
    * The key is composed of the two convex names followed by:
    * - "_min" when iDist > sDist
    * - "_max" otherwise
    */
-  std::string __keyByNames(const mc_rbdyn::Collision & col);
+  std::string __keyByNames(const mc_rbdyn::DistanceLimit & dl);
 
-  /** Create an internal ID for a collision.
+  /** Create an internal ID for a distance limit.
    *
-   * Returns -1 if a collision with the same identity already exists.
+   * Returns -1 if a distance limit with the same identity already exists.
    */
-  int __createCollId(const mc_rbdyn::Collision & col);
+  int __createDistanceLimitId(const mc_rbdyn::DistanceLimit & dl);
 
-  /** Remove and return the internal ID and collision data associated with a collision.
+  /** Remove and return the internal ID and distance limit data associated with a distance limit.
    *
-   * The collision identity is computed using __keyByNames.
+   * The distance limit identity is computed using __keyByNames.
    */
-  std::pair<int, mc_rbdyn::Collision> __popCollId(const mc_rbdyn::Collision & col);
+  std::pair<int, mc_rbdyn::DistanceLimit> __popDistanceLimitId(const mc_rbdyn::DistanceLimit & dl);
 
-  /** Actually adds the collision to the constraint, handles ID creation and wildcard support */
-  void __addCollision(mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col);
+  /** Actually adds the distance limit to the constraint, handles ID creation and wildcard support */
+  void __addDistanceLimit(mc_solver::QPSolver & solver, const mc_rbdyn::DistanceLimit & dl);
 
-  /* Internal management for collision display */
+  /* Internal management for distance limit display */
   bool autoMonitor_ = true;
   std::unordered_set<int> monitored_;
   std::shared_ptr<mc_rtc::gui::StateBuilder> gui_;
   std::vector<std::string> category_;
 
-  void addMonitorButton(int collId, const mc_rbdyn::Collision & col);
-  void toggleCollisionMonitor(int collId, const mc_rbdyn::Collision * col = nullptr);
+  void addMonitorButton(int dlId, const mc_rbdyn::DistanceLimit & dl);
+  void toggleDistanceLimitMonitor(int dlId, const mc_rbdyn::DistanceLimit * dl = nullptr);
 };
 
 } // namespace mc_solver

--- a/include/mc_tvm/DistanceFunction.h
+++ b/include/mc_tvm/DistanceFunction.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#pragma once
+
+#include <mc_tvm/Convex.h>
+
+#include <tvm/function/abstract/Function.h>
+
+#include <sch/CD/CD_Pair.h>
+
+#include <RBDyn/Jacobian.h>
+
+namespace mc_tvm
+{
+
+/** This class implements a collision function for two given objects */
+class MC_TVM_DLLAPI DistanceFunction : public tvm::function::abstract::Function
+{
+public:
+  SET_UPDATES(DistanceFunction, Value, Velocity, Jacobian, NormalAcceleration)
+
+  /** Constructor
+   *
+   * \param c1 First collision object
+   *
+   * \param c2 Second collision object
+   *
+   * \param r1Selector Joint selector for the first robot
+   *
+   * \param r2Selector Joint selector for the second robot
+   *
+   * \param dt Timestep
+   *
+   */
+  DistanceFunction(Convex & c1,
+                   Convex & c2,
+                   const Eigen::VectorXd & r1Selector,
+                   const Eigen::VectorXd & r2Selector,
+                   double dt);
+
+  /** Called *once* every iteration to advance the iteration counter */
+  void tick();
+
+  /** Distance between the two objects */
+  inline double distance() const noexcept { return this->value()(0); }
+
+  /** First convex involved in the collision */
+  inline const Convex & c1() const noexcept { return *c1_; }
+
+  /** Closest point on c1 in inertial frame coordinates */
+  inline const Eigen::Vector3d & p1() const noexcept { return p1_; }
+
+  /** Second convex involved in the collision */
+  inline const Convex & c2() const noexcept { return *c2_; }
+
+  /** Closest point on c2 in inertial frame coordinates */
+  inline const Eigen::Vector3d & p2() const noexcept { return p2_; }
+
+protected:
+  /* Update functions */
+  void updateValue();
+  void updateVelocity();
+  void updateJacobian();
+  void updateNormalAcceleration();
+
+  uint64_t iter_ = 0;
+  uint64_t prevIter_ = 0;
+
+  Convex * c1_;
+  Convex * c2_;
+  double dt_;
+
+  Eigen::Vector3d p1_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d p2_ = Eigen::Vector3d::Zero();
+
+  sch::CD_Pair pair_;
+
+  struct ObjectData
+  {
+    Eigen::Vector3d nearestPoint_;
+    rbd::Jacobian jac_;
+    Eigen::VectorXd selector_;
+  };
+  std::vector<ObjectData> data_;
+
+  Eigen::Vector3d normVecDist_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d prevNormVecDist_ = Eigen::Vector3d::Zero();
+  Eigen::Vector3d speedVec_ = Eigen::Vector3d::Zero();
+
+  /** Intermediate computation */
+  Eigen::MatrixXd fullJac_;
+  Eigen::MatrixXd distJac_;
+};
+
+using DistanceFunctionPtr = std::shared_ptr<DistanceFunction>;
+
+} // namespace mc_tvm

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -233,6 +233,7 @@ set(mc_rbdyn_SRC
     mc_rbdyn/RobotLoader.cpp
     mc_rbdyn/RobotConverter.cpp
     mc_rbdyn/Collision.cpp
+    mc_rbdyn/DistanceLimit.cpp
     mc_rbdyn/ForceSensor.cpp
     mc_rbdyn/RobotModule.cpp
     mc_rbdyn/RobotModule_visual.cpp
@@ -273,6 +274,7 @@ set(mc_rbdyn_HDR
     ../include/mc_rbdyn/surface_hull.h
     ../include/mc_rbdyn/surface_utils.h
     ../include/mc_rbdyn/Collision.h
+    ../include/mc_rbdyn/DistanceLimit.h
     ../include/mc_rbdyn/CompoundJointConstraintDescription.h
     ../include/mc_rbdyn/ForceSensor.h
     ../include/mc_rbdyn/Flexibility.h

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -294,6 +294,7 @@ set(mc_tvm_HDR_DIR ../include/mc_tvm)
 set(mc_tvm_HDR
     ${mc_tvm_HDR_DIR}/api.h
     ${mc_tvm_HDR_DIR}/CollisionFunction.h
+    ${mc_tvm_HDR_DIR}/DistanceFunction.h
     ${mc_tvm_HDR_DIR}/CoM.h
     ${mc_tvm_HDR_DIR}/CoMFunction.h
     ${mc_tvm_HDR_DIR}/CoMInConvexFunction.h
@@ -319,6 +320,7 @@ set(mc_tvm_HDR
 )
 set(mc_tvm_SRC
     mc_tvm/CollisionFunction.cpp
+    mc_tvm/DistanceFunction.cpp
     mc_tvm/CoM.cpp
     mc_tvm/CoMFunction.cpp
     mc_tvm/CoMInConvexFunction.cpp
@@ -435,6 +437,7 @@ add_subdirectory(mc_robots)
 set(mc_solver_SRC
     mc_solver/BoundedSpeedConstr.cpp
     mc_solver/CollisionsConstraint.cpp
+    mc_solver/DistanceConstraint.cpp
     mc_solver/CoMIncPlaneConstr.cpp
     mc_solver/ConstraintSet.cpp
     mc_solver/CompoundJointConstraint.cpp
@@ -459,6 +462,7 @@ set(mc_solver_HDR
     ../include/mc_solver/utils/UpdateNrVars.h
     ../include/mc_solver/BoundedSpeedConstr.h
     ../include/mc_solver/CollisionsConstraint.h
+    ../include/mc_solver/DistanceConstraint.h
     ../include/mc_solver/CoMIncPlaneConstr.h
     ../include/mc_solver/CompoundJointConstraint.h
     ../include/mc_solver/ConstraintSet.h

--- a/src/mc_control/HalfSitPose/mc_halfsitpose_controller.cpp
+++ b/src/mc_control/HalfSitPose/mc_halfsitpose_controller.cpp
@@ -33,7 +33,7 @@ MCHalfSitPoseController::MCHalfSitPoseController(std::shared_ptr<mc_rbdyn::Robot
 
   qpsolver->addConstraintSet(selfCollisionConstraint);
   /* Get the complete collision constraint set */
-  selfCollisionConstraint->addCollisions(solver(), robot_module->commonSelfCollisions());
+  selfCollisionConstraint->addDistanceLimits(solver(), robot_module->commonSelfCollisions());
   qpsolver->addConstraintSet(kinematicsConstraint);
   qpsolver->addTask(postureTask.get());
   qpsolver->addConstraintSet(contactConstraint);

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -209,7 +209,7 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   std::array<double, 3> damper{0.1, 0.01, 0.5};
   dynamicsConstraint.reset(new mc_solver::DynamicsConstraint(robots(), 0, dt, damper, 0.5));
   kinematicsConstraint.reset(new mc_solver::KinematicsConstraint(robots(), 0, dt, damper, 0.5));
-  selfCollisionConstraint.reset(new mc_solver::CollisionsConstraint(robots(), 0, 0, dt));
+  selfCollisionConstraint.reset(new mc_solver::DistanceConstraint(robots(), 0, 0, dt));
   selfCollisionConstraint->addCollisions(solver(), robot_modules[0]->minimalSelfCollisions());
   compoundJointConstraint.reset(new mc_solver::CompoundJointConstraint(robots(), 0, timeStep));
   postureTask = std::make_shared<mc_tasks::PostureTask>(solver(), 0, 10.0, 5.0);
@@ -319,13 +319,26 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
           std::shared_ptr<mc_solver::ContactConstraint>(contactConstraint.get(), [](mc_solver::ContactConstraint *) {});
     }
   }
+  /** Load distance constraint managers */
+  {
+    auto config_collisions = config("distances", std::vector<mc_rtc::Configuration>{});
+    for(auto & config_cc : config_collisions)
+    {
+      if(!config_cc.has("type")) { config_cc.add("type", "distance"); }
+      auto cc = mc_solver::ConstraintSetLoader::load<mc_solver::DistanceConstraint>(solver(), config_cc);
+      auto & r1 = robots().robot(cc->r1Index);
+      auto & r2 = robots().robot(cc->r2Index);
+      collision_constraints_[{r1.name(), r2.name()}] = cc;
+      solver().addConstraintSet(*cc);
+    }
+  }
   /** Load collision managers */
   {
     auto config_collisions = config("collisions", std::vector<mc_rtc::Configuration>{});
     for(auto & config_cc : config_collisions)
     {
       if(!config_cc.has("type")) { config_cc.add("type", "collision"); }
-      auto cc = mc_solver::ConstraintSetLoader::load<mc_solver::CollisionsConstraint>(solver(), config_cc);
+      auto cc = mc_solver::ConstraintSetLoader::load<mc_solver::DistanceConstraint>(solver(), config_cc);
       auto & r1 = robots().robot(cc->r1Index);
       auto & r2 = robots().robot(cc->r2Index);
       collision_constraints_[{r1.name(), r2.name()}] = cc;
@@ -961,7 +974,7 @@ void MCController::addCollisions(const std::string & r1,
     auto r1Index = robot(r1).robotIndex();
     auto r2Index = robot(r2).robotIndex();
     collision_constraints_[{r1, r2}] =
-        std::make_shared<mc_solver::CollisionsConstraint>(robots(), r1Index, r2Index, solver().dt());
+        std::make_shared<mc_solver::DistanceConstraint>(robots(), r1Index, r2Index, solver().dt());
     solver().addConstraintSet(*collision_constraints_[{r1, r2}]);
   }
   auto & cc = collision_constraints_[{r1, r2}];

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -27,6 +27,7 @@
 #include <RBDyn/FK.h>
 #include <RBDyn/FV.h>
 
+#include "mc_rbdyn/DistanceLimit.h"
 #include <filesystem>
 namespace fs = std::filesystem;
 
@@ -210,7 +211,7 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   dynamicsConstraint.reset(new mc_solver::DynamicsConstraint(robots(), 0, dt, damper, 0.5));
   kinematicsConstraint.reset(new mc_solver::KinematicsConstraint(robots(), 0, dt, damper, 0.5));
   selfCollisionConstraint.reset(new mc_solver::DistanceConstraint(robots(), 0, 0, dt));
-  selfCollisionConstraint->addCollisions(solver(), robot_modules[0]->minimalSelfCollisions());
+  selfCollisionConstraint->addDistanceLimits(solver(), robot_modules[0]->minimalSelfCollisions());
   compoundJointConstraint.reset(new mc_solver::CompoundJointConstraint(robots(), 0, timeStep));
   postureTask = std::make_shared<mc_tasks::PostureTask>(solver(), 0, 10.0, 5.0);
   /** Load additional robots from the configuration */
@@ -954,11 +955,11 @@ void MCController::updateContacts()
 
 void MCController::addCollisions(const std::string & r1,
                                  const std::string & r2,
-                                 const std::vector<mc_rbdyn::Collision> & collisions)
+                                 const std::vector<mc_rbdyn::DistanceLimit> & collisions)
 {
   if(r1 != r2 && collision_constraints_.count({r2, r1}))
   {
-    std::vector<mc_rbdyn::Collision> swapped;
+    std::vector<mc_rbdyn::DistanceLimit> swapped;
     swapped.reserve(collisions.size());
     for(const auto & c : collisions) { swapped.push_back({c.body2, c.body1, c.iDist, c.sDist, c.damping}); }
     addCollisions(r2, r1, swapped);
@@ -980,12 +981,12 @@ void MCController::addCollisions(const std::string & r1,
   auto & cc = collision_constraints_[{r1, r2}];
   mc_rtc::log::info("Add collisions {}/{}", r1, r2);
   for(const auto & c : collisions) { mc_rtc::log::info("- {}::{}/{}::{}", r1, c.body1, r2, c.body2); }
-  cc->addCollisions(solver(), collisions);
+  cc->addDistanceLimits(solver(), collisions);
 }
 
 bool MCController::hasCollision(const std::string & r1,
                                 const std::string & r2,
-                                const mc_rbdyn::Collision & col) const noexcept
+                                const mc_rbdyn::DistanceLimit & col) const noexcept
 {
   return hasCollision(r1, r2, col.body1, col.body2);
 }
@@ -996,24 +997,24 @@ bool MCController::hasCollision(const std::string & r1,
                                 const std::string & c2) const noexcept
 {
   auto it = collision_constraints_.find({r1, r2});
-  if(it != collision_constraints_.end()) { return it->second->hasCollision(c1, c2); }
+  if(it != collision_constraints_.end()) { return it->second->hasDistanceLimit(c1, c2); }
   if(r1 != r2)
   {
     it = collision_constraints_.find({r2, r1});
-    if(it != collision_constraints_.end()) { return it->second->hasCollision(c2, c1); }
+    if(it != collision_constraints_.end()) { return it->second->hasDistanceLimit(c2, c1); }
   }
   return false;
 }
 
 void MCController::removeCollisions(const std::string & r1,
                                     const std::string & r2,
-                                    const std::vector<mc_rbdyn::Collision> & collisions)
+                                    const std::vector<mc_rbdyn::DistanceLimit> & collisions)
 {
   if(!collision_constraints_.count({r1, r2})) { return; }
   auto & cc = collision_constraints_[{r1, r2}];
   mc_rtc::log::info("Remove collisions {}/{}", r1, r2);
   for(const auto & c : collisions) { mc_rtc::log::info("- {}::{}/{}::{}", r1, c.body1, r2, c.body2); }
-  cc->removeCollisions(solver(), collisions);
+  cc->removeDistanceLimits(solver(), collisions);
 }
 
 void MCController::removeCollisions(const std::string & r1, const std::string & r2)

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -338,7 +338,7 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
     auto config_collisions = config("collisions", std::vector<mc_rtc::Configuration>{});
     for(auto & config_cc : config_collisions)
     {
-      if(!config_cc.has("type")) { config_cc.add("type", "collision"); }
+      config_cc.add("type", "distance");
       auto cc = mc_solver::ConstraintSetLoader::load<mc_solver::DistanceConstraint>(solver(), config_cc);
       auto & r1 = robots().robot(cc->r1Index);
       auto & r2 = robots().robot(cc->r2Index);

--- a/src/mc_control/MCController.cpp
+++ b/src/mc_control/MCController.cpp
@@ -322,8 +322,8 @@ MCController::MCController(const std::vector<std::shared_ptr<mc_rbdyn::RobotModu
   }
   /** Load distance constraint managers */
   {
-    auto config_collisions = config("distances", std::vector<mc_rtc::Configuration>{});
-    for(auto & config_cc : config_collisions)
+    auto config_distance_limits = config("distances", std::vector<mc_rtc::Configuration>{});
+    for(auto & config_cc : config_distance_limits)
     {
       if(!config_cc.has("type")) { config_cc.add("type", "distance"); }
       auto cc = mc_solver::ConstraintSetLoader::load<mc_solver::DistanceConstraint>(solver(), config_cc);

--- a/src/mc_control/fsm/State.cpp
+++ b/src/mc_control/fsm/State.cpp
@@ -11,6 +11,7 @@
 #include <mc_tasks/MetaTaskLoader.h>
 
 #include <mc_rbdyn/configuration_io.h>
+#include "mc_rbdyn/DistanceLimit.h"
 
 namespace mc_control
 {
@@ -66,7 +67,7 @@ void State::start_(Controller & ctl)
       if(c.has("r2")) { r2 = static_cast<std::string>(c("r2")); }
       if(c.has("collisions"))
       {
-        std::vector<mc_rbdyn::Collision> collisions = c("collisions");
+        std::vector<mc_rbdyn::DistanceLimit> collisions = c("collisions");
         ctl.removeCollisions(r1, r2, collisions);
       }
       else
@@ -82,7 +83,7 @@ void State::start_(Controller & ctl)
       std::string r1 = c("r1");
       std::string r2 = r1;
       if(c.has("r2")) { r2 = static_cast<std::string>(c("r2")); }
-      std::vector<mc_rbdyn::Collision> collisions = c("collisions");
+      std::vector<mc_rbdyn::DistanceLimit> collisions = c("collisions");
       ctl.addCollisions(r1, r2, collisions);
     }
   }
@@ -164,7 +165,7 @@ void State::teardown_(Controller & ctl)
       if(c.has("r2")) { r2 = static_cast<std::string>(c("r2")); }
       if(c.has("collisions"))
       {
-        std::vector<mc_rbdyn::Collision> collisions = c("collisions");
+        std::vector<mc_rbdyn::DistanceLimit> collisions = c("collisions");
         ctl.removeCollisions(r1, r2, collisions);
       }
       else
@@ -180,7 +181,7 @@ void State::teardown_(Controller & ctl)
       std::string r1 = c("r1");
       std::string r2 = r1;
       if(c.has("r2")) { r2 = static_cast<std::string>(c("r2")); }
-      std::vector<mc_rbdyn::Collision> collisions = c("collisions");
+      std::vector<mc_rbdyn::DistanceLimit> collisions = c("collisions");
       ctl.addCollisions(r1, r2, collisions);
     }
   }

--- a/src/mc_rbdyn/DistanceLimit.cpp
+++ b/src/mc_rbdyn/DistanceLimit.cpp
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2015-2019 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#include <mc_rbdyn/DistanceLimit.h>
+
+#include <iostream>
+
+namespace mc_rbdyn
+{
+
+bool DistanceLimit::operator==(const DistanceLimit & rhs) const
+{
+  return body1 == rhs.body1 && body2 == rhs.body2 && iDist == rhs.iDist && sDist == rhs.sDist;
+}
+
+bool DistanceLimit::operator!=(const DistanceLimit & rhs) const
+{
+  return !(*this == rhs);
+}
+
+std::ostream & operator<<(std::ostream & os, const DistanceLimit & dl)
+{
+  os << "DistanceLimit: " << dl.body1 << "/" << dl.body2 << " { " << dl.iDist << ", " << dl.sDist << ", " << dl.damping
+     << "}";
+  return os;
+}
+
+} // namespace mc_rbdyn

--- a/src/mc_rbdyn/Robot.cpp
+++ b/src/mc_rbdyn/Robot.cpp
@@ -183,7 +183,7 @@ bool VisualToConvex(const std::string & robot,
                     const std::string & bName,
                     const rbd::parsers::Visual & visual,
                     std::map<std::string, mc_rbdyn::Robot::convex_pair_t> & convexes,
-                    std::map<std::string, sva::PTransformd> & collisionTransforms)
+                    std::map<std::string, sva::PTransformd> & convexTransforms)
 {
   // Ignore visual types that we cannot easily map to SCH
   if(visual.geometry.type == rbd::parsers::Geometry::Type::UNKNOWN
@@ -237,7 +237,7 @@ bool VisualToConvex(const std::string & robot,
     default:
       return false;
   }
-  collisionTransforms[cName] = visual.origin;
+  convexTransforms[cName] = visual.origin;
   return true;
 }
 
@@ -351,20 +351,20 @@ Robot::Robot(NewRobotToken,
 
   if(loadFiles)
   {
-    loadSCH(*this, module_.convexHull(), &sch::mc_rbdyn::Polyhedron, convexes_, collisionTransforms_);
+    loadSCH(*this, module_.convexHull(), &sch::mc_rbdyn::Polyhedron, convexes_, convexTransforms_);
     for(const auto & c : module_._collision)
     {
       const auto & body = c.first;
       const auto & collisions = c.second;
       if(collisions.size() == 1)
       {
-        VisualToConvex(name_, body, body, collisions[0], convexes_, collisionTransforms_);
+        VisualToConvex(name_, body, body, collisions[0], convexes_, convexTransforms_);
         continue;
       }
       size_t added = 0;
       for(const auto & col : collisions)
       {
-        if(VisualToConvex(name_, body + "_" + std::to_string(added), body, col, convexes_, collisionTransforms_))
+        if(VisualToConvex(name_, body + "_" + std::to_string(added), body, col, convexes_, convexTransforms_))
         {
           added++;
         }
@@ -380,21 +380,21 @@ Robot::Robot(NewRobotToken,
         continue;
       }
       convexes_[o.first] = {o.second.first, S_ObjectPtr(o.second.second->clone())};
-      auto it = module_.collisionTransforms().find(o.first);
-      if(it != module_.collisionTransforms().end()) { collisionTransforms_[o.first] = it->second; }
+      auto it = module_.convexTransforms().find(o.first);
+      if(it != module_.convexTransforms().end()) { convexTransforms_[o.first] = it->second; }
       else
       {
-        collisionTransforms_[o.first] = sva::PTransformd::Identity();
+        convexTransforms_[o.first] = sva::PTransformd::Identity();
       }
     }
-    for(const auto & b : mb().bodies()) { collisionTransforms_[b.name()] = sva::PTransformd::Identity(); }
+    for(const auto & b : mb().bodies()) { convexTransforms_[b.name()] = sva::PTransformd::Identity(); }
     for(const auto & [body, visuals] : module_._visual)
     {
-      if(visuals.size() && hasBody(body)) { collisionTransforms_[body] = visuals[0].origin; }
+      if(visuals.size() && hasBody(body)) { convexTransforms_[body] = visuals[0].origin; }
     }
-    for(const auto & p : module_.collisionTransforms()) { collisionTransforms_[p.first] = p.second; }
-    fixCollisionTransforms();
-    fixSCH(*this, this->convexes_, this->collisionTransforms_);
+    for(const auto & p : module_.convexTransforms()) { convexTransforms_[p.first] = p.second; }
+    fixConvexTransforms();
+    fixSCH(*this, this->convexes_, this->convexTransforms_);
   }
 
   if(!params.data_)
@@ -1091,7 +1091,7 @@ void Robot::addConvex(const std::string & cName,
     return;
   }
   convexes_[cName] = {body, convex};
-  collisionTransforms_[cName] = X_b_c;
+  convexTransforms_[cName] = X_b_c;
   sch::mc_rbdyn::transform(*convex, X_b_c * bodyPosW(body));
 }
 
@@ -1100,7 +1100,7 @@ void Robot::removeConvex(const std::string & cName)
   if(convexes_.count(cName))
   {
     convexes_.erase(cName);
-    collisionTransforms_.erase(cName);
+    convexTransforms_.erase(cName);
   }
 }
 
@@ -1120,13 +1120,13 @@ const std::vector<sva::PTransformd> & Robot::bodyTransforms() const
   return bodyTransforms_;
 }
 
-const sva::PTransformd & Robot::collisionTransform(const std::string & cName) const
+const sva::PTransformd & Robot::convexTransform(const std::string & cName) const
 {
-  if(collisionTransforms_.count(cName) == 0)
+  if(convexTransforms_.count(cName) == 0)
   {
     mc_rtc::log::error_and_throw("No collision transform with name {} found in this robot", cName);
   }
-  return collisionTransforms_.at(cName);
+  return convexTransforms_.at(cName);
 }
 
 void Robot::fixSurfaces()
@@ -1171,9 +1171,9 @@ void Robot::makeFrames(std::vector<mc_rbdyn::RobotModule::FrameDescription> fram
   }
 }
 
-void Robot::fixCollisionTransforms()
+void Robot::fixConvexTransforms()
 {
-  for(auto & ct : collisionTransforms_)
+  for(auto & ct : convexTransforms_)
   {
     if(convexes_.count(ct.first))
     {
@@ -1239,8 +1239,8 @@ void Robot::forwardKinematics(rbd::MultiBodyConfig & mbc) const
     auto get_cvx_tf = [&]()
     {
       unsigned int index = static_cast<unsigned int>(mb().bodyIndexByName(cvx.second.first));
-      auto tfs_it = collisionTransforms_.find(cvx.first);
-      if(tfs_it != collisionTransforms_.end()) { return tfs_it->second * mbc.bodyPosW[index]; }
+      auto tfs_it = convexTransforms_.find(cvx.first);
+      if(tfs_it != convexTransforms_.end()) { return tfs_it->second * mbc.bodyPosW[index]; }
       return mbc.bodyPosW[index];
     };
     sch::mc_rbdyn::transform(*cvx.second.second, get_cvx_tf());
@@ -1296,7 +1296,7 @@ void Robot::posW(const sva::PTransformd & pt)
     pt_.rotation() = Eigen::Quaterniond(pt.rotation()).normalized().toRotationMatrix();
     mb().transform(0, pt_);
     forwardKinematics();
-    fixSCH(*this, this->convexes_, this->collisionTransforms_);
+    fixSCH(*this, this->convexes_, this->convexTransforms_);
   }
   else
   {
@@ -1363,9 +1363,9 @@ void Robot::copyLoadedData(Robot & robot) const
   {
     robot.convexes_[cH.first] = {cH.second.first, S_ObjectPtr(cH.second.second->clone())};
   }
-  robot.collisionTransforms_ = collisionTransforms_;
-  robot.fixCollisionTransforms();
-  fixSCH(robot, robot.convexes_, robot.collisionTransforms_);
+  robot.convexTransforms_ = convexTransforms_;
+  robot.fixConvexTransforms();
+  fixSCH(robot, robot.convexes_, robot.convexTransforms_);
   for(size_t i = 0; i < data_->forceSensors.size(); ++i)
   {
     robot.data_->forceSensors[i].copyCalibrator(data_->forceSensors[i]);
@@ -1562,7 +1562,7 @@ mc_tvm::Convex & Robot::tvmConvex(const std::string & name) const
     const auto & cvx = convex(name);
     std::tie(it, std::ignore) = tvm_convexes_.insert(
         {name, std::unique_ptr<mc_tvm::Convex>{new mc_tvm::Convex(mc_tvm::Convex::NewConvexToken{}, cvx.second,
-                                                                  frame(cvx.first), collisionTransform(name))}});
+                                                                  frame(cvx.first), convexTransform(name))}});
   }
   return *it->second;
 }

--- a/src/mc_rbdyn/RobotModule.cpp
+++ b/src/mc_rbdyn/RobotModule.cpp
@@ -53,7 +53,7 @@ void RobotModule::init(const rbd::parsers::ParserResult & res)
   {
     const auto & body = col.first;
     const auto & cols = col.second;
-    if(cols.size()) { _collisionTransforms[body] = cols[0].origin; }
+    if(cols.size()) { _convexTransforms[body] = cols[0].origin; }
   }
   boundsFromURDF(res.limits);
   _visual = res.visual;

--- a/src/mc_rbdyn/RobotModule_connect.cpp
+++ b/src/mc_rbdyn/RobotModule_connect.cpp
@@ -12,6 +12,7 @@
 #include <RBDyn/FK.h>
 #include <RBDyn/parsers/urdf.h>
 
+#include "mc_rbdyn/DistanceLimit.h"
 #include <filesystem>
 namespace fs = std::filesystem;
 
@@ -403,7 +404,7 @@ RobotModule RobotModule::connect(const mc_rbdyn::RobotModule & other,
 
   /** Update self-collisions set */
   auto updateSelfCollisions =
-      [&](const std::vector<mc_rbdyn::Collision> & colsIn, std::vector<mc_rbdyn::Collision> & colsOut)
+      [&](const std::vector<mc_rbdyn::DistanceLimit> & colsIn, std::vector<mc_rbdyn::DistanceLimit> & colsOut)
   {
     for(const auto & c : colsIn)
     {
@@ -750,11 +751,11 @@ RobotModule RobotModule::disconnect(const mc_rbdyn::RobotModule & other,
 
   /** Update self-collisions set */
   auto updateSelfCollisions =
-      [&](const std::vector<mc_rbdyn::Collision> & colsIn, std::vector<mc_rbdyn::Collision> & colsOut)
+      [&](const std::vector<mc_rbdyn::DistanceLimit> & colsIn, std::vector<mc_rbdyn::DistanceLimit> & colsOut)
   {
     for(const auto & c : colsIn)
     {
-      auto it = std::find_if(colsOut.begin(), colsOut.end(), [&](const Collision & col)
+      auto it = std::find_if(colsOut.begin(), colsOut.end(), [&](const DistanceLimit & col)
                              { return col.body1 == convexName(c.body1) && col.body2 == convexName(c.body2); });
       if(it != colsOut.end()) { colsOut.erase(it); }
     }

--- a/src/mc_rbdyn/RobotModule_connect.cpp
+++ b/src/mc_rbdyn/RobotModule_connect.cpp
@@ -353,7 +353,7 @@ RobotModule RobotModule::connect(const mc_rbdyn::RobotModule & other,
   }
 
   /** Update collision transforms */
-  for(const auto & ct : other._collisionTransforms) { out._collisionTransforms[convexName(ct.first)] = ct.second; }
+  for(const auto & ct : other._convexTransforms) { out._convexTransforms[convexName(ct.first)] = ct.second; }
 
   /** Update flexibility */
   for(const auto & f : other._flexibility) { out._flexibility.push_back({jointName(f.jointName), f.K, f.C, f.O}); }
@@ -700,7 +700,7 @@ RobotModule RobotModule::disconnect(const mc_rbdyn::RobotModule & other,
   for(const auto & co : other._collisionObjects) { out._collisionObjects.erase(convexName(co.first)); }
 
   /** Update collision transforms */
-  for(const auto & ct : other._collisionTransforms) { out._collisionTransforms.erase(convexName(ct.first)); }
+  for(const auto & ct : other._convexTransforms) { out._convexTransforms.erase(convexName(ct.first)); }
 
   /** Update flexibilities */
   for(const auto & flex : other._flexibility)

--- a/src/mc_rbdyn/configuration_io.cpp
+++ b/src/mc_rbdyn/configuration_io.cpp
@@ -1093,7 +1093,7 @@ mc_rbdyn::RobotModule ConfigurationLoader<mc_rbdyn::RobotModule>::load(const mc_
     rm.mbc = config("mbc");
     rm._bounds = config("bounds");
     rm._visual = static_cast<std::map<std::string, std::vector<rbd::parsers::Visual>>>(config("visuals"));
-    rm._collisionTransforms = config("collisionTransforms");
+    rm._convexTransforms = config("convexTransforms");
   }
   else
   {
@@ -1104,17 +1104,17 @@ mc_rbdyn::RobotModule ConfigurationLoader<mc_rbdyn::RobotModule>::load(const mc_
       mc_rtc::log::error_and_throw("Could not open model for {} at {}", rm.name, rm.urdf_path);
     }
     rm.init(rbd::parsers::from_urdf_file(rm.urdf_path, fixed));
-    auto ctfs = config("collisionTransforms", std::map<std::string, sva::PTransformd>{});
+    auto ctfs = config("convexTransforms", std::map<std::string, sva::PTransformd>{});
     for(const auto & ctf : ctfs)
     {
-      if(rm._collisionTransforms.count(ctf.first))
+      if(rm._convexTransforms.count(ctf.first))
       {
         mc_rtc::log::warning("The collision transform for {} was already loaded from the URDF, the one specified in "
                              "the module will be ignored",
                              ctf.first);
         continue;
       }
-      rm._collisionTransforms[ctf.first] = ctf.second;
+      rm._convexTransforms[ctf.first] = ctf.second;
     }
   }
   if(config.has("accelerationBounds"))
@@ -1212,7 +1212,7 @@ mc_rtc::Configuration ConfigurationLoader<mc_rbdyn::RobotModule>::save(const mc_
   {
     config.add("mb", rm.mb);
     config.add("mbc", rm.mbc);
-    config.add("collisionTransforms", rm._collisionTransforms);
+    config.add("convexTransforms", rm._convexTransforms);
     config.add("bounds", rm._bounds);
     config.add("visuals", rm._visual);
   }

--- a/src/mc_rbdyn/configuration_io.cpp
+++ b/src/mc_rbdyn/configuration_io.cpp
@@ -19,6 +19,7 @@
 #include <sch-core/S_Superellipsoid.h>
 
 #include <mc_rtc/deprecated.h>
+#include "mc_rbdyn/DistanceLimit.h"
 #include <filesystem>
 namespace fs = std::filesystem;
 
@@ -193,6 +194,71 @@ mc_rbdyn::Collision ConfigurationLoader<mc_rbdyn::Collision>::load(const mc_rtc:
 }
 
 mc_rtc::Configuration ConfigurationLoader<mc_rbdyn::Collision>::save(const mc_rbdyn::Collision & c)
+{
+  mc_rtc::Configuration config;
+  config.add("body1", c.body1);
+  config.add("body2", c.body2);
+  config.add("iDist", c.iDist);
+  config.add("sDist", c.sDist);
+  config.add("damping", c.damping);
+  auto saveActiveJoints = [&](std::string prefix, const std::optional<std::vector<std::string>> & joints, bool inactive)
+  {
+    if(joints)
+    {
+      if(inactive) { config.add(prefix + "InactiveJoints", *c.r1Joints); }
+      else
+      {
+        config.add(prefix + "ActiveJoints", *c.r1Joints);
+      }
+    }
+  };
+  saveActiveJoints("r1", c.r1Joints, c.r1JointsInactive);
+  saveActiveJoints("r2", c.r2Joints, c.r2JointsInactive);
+  return config;
+}
+
+mc_rbdyn::DistanceLimit ConfigurationLoader<mc_rbdyn::DistanceLimit>::load(const mc_rtc::Configuration & config)
+{
+  auto body1 = config("body1");
+  auto body2 = config("body2");
+  auto loadActiveJoints = [&](std::string prefix) -> std::tuple<std::optional<std::vector<std::string>>, bool>
+  {
+    auto active_joints = config.find(prefix + "ActiveJoints");
+    auto joints = config.find(prefix + "Joints");
+    auto inactive_joints = config.find(prefix + "InactiveJoints");
+    if((active_joints || joints) && inactive_joints)
+    {
+      mc_rtc::log::warning(
+          "DistanceLimit ({} - {}) has both {}ActiveJoints and {}InactiveJoints, {}ActiveJoints will be used", body1,
+          body2, prefix);
+    }
+
+    if(joints)
+    {
+      mc_rtc::log::deprecated(fmt::format("DistanceLimit ({} - {})", body1, body2), prefix + "Joints",
+                              prefix + "ActiveJoints");
+      auto jointsV = joints->operator std::vector<std::string>();
+      if(jointsV.empty())
+      {
+        mc_rtc::log::warning(
+            "[DistanceLimit][breaking change] The meaning of an empty joint vector has changed from all joints active "
+            "to "
+            "no joints active. Remove {}Joints from your configuration to restore the former behaviour.",
+            prefix);
+      }
+      return {jointsV, false};
+    }
+    if(active_joints) { return {active_joints->operator std::vector<std::string>(), false}; }
+    if(inactive_joints) { return {inactive_joints->operator std::vector<std::string>(), true}; }
+    return {std::nullopt, false};
+  };
+  const auto & [r1Joints, r1Inactive] = loadActiveJoints("r1");
+  const auto & [r2Joints, r2Inactive] = loadActiveJoints("r2");
+  return mc_rbdyn::DistanceLimit(body1, body2, config("iDist", 0.05), config("sDist", 0.01), config("damping", 0.0),
+                                 r1Joints, r2Joints, r1Inactive, r2Inactive);
+}
+
+mc_rtc::Configuration ConfigurationLoader<mc_rbdyn::DistanceLimit>::save(const mc_rbdyn::DistanceLimit & c)
 {
   mc_rtc::Configuration config;
   config.add("body1", c.body1);

--- a/src/mc_rbdyn/gui/RobotConvex.cpp
+++ b/src/mc_rbdyn/gui/RobotConvex.cpp
@@ -23,7 +23,7 @@ void addConvexToGUI(mc_rtc::gui::StateBuilder & gui,
   const auto & convex = robot.convex(name);
   const auto & body = convex.first;
   const auto & c = convex.second;
-  auto get_pose = [&, name, body]() { return robot.collisionTransform(name) * robot.bodyPosW(body); };
+  auto get_pose = [&, name, body]() { return robot.convexTransform(name) * robot.bodyPosW(body); };
   auto publish_object = [&](auto && element) { gui.addElement(category, element); };
   if(auto * poly = dynamic_cast<sch::S_Polyhedron *>(c.get()))
   {

--- a/src/mc_solver/CollisionsConstraint.cpp
+++ b/src/mc_solver/CollisionsConstraint.cpp
@@ -125,7 +125,7 @@ struct TVMCollisionConstraint
 } // namespace details
 
 /** Helper to cast the constraint */
-static inline mc_rtc::void_ptr_caster<tasks::qp::CollisionConstr> tasks_constraint{};
+static inline mc_rtc::void_ptr_caster<tasks::qp::DistanceConstr> tasks_constraint{};
 static inline mc_rtc::void_ptr_caster<details::TVMCollisionConstraint> tvm_constraint{};
 
 /** Helper for wildcard
@@ -159,11 +159,11 @@ static mc_rtc::void_ptr make_constraint(QPSolver::Backend backend, const mc_rbdy
   switch(backend)
   {
     case QPSolver::Backend::Tasks:
-      return mc_rtc::make_void_ptr<tasks::qp::CollisionConstr>(robots.mbs(), timeStep);
+      return mc_rtc::make_void_ptr<tasks::qp::DistanceConstr>(robots.mbs(), timeStep);
     case QPSolver::Backend::TVM:
       return mc_rtc::make_void_ptr<details::TVMCollisionConstraint>();
     default:
-      mc_rtc::log::error_and_throw("[CollisionConstr] Not implemented for solver backend: {}", backend);
+      mc_rtc::log::error_and_throw("[DistanceConstr] Not implemented for solver backend: {}", backend);
   }
 }
 

--- a/src/mc_solver/CollisionsConstraint.cpp
+++ b/src/mc_solver/CollisionsConstraint.cpp
@@ -197,12 +197,12 @@ bool CollisionsConstraint::removeCollision(QPSolver & solver, const std::string 
     {
       case QPSolver::Backend::Tasks:
       {
-        auto collConstr = tasks_constraint(constraint_);
+        auto distConstr = tasks_constraint(constraint_);
         auto & qpsolver = tasks_solver(solver);
-        bool ret = collConstr->rmCollision(p.first);
+        bool ret = distConstr->rmDistanceLimit(p.first);
         if(ret)
         {
-          collConstr->updateNrVars({}, qpsolver.data());
+          distConstr->updateNrVars({}, qpsolver.data());
           qpsolver.updateConstrSize();
         }
         return ret;
@@ -239,8 +239,8 @@ bool CollisionsConstraint::removeCollisionByBody(QPSolver & solver,
       {
         case QPSolver::Backend::Tasks:
         {
-          auto collConstr = tasks_constraint(constraint_);
-          collConstr->rmCollision(out.first);
+          auto distConstr = tasks_constraint(constraint_);
+          distConstr->rmDistanceLimit(out.first);
           break;
         }
         case QPSolver::Backend::TVM:
@@ -339,22 +339,22 @@ void CollisionsConstraint::__addCollision(mc_solver::QPSolver & solver, const mc
   {
     case QPSolver::Backend::Tasks:
     {
-      auto collConstr = tasks_constraint(constraint_);
+      auto distConstr = tasks_constraint(constraint_);
       const auto & body1 = r1.convex(col.body1);
       const auto & body2 = r2.convex(col.body2);
-      const sva::PTransformd & X_b1_c = r1.collisionTransform(col.body1);
-      const sva::PTransformd & X_b2_c = r2.collisionTransform(col.body2);
+      const sva::PTransformd & X_b1_c = r1.convexTransform(col.body1);
+      const sva::PTransformd & X_b2_c = r2.convexTransform(col.body2);
       if(r1.mb().nrDof() == 0)
       {
-        collConstr->addCollision(robots.mbs(), collId, static_cast<int>(r2Index), body2.first, body2.second.get(),
-                                 X_b2_c, static_cast<int>(r1Index), body1.first, body1.second.get(), X_b1_c, col.iDist,
-                                 col.sDist, col.damping, defaultDampingOffset, r2Selector, r1Selector);
+        distConstr->addDistanceLimit(robots.mbs(), collId, static_cast<int>(r2Index), body2.first, body2.second.get(),
+                                     X_b2_c, static_cast<int>(r1Index), body1.first, body1.second.get(), X_b1_c,
+                                     col.iDist, col.sDist, col.damping, defaultDampingOffset, r2Selector, r1Selector);
       }
       else
       {
-        collConstr->addCollision(robots.mbs(), collId, static_cast<int>(r1Index), body1.first, body1.second.get(),
-                                 X_b1_c, static_cast<int>(r2Index), body2.first, body2.second.get(), X_b2_c, col.iDist,
-                                 col.sDist, col.damping, defaultDampingOffset, r1Selector, r2Selector);
+        distConstr->addDistanceLimit(robots.mbs(), collId, static_cast<int>(r1Index), body1.first, body1.second.get(),
+                                     X_b1_c, static_cast<int>(r2Index), body2.first, body2.second.get(), X_b2_c,
+                                     col.iDist, col.sDist, col.damping, defaultDampingOffset, r1Selector, r2Selector);
       }
       break;
     }
@@ -429,10 +429,10 @@ void CollisionsConstraint::toggleCollisionMonitor(int collId, const mc_rbdyn::Di
       case QPSolver::Backend::Tasks:
       {
         auto collConstr = tasks_constraint(constraint_);
-        addMonitor(
-            [collConstr, collId]() { return collConstr->getCollisionData(collId).distance; },
-            [collConstr, collId]() -> const Eigen::Vector3d & { return collConstr->getCollisionData(collId).p1; },
-            [collConstr, collId]() -> const Eigen::Vector3d & { return collConstr->getCollisionData(collId).p2; });
+        addMonitor([collConstr, collId]() { return collConstr->getDistanceData(collId).distance; },
+                   [collConstr, collId]() -> const Eigen::Vector3d & { return collConstr->getDistanceData(collId).p1; },
+                   [collConstr, collId]() -> const Eigen::Vector3d &
+                   { return collConstr->getDistanceData(collId).p2; });
         break;
       }
       case QPSolver::Backend::TVM:
@@ -513,8 +513,8 @@ void CollisionsConstraint::update(QPSolver &)
     {
       case QPSolver::Backend::Tasks:
       {
-        auto collConstr = tasks_constraint(constraint_);
-        return collConstr->getCollisionData(collId).distance;
+        auto distConstr = tasks_constraint(constraint_);
+        return distConstr->getDistanceData(collId).distance;
       }
       case QPSolver::Backend::TVM:
       {

--- a/src/mc_solver/CollisionsConstraint.cpp
+++ b/src/mc_solver/CollisionsConstraint.cpp
@@ -19,6 +19,7 @@
 
 #include <Tasks/QPConstr.h>
 
+#include "mc_rbdyn/DistanceLimit.h"
 #include <tvm/task_dynamics/VelocityDamper.h>
 
 #include "utils/jointsToSelector.h"
@@ -33,9 +34,9 @@ struct TVMCollisionConstraint
 {
   struct CollisionData
   {
-    CollisionData(int id, const mc_rbdyn::Collision & col) : id(id), collision(col) {}
+    CollisionData(int id, const mc_rbdyn::DistanceLimit & col) : id(id), collision(col) {}
     int id;
-    mc_rbdyn::Collision collision;
+    mc_rbdyn::DistanceLimit collision;
     mc_tvm::CollisionFunctionPtr function;
     tvm::TaskWithRequirementsPtr task;
   };
@@ -44,7 +45,7 @@ struct TVMCollisionConstraint
   /** Solver this has been added to */
   mc_solver::TVMQPSolver * solver;
 
-  auto getData(const mc_rbdyn::Collision & col)
+  auto getData(const mc_rbdyn::DistanceLimit & col)
   {
     return std::find_if(data_.begin(), data_.end(), [&](const auto & d) { return d.collision == col; });
   }
@@ -71,7 +72,7 @@ struct TVMCollisionConstraint
     }
   }
 
-  void deleteCollision(TVMQPSolver & solver, const mc_rbdyn::Collision & col)
+  void deleteCollision(TVMQPSolver & solver, const mc_rbdyn::DistanceLimit & col)
   {
     removeOrDeleteCollision<true>(solver, getData(col));
   }
@@ -97,7 +98,7 @@ struct TVMCollisionConstraint
   CollisionData & createCollision(TVMQPSolver & solver,
                                   const mc_rbdyn::Robot & r1,
                                   const mc_rbdyn::Robot & r2,
-                                  const mc_rbdyn::Collision & col,
+                                  const mc_rbdyn::DistanceLimit & col,
                                   int id,
                                   const Eigen::VectorXd & r1Selector,
                                   const Eigen::VectorXd & r2Selector)
@@ -216,7 +217,7 @@ bool CollisionsConstraint::removeCollision(QPSolver & solver, const std::string 
   return false;
 }
 
-void CollisionsConstraint::removeCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols)
+void CollisionsConstraint::removeCollisions(QPSolver & solver, const std::vector<mc_rbdyn::DistanceLimit> & cols)
 {
   for(const auto & c : cols) { removeCollision(solver, c.body1, c.body2); }
 }
@@ -227,7 +228,7 @@ bool CollisionsConstraint::removeCollisionByBody(QPSolver & solver,
 {
   const auto & r1 = solver.robots().robot(r1Index);
   const auto & r2 = solver.robots().robot(r2Index);
-  std::vector<mc_rbdyn::Collision> toRm;
+  std::vector<mc_rbdyn::DistanceLimit> toRm;
   for(const auto & col : cols)
   {
     if(r1.convex(col.body1).first == b1Name && r2.convex(col.body2).first == b2Name)
@@ -277,7 +278,7 @@ bool CollisionsConstraint::removeCollisionByBody(QPSolver & solver,
   return toRm.size() > 0;
 }
 
-void CollisionsConstraint::__addCollision(mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col)
+void CollisionsConstraint::__addCollision(mc_solver::QPSolver & solver, const mc_rbdyn::DistanceLimit & col)
 {
   const auto & robots = solver.robots();
   const mc_rbdyn::Robot & r1 = robots.robot(r1Index);
@@ -370,7 +371,7 @@ void CollisionsConstraint::__addCollision(mc_solver::QPSolver & solver, const mc
   addMonitorButton(collId, col);
 }
 
-void CollisionsConstraint::addMonitorButton(int collId, const mc_rbdyn::Collision & col)
+void CollisionsConstraint::addMonitorButton(int collId, const mc_rbdyn::DistanceLimit & col)
 {
   if(gui_ && inSolver_)
   {
@@ -384,7 +385,7 @@ void CollisionsConstraint::addMonitorButton(int collId, const mc_rbdyn::Collisio
   }
 }
 
-void CollisionsConstraint::toggleCollisionMonitor(int collId, const mc_rbdyn::Collision * col_p)
+void CollisionsConstraint::toggleCollisionMonitor(int collId, const mc_rbdyn::DistanceLimit * col_p)
 {
   auto findCollisionById = [this, collId, &col_p]()
   {
@@ -449,12 +450,12 @@ void CollisionsConstraint::toggleCollisionMonitor(int collId, const mc_rbdyn::Co
   }
 }
 
-void CollisionsConstraint::addCollision(QPSolver & solver, const mc_rbdyn::Collision & col)
+void CollisionsConstraint::addCollision(QPSolver & solver, const mc_rbdyn::DistanceLimit & col)
 {
   addCollisions(solver, {col});
 }
 
-void CollisionsConstraint::addCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols)
+void CollisionsConstraint::addCollisions(QPSolver & solver, const std::vector<mc_rbdyn::DistanceLimit> & cols)
 {
   for(const auto & c : cols) { __addCollision(solver, c); }
   switch(backend_)
@@ -580,28 +581,28 @@ std::string CollisionsConstraint::__keyByNames(const std::string & name1, const 
   return name1 + name2;
 }
 
-int CollisionsConstraint::__createCollId(const mc_rbdyn::Collision & col)
+int CollisionsConstraint::__createCollId(const mc_rbdyn::DistanceLimit & col)
 {
   std::string key = __keyByNames(col.body1, col.body2);
   auto it = collIdDict.find(key);
   if(it != collIdDict.end()) { return -1; }
   int collId = this->collId;
-  collIdDict[key] = std::pair<int, mc_rbdyn::Collision>(collId, col);
+  collIdDict[key] = std::pair<int, mc_rbdyn::DistanceLimit>(collId, col);
   this->collId += 1;
   return collId;
 }
 
-std::pair<int, mc_rbdyn::Collision> CollisionsConstraint::__popCollId(const std::string & name1,
-                                                                      const std::string & name2)
+std::pair<int, mc_rbdyn::DistanceLimit> CollisionsConstraint::__popCollId(const std::string & name1,
+                                                                          const std::string & name2)
 {
   std::string key = __keyByNames(name1, name2);
   if(collIdDict.count(key))
   {
-    std::pair<int, mc_rbdyn::Collision> p = collIdDict[key];
+    std::pair<int, mc_rbdyn::DistanceLimit> p = collIdDict[key];
     collIdDict.erase(key);
     return p;
   }
-  return std::pair<unsigned int, mc_rbdyn::Collision>(0, mc_rbdyn::Collision());
+  return std::pair<unsigned int, mc_rbdyn::DistanceLimit>(0, mc_rbdyn::DistanceLimit());
 }
 
 bool CollisionsConstraint::hasCollision(const std::string & c1, const std::string & c2) const noexcept
@@ -634,7 +635,7 @@ static auto registered = mc_solver::ConstraintSetLoader::register_load_function(
           ret->addCollisions(solver, solver.robots().robotModule(ret->r1Index).minimalSelfCollisions());
         }
       }
-      std::vector<mc_rbdyn::Collision> collisions = config("collisions", std::vector<mc_rbdyn::Collision>{});
+      std::vector<mc_rbdyn::DistanceLimit> collisions = config("collisions", std::vector<mc_rbdyn::DistanceLimit>{});
       ret->addCollisions(solver, collisions);
       return ret;
     });

--- a/src/mc_solver/DistanceConstraint.cpp
+++ b/src/mc_solver/DistanceConstraint.cpp
@@ -19,6 +19,7 @@
 
 #include <Tasks/QPConstr.h>
 
+#include "mc_rbdyn/DistanceLimit.h"
 #include <tvm/task_dynamics/VelocityDamper.h>
 
 #include "utils/jointsToSelector.h"
@@ -31,22 +32,22 @@ namespace details
 
 struct TVMDistanceConstraint
 {
-  struct DistanceData
+  struct DistanceLimitData
   {
-    DistanceData(int id, const mc_rbdyn::Collision & col) : id(id), collision(col) {}
+    DistanceLimitData(int id, const mc_rbdyn::DistanceLimit & dl) : id(id), distLim(dl) {}
     int id;
-    mc_rbdyn::Collision collision;
+    mc_rbdyn::DistanceLimit distLim;
     mc_tvm::DistanceFunctionPtr function;
     tvm::TaskWithRequirementsPtr task;
   };
   /** All distances handled by this constraint */
-  std::vector<DistanceData> data_;
+  std::vector<DistanceLimitData> data_;
   /** Solver this has been added to */
   mc_solver::TVMQPSolver * solver;
 
-  auto getData(const mc_rbdyn::Collision & col)
+  auto getData(const mc_rbdyn::DistanceLimit & dl)
   {
-    return std::find_if(data_.begin(), data_.end(), [&](const auto & d) { return d.collision == col; });
+    return std::find_if(data_.begin(), data_.end(), [&](const auto & d) { return d.distLim == dl; });
   }
 
   auto getData(int id)
@@ -55,8 +56,8 @@ struct TVMDistanceConstraint
   }
 
   template<bool Delete>
-  std::vector<DistanceData>::iterator removeOrDeleteDistance(TVMQPSolver & solver,
-                                                             std::vector<DistanceData>::iterator it)
+  std::vector<DistanceLimitData>::iterator removeOrDeleteDistanceLimit(TVMQPSolver & solver,
+                                                                       std::vector<DistanceLimitData>::iterator it)
   {
     if(it == data_.end()) { return data_.end(); }
     if(it->task)
@@ -71,16 +72,16 @@ struct TVMDistanceConstraint
     }
   }
 
-  void deleteDistance(TVMQPSolver & solver, const mc_rbdyn::Collision & col)
+  void deleteDistanceLimit(TVMQPSolver & solver, const mc_rbdyn::DistanceLimit & dl)
   {
-    removeOrDeleteDistance<true>(solver, getData(col));
+    removeOrDeleteDistanceLimit<true>(solver, getData(dl));
   }
 
-  void deleteDistance(TVMQPSolver & solver, int id) { removeOrDeleteDistance<true>(solver, getData(id)); }
+  void deleteDistanceLimit(TVMQPSolver & solver, int id) { removeOrDeleteDistanceLimit<true>(solver, getData(id)); }
 
-  void deleteDistances(mc_solver::TVMQPSolver & solver)
+  void deleteDistanceLimits(mc_solver::TVMQPSolver & solver)
   {
-    for(auto it = data_.begin(); it != data_.end(); ++it) { removeOrDeleteDistance<false>(solver, it); }
+    for(auto it = data_.begin(); it != data_.end(); ++it) { removeOrDeleteDistanceLimit<false>(solver, it); }
   }
 
   void clear()
@@ -91,44 +92,46 @@ struct TVMDistanceConstraint
       return;
     }
     auto it = data_.begin();
-    while(it != data_.end()) { it = removeOrDeleteDistance<true>(*solver, it); }
+    while(it != data_.end()) { it = removeOrDeleteDistanceLimit<true>(*solver, it); }
   }
 
-  DistanceData & createDistance(TVMQPSolver & solver,
-                                const mc_rbdyn::Robot & r1,
-                                const mc_rbdyn::Robot & r2,
-                                const mc_rbdyn::Collision & col,
-                                int id,
-                                const Eigen::VectorXd & r1Selector,
-                                const Eigen::VectorXd & r2Selector)
+  DistanceLimitData & createDistanceLimit(TVMQPSolver & solver,
+                                          const mc_rbdyn::Robot & r1,
+                                          const mc_rbdyn::Robot & r2,
+                                          const mc_rbdyn::DistanceLimit & dl,
+                                          int id,
+                                          const Eigen::VectorXd & r1Selector,
+                                          const Eigen::VectorXd & r2Selector)
   {
-    data_.push_back({id, col});
+    data_.push_back({id, dl});
     auto & data = data_.back();
-    auto & c1 = r1.tvmConvex(col.body1);
-    auto & c2 = r2.tvmConvex(col.body2);
+    auto & c1 = r1.tvmConvex(dl.body1);
+    auto & c2 = r2.tvmConvex(dl.body2);
     data.function = std::make_shared<mc_tvm::DistanceFunction>(c1, c2, r1Selector, r2Selector, solver.dt());
     return data;
   }
 
-  void addDistance(TVMQPSolver & solver, DistanceData & data)
+  void addDistanceLimit(TVMQPSolver & solver, DistanceLimitData & data)
   {
-    const auto & col = data.collision;
+    const auto & dl = data.distLim;
 
-    if(col.iDist > col.sDist)
+    if(dl.iDist > dl.sDist)
     {
+      // Lower distance bound: distance > sDist
       data.task = solver.problem().add(
           data.function >= 0.,
           tvm::task_dynamics::VelocityDamper(
-              solver.dt(), {col.iDist, col.sDist, col.damping, mc_solver::DistanceConstraint::defaultDampingOffset},
+              solver.dt(), {dl.iDist, dl.sDist, dl.damping, mc_solver::DistanceConstraint::defaultDampingOffset},
               tvm::constant::big_number),
           {tvm::requirements::PriorityLevel(0)});
     }
     else
     {
+      // Upper distance bound: distance < sDist
       data.task = solver.problem().add(
           data.function <= 0.,
           tvm::task_dynamics::VelocityDamper(
-              solver.dt(), {-col.iDist, -col.sDist, col.damping, mc_solver::DistanceConstraint::defaultDampingOffset},
+              solver.dt(), {-dl.iDist, -dl.sDist, dl.damping, mc_solver::DistanceConstraint::defaultDampingOffset},
               tvm::constant::big_number),
           {tvm::requirements::PriorityLevel(0)});
     }
@@ -163,7 +166,10 @@ bool handle_wildcard(const mc_rbdyn::Robot & robot, const std::string & body, Ca
       cb(cName);
     }
   }
-  if(!match) { mc_rtc::log::error_and_throw("No match found for collision wildcard {} in {}", body, robot.name()); }
+  if(!match)
+  {
+    mc_rtc::log::error_and_throw("No match found for distance limit wildcard {} in {}", body, robot.name());
+  }
   return true;
 }
 
@@ -184,11 +190,11 @@ DistanceConstraint::DistanceConstraint(const mc_rbdyn::Robots & robots,
                                        unsigned int r1Index,
                                        unsigned int r2Index,
                                        double timeStep)
-: constraint_(make_constraint(backend_, robots, timeStep)), r1Index(r1Index), r2Index(r2Index), collId(0), collIdDict()
+: constraint_(make_constraint(backend_, robots, timeStep)), r1Index(r1Index), r2Index(r2Index), dlId(0), dlIdDict()
 {
 }
 
-bool DistanceConstraint::removeCollision(QPSolver & solver, const mc_rbdyn::Collision & col)
+bool DistanceConstraint::removeDistanceLimit(QPSolver & solver, const mc_rbdyn::DistanceLimit & dl)
 {
   const auto & robots = solver.robots();
   const mc_rbdyn::Robot & r1 = robots.robot(r1Index);
@@ -196,44 +202,44 @@ bool DistanceConstraint::removeCollision(QPSolver & solver, const mc_rbdyn::Coll
 
   auto on_b1_wildcard = [&](const std::string & nb1)
   {
-    auto nCol = col;
-    nCol.body1 = nb1;
-    removeCollision(solver, nCol);
+    auto nDl = dl;
+    nDl.body1 = nb1;
+    removeDistanceLimit(solver, nDl);
   };
 
   auto on_b2_wildcard = [&](const std::string & nb2)
   {
-    auto nCol = col;
-    nCol.body2 = nb2;
-    removeCollision(solver, nCol);
+    auto nDl = dl;
+    nDl.body2 = nb2;
+    removeDistanceLimit(solver, nDl);
   };
 
-  if(handle_wildcard(r1, col.body1, on_b1_wildcard) || handle_wildcard(r2, col.body2, on_b2_wildcard)) { return true; }
+  if(handle_wildcard(r1, dl.body1, on_b1_wildcard) || handle_wildcard(r2, dl.body2, on_b2_wildcard)) { return true; }
 
-  auto p = __popCollId(col);
+  auto p = __popDistanceLimitId(dl);
 
   if(!p.second.isNone())
   {
-    if(monitored_.count(p.first)) { toggleCollisionMonitor(p.first, &p.second); }
+    if(monitored_.count(p.first)) { toggleDistanceLimitMonitor(p.first, &p.second); }
 
     category_.push_back("Monitors");
     std::string name = "Monitor " + p.second.body1 + "/" + p.second.body2;
     gui_->removeElement(category_, name);
     category_.pop_back();
 
-    cols.erase(std::find(cols.begin(), cols.end(), p.second));
+    dls.erase(std::find(dls.begin(), dls.end(), p.second));
 
     switch(backend_)
     {
       case QPSolver::Backend::Tasks:
       {
-        auto collConstr = tasks_constraint(constraint_);
+        auto distConstr = tasks_constraint(constraint_);
         auto & qpsolver = tasks_solver(solver);
-        bool ret = collConstr->rmCollision(p.first);
+        bool ret = distConstr->rmCollision(p.first); // need Tasks change? Yep
 
         if(ret)
         {
-          collConstr->updateNrVars({}, qpsolver.data());
+          distConstr->updateNrVars({}, qpsolver.data());
           qpsolver.updateConstrSize();
         }
 
@@ -241,7 +247,7 @@ bool DistanceConstraint::removeCollision(QPSolver & solver, const mc_rbdyn::Coll
       }
 
       case QPSolver::Backend::TVM:
-        tvm_constraint(constraint_)->deleteDistance(tvm_solver(solver), p.second);
+        tvm_constraint(constraint_)->deleteDistanceLimit(tvm_solver(solver), p.second);
         break;
 
       default:
@@ -252,55 +258,55 @@ bool DistanceConstraint::removeCollision(QPSolver & solver, const mc_rbdyn::Coll
   return false;
 }
 
-void DistanceConstraint::removeCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols)
+void DistanceConstraint::removeDistanceLimits(QPSolver & solver, const std::vector<mc_rbdyn::DistanceLimit> & dls)
 {
-  for(const auto & c : cols) { removeCollision(solver, c); }
+  for(const auto & dl : dls) { removeDistanceLimit(solver, dl); }
 }
 
-bool DistanceConstraint::removeCollisionByBody(QPSolver & solver,
-                                               const std::string & b1Name,
-                                               const std::string & b2Name)
+bool DistanceConstraint::removeDistanceLimitByBody(QPSolver & solver,
+                                                   const std::string & b1Name,
+                                                   const std::string & b2Name)
 {
   const auto & r1 = solver.robots().robot(r1Index);
   const auto & r2 = solver.robots().robot(r2Index);
-  std::vector<mc_rbdyn::Collision> toRm;
-  for(const auto & col : cols)
+  std::vector<mc_rbdyn::DistanceLimit> toRm;
+  for(const auto & dl : dls)
   {
-    if(r1.convex(col.body1).first == b1Name && r2.convex(col.body2).first == b2Name)
+    if(r1.convex(dl.body1).first == b1Name && r2.convex(dl.body2).first == b2Name)
     {
-      auto out = __popCollId(col);
+      auto out = __popDistanceLimitId(dl);
       toRm.push_back(out.second);
       switch(backend_)
       {
         case QPSolver::Backend::Tasks:
         {
-          auto collConstr = tasks_constraint(constraint_);
-          collConstr->rmCollision(out.first);
+          auto distConstr = tasks_constraint(constraint_);
+          distConstr->rmCollision(out.first);
           break;
         }
         case QPSolver::Backend::TVM:
-          tvm_constraint(constraint_)->deleteDistance(tvm_solver(solver), out.first);
+          tvm_constraint(constraint_)->deleteDistanceLimit(tvm_solver(solver), out.first);
           break;
         default:
           break;
       }
-      if(monitored_.count(out.first)) { toggleCollisionMonitor(out.first, &out.second); }
+      if(monitored_.count(out.first)) { toggleDistanceLimitMonitor(out.first, &out.second); }
       category_.push_back("Monitors");
       std::string name = "Monitor " + __keyByNames(out.second);
       gui_->removeElement(category_, name);
       category_.pop_back();
     }
   }
-  for(const auto & it : toRm) { cols.erase(std::find(cols.begin(), cols.end(), it)); }
+  for(const auto & it : toRm) { dls.erase(std::find(dls.begin(), dls.end(), it)); }
   if(toRm.size())
   {
     switch(backend_)
     {
       case QPSolver::Backend::Tasks:
       {
-        auto collConstr = tasks_constraint(constraint_);
+        auto distConstr = tasks_constraint(constraint_);
         auto & qpsolver = tasks_solver(solver);
-        collConstr->updateNrVars({}, qpsolver.data());
+        distConstr->updateNrVars({}, qpsolver.data());
         qpsolver.updateConstrSize();
         break;
       }
@@ -313,32 +319,32 @@ bool DistanceConstraint::removeCollisionByBody(QPSolver & solver,
   return toRm.size() > 0;
 }
 
-void DistanceConstraint::__addCollision(mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col)
+void DistanceConstraint::__addDistanceLimit(mc_solver::QPSolver & solver, const mc_rbdyn::DistanceLimit & dl)
 {
   const auto & robots = solver.robots();
   const mc_rbdyn::Robot & r1 = robots.robot(r1Index);
   const mc_rbdyn::Robot & r2 = robots.robot(r2Index);
-  if(col.body1.size() == 0 || col.body2.size() == 0)
+  if(dl.body1.size() == 0 || dl.body2.size() == 0)
   {
-    mc_rtc::log::error("Attempted to add a collision without a specific body");
+    mc_rtc::log::error("Attempted to add a distance limit without a specific body");
     return;
   }
   auto on_b1_wildcard = [&](const std::string & nb1)
   {
-    auto nCol = col;
-    nCol.body1 = nb1;
-    __addCollision(solver, nCol);
+    auto nDl = dl;
+    nDl.body1 = nb1;
+    __addDistanceLimit(solver, nDl);
   };
   auto on_b2_wildcard = [&](const std::string & nb2)
   {
-    auto nCol = col;
-    nCol.body2 = nb2;
-    __addCollision(solver, nCol);
+    auto nDl = dl;
+    nDl.body2 = nb2;
+    __addDistanceLimit(solver, nDl);
   };
-  if(handle_wildcard(r1, col.body1, on_b1_wildcard) || handle_wildcard(r2, col.body2, on_b2_wildcard)) { return; }
-  int collId = __createCollId(col);
-  if(collId < 0) { return; }
-  cols.push_back(col);
+  if(handle_wildcard(r1, dl.body1, on_b1_wildcard) || handle_wildcard(r2, dl.body2, on_b2_wildcard)) { return; }
+  int dlId = __createDistanceLimitId(dl);
+  if(dlId < 0) { return; }
+  dls.push_back(dl);
 
   auto computeJointsSelector =
       [&robots](const std::optional<std::vector<std::string>> & joints, bool inactive, auto rIndex)
@@ -366,87 +372,88 @@ void DistanceConstraint::__addCollision(mc_solver::QPSolver & solver, const mc_r
     }
   };
 
-  auto r1Selector = computeJointsSelector(col.r1Joints, col.r1JointsInactive, r1Index);
+  auto r1Selector = computeJointsSelector(dl.r1Joints, dl.r1JointsInactive, r1Index);
   auto r2Selector = r1Index == r2Index ? Eigen::VectorXd::Zero(0).eval()
-                                       : computeJointsSelector(col.r2Joints, col.r2JointsInactive, r2Index);
+                                       : computeJointsSelector(dl.r2Joints, dl.r2JointsInactive, r2Index);
 
   switch(backend_)
   {
     case QPSolver::Backend::Tasks:
     {
-      auto collConstr = tasks_constraint(constraint_);
-      const auto & body1 = r1.convex(col.body1);
-      const auto & body2 = r2.convex(col.body2);
-      const sva::PTransformd & X_b1_c = r1.collisionTransform(col.body1);
-      const sva::PTransformd & X_b2_c = r2.collisionTransform(col.body2);
+      auto distConstr = tasks_constraint(constraint_);
+      const auto & body1 = r1.convex(dl.body1);
+      const auto & body2 = r2.convex(dl.body2);
+      const sva::PTransformd & X_b1_c = r1.collisionTransform(dl.body1); // why is it called collisionTransform
+      const sva::PTransformd & X_b2_c = r2.collisionTransform(dl.body2);
       if(r1.mb().nrDof() == 0)
       {
-        collConstr->addCollision(robots.mbs(), collId, static_cast<int>(r2Index), body2.first, body2.second.get(),
-                                 X_b2_c, static_cast<int>(r1Index), body1.first, body1.second.get(), X_b1_c, col.iDist,
-                                 col.sDist, col.damping, defaultDampingOffset, r2Selector, r1Selector);
+        distConstr->addCollision(robots.mbs(), dlId, static_cast<int>(r2Index), body2.first, body2.second.get(), X_b2_c,
+                                 static_cast<int>(r1Index), body1.first, body1.second.get(), X_b1_c, dl.iDist, dl.sDist,
+                                 dl.damping, defaultDampingOffset, r2Selector, r1Selector);
       }
       else
       {
-        collConstr->addCollision(robots.mbs(), collId, static_cast<int>(r1Index), body1.first, body1.second.get(),
-                                 X_b1_c, static_cast<int>(r2Index), body2.first, body2.second.get(), X_b2_c, col.iDist,
-                                 col.sDist, col.damping, defaultDampingOffset, r1Selector, r2Selector);
+        distConstr->addCollision(robots.mbs(), dlId, static_cast<int>(r1Index), body1.first, body1.second.get(), X_b1_c,
+                                 static_cast<int>(r2Index), body2.first, body2.second.get(), X_b2_c, dl.iDist, dl.sDist,
+                                 dl.damping, defaultDampingOffset, r1Selector, r2Selector);
       }
       break;
     }
     case QPSolver::Backend::TVM:
     {
-      auto & data =
-          tvm_constraint(constraint_)->createDistance(tvm_solver(solver), r1, r2, col, collId, r1Selector, r2Selector);
-      if(inSolver_) { tvm_constraint(constraint_)->addDistance(tvm_solver(solver), data); }
+      auto & data = tvm_constraint(constraint_)
+                        ->createDistanceLimit(tvm_solver(solver), r1, r2, dl, dlId, r1Selector, r2Selector);
+      if(inSolver_) { tvm_constraint(constraint_)->addDistanceLimit(tvm_solver(solver), data); }
       break;
     }
     default:
       break;
   }
-  addMonitorButton(collId, col);
+  addMonitorButton(dlId, dl);
 }
 
-void DistanceConstraint::addMonitorButton(int collId, const mc_rbdyn::Collision & col)
+void DistanceConstraint::addMonitorButton(int dlId, const mc_rbdyn::DistanceLimit & dl)
 {
   if(gui_ && inSolver_)
   {
     auto & gui = *gui_;
-    std::string name = col.body1 + "/" + col.body2;
+    std::string name = dl.body1 + "/" + dl.body2;
     category_.push_back("Monitors");
     gui.addElement(category_, mc_rtc::gui::Checkbox(
-                                  "Monitor " + name, [collId, this]() { return monitored_.count(collId) != 0; },
-                                  [collId, this]() { toggleCollisionMonitor(collId); }));
+                                  "Monitor " + name, [dlId, this]() { return monitored_.count(dlId) != 0; },
+                                  [dlId, this]() { toggleDistanceLimitMonitor(dlId); }));
     category_.pop_back();
   }
 }
 
-void DistanceConstraint::toggleCollisionMonitor(int collId, const mc_rbdyn::Collision * col_p)
+void DistanceConstraint::toggleDistanceLimitMonitor(int dlId, const mc_rbdyn::DistanceLimit * dl_p)
 {
-  auto findCollisionById = [this, collId, &col_p]()
+  auto findDistanceLimitById = [this, dlId, &dl_p]()
   {
-    if(col_p) { return; }
-    for(const auto & c : collIdDict)
+    if(dl_p) { return; }
+    for(const auto & c : dlIdDict)
     {
-      if(c.second.first == collId)
+      if(c.second.first == dlId)
       {
-        col_p = &c.second.second;
+        dl_p = &c.second.second;
         return;
       }
     }
-    mc_rtc::log::error_and_throw("[CollisionConstraint] Attempted to toggleCollisionMonitor on non-existent collision");
+    mc_rtc::log::error_and_throw(
+        "[DistanceConstraint] Attempted to toggleDistanceLimitMonitor on non-existent distance limit");
   };
-  findCollisionById();
-  const auto & col = *col_p;
+  findDistanceLimitById();
+  const auto & dl = *dl_p;
   auto & gui = *gui_;
-  std::string label = col.body1 + "::" + col.body2;
-  if(monitored_.count(collId))
+  std::string label = dl.body1 + "::" + dl.body2;
+  if(monitored_.count(dlId))
   {
     // Remove the monitor
     gui.removeElement(category_, label);
     category_.push_back("Arrows");
     gui.removeElement(category_, label);
     category_.pop_back();
-    monitored_.erase(collId);
+    monitored_.erase(dlId);
   }
   else
   {
@@ -463,17 +470,16 @@ void DistanceConstraint::toggleCollisionMonitor(int collId, const mc_rbdyn::Coll
     {
       case QPSolver::Backend::Tasks:
       {
-        auto collConstr = tasks_constraint(constraint_);
-        addMonitor(
-            [collConstr, collId]() { return collConstr->getCollisionData(collId).distance; },
-            [collConstr, collId]() -> const Eigen::Vector3d & { return collConstr->getCollisionData(collId).p1; },
-            [collConstr, collId]() -> const Eigen::Vector3d & { return collConstr->getCollisionData(collId).p2; });
+        auto distConstr = tasks_constraint(constraint_);
+        addMonitor([distConstr, dlId]() { return distConstr->getCollisionData(dlId).distance; }, // needs Tasks change?
+                   [distConstr, dlId]() -> const Eigen::Vector3d & { return distConstr->getCollisionData(dlId).p1; },
+                   [distConstr, dlId]() -> const Eigen::Vector3d & { return distConstr->getCollisionData(dlId).p2; });
         break;
       }
       case QPSolver::Backend::TVM:
       {
-        auto collConstr = tvm_constraint(constraint_);
-        auto fn = collConstr->getData(collId)->function;
+        auto distConstr = tvm_constraint(constraint_);
+        auto fn = distConstr->getData(dlId)->function;
         addMonitor([fn]() { return fn->distance(); }, [fn]() -> const Eigen::Vector3d & { return fn->p1(); },
                    [fn]() -> const Eigen::Vector3d & { return fn->p2(); });
         break;
@@ -481,25 +487,25 @@ void DistanceConstraint::toggleCollisionMonitor(int collId, const mc_rbdyn::Coll
       default:
         break;
     }
-    monitored_.insert(collId);
+    monitored_.insert(dlId);
   }
 }
 
-void DistanceConstraint::addCollision(QPSolver & solver, const mc_rbdyn::Collision & col)
+void DistanceConstraint::addDistanceLimit(QPSolver & solver, const mc_rbdyn::DistanceLimit & dl)
 {
-  addCollisions(solver, {col});
+  addDistanceLimits(solver, {dl});
 }
 
-void DistanceConstraint::addCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols)
+void DistanceConstraint::addDistanceLimits(QPSolver & solver, const std::vector<mc_rbdyn::DistanceLimit> & dls)
 {
-  for(const auto & c : cols) { __addCollision(solver, c); }
+  for(const auto & dl : dls) { __addDistanceLimit(solver, dl); }
   switch(backend_)
   {
     case QPSolver::Backend::Tasks:
     {
-      auto & collConstr = *tasks_constraint(constraint_);
+      auto & distConstr = *tasks_constraint(constraint_);
       auto & qpsolver = tasks_solver(solver);
-      collConstr.updateNrVars({}, qpsolver.data());
+      distConstr.updateNrVars({}, qpsolver.data());
       qpsolver.updateConstrSize();
       break;
     }
@@ -521,66 +527,54 @@ void DistanceConstraint::addToSolverImpl(QPSolver & solver)
   {
     case QPSolver::Backend::Tasks:
     {
-      auto & collConstr = *tasks_constraint(constraint_);
+      auto & distConstr = *tasks_constraint(constraint_);
       auto & qpsolver = tasks_solver(solver);
-      collConstr.addToSolver(solver.robots().mbs(), qpsolver.solver());
+      distConstr.addToSolver(solver.robots().mbs(), qpsolver.solver());
       break;
     }
     case QPSolver::Backend::TVM:
     {
       auto cstr = tvm_constraint(constraint_);
-      for(auto & c : cstr->data_) { tvm_constraint(constraint_)->addDistance(tvm_solver(solver), c); }
+      for(auto & c : cstr->data_) { tvm_constraint(constraint_)->addDistanceLimit(tvm_solver(solver), c); }
       tvm_constraint(constraint_)->solver = &tvm_solver(solver);
       break;
     }
     default:
       break;
   }
-  for(const auto & cols : collIdDict) { addMonitorButton(cols.second.first, cols.second.second); }
+  for(const auto & dl : dlIdDict) { addMonitorButton(dl.second.first, dl.second.second); }
 }
 
 void DistanceConstraint::update(QPSolver &)
 {
   if(!autoMonitor_) { return; }
-  auto getDistance = [this](int collId)
+  auto getDistance = [this](int dlId)
   {
     switch(backend_)
     {
       case QPSolver::Backend::Tasks:
       {
-        auto collConstr = tasks_constraint(constraint_);
-        return collConstr->getCollisionData(collId).distance;
+        auto distConstr = tasks_constraint(constraint_);
+        return distConstr->getCollisionData(dlId).distance;
       }
       case QPSolver::Backend::TVM:
       {
-        auto collConstr = tvm_constraint(constraint_);
-        auto & fn = collConstr->getData(collId)->function;
+        auto distConstr = tvm_constraint(constraint_);
+        auto & fn = distConstr->getData(dlId)->function;
         return fn->distance();
       }
       default:
         mc_rtc::log::error_and_throw("Not implemented for this backend");
     }
   };
-  for(const auto & [name, info] : collIdDict)
+  for(const auto & [name, info] : dlIdDict)
   {
-    const auto & [collId, coll] = info;
-    auto distance = getDistance(collId);
-    if(distance < coll.iDist && coll.iDist > coll.sDist && !monitored_.count(collId))
-    {
-      toggleCollisionMonitor(collId, &coll);
-    }
-    if(distance > coll.iDist && coll.iDist > coll.sDist && monitored_.count(collId))
-    {
-      toggleCollisionMonitor(collId, &coll);
-    }
-    if(distance > coll.iDist && coll.iDist < coll.sDist && !monitored_.count(collId))
-    {
-      toggleCollisionMonitor(collId, &coll);
-    }
-    if(distance < coll.iDist && coll.iDist < coll.sDist && monitored_.count(collId))
-    {
-      toggleCollisionMonitor(collId, &coll);
-    }
+    const auto & [dlId, dl] = info;
+    auto distance = getDistance(dlId);
+    if(distance < dl.iDist && dl.iDist > dl.sDist && !monitored_.count(dlId)) { toggleDistanceLimitMonitor(dlId, &dl); }
+    if(distance > dl.iDist && dl.iDist > dl.sDist && monitored_.count(dlId)) { toggleDistanceLimitMonitor(dlId, &dl); }
+    if(distance > dl.iDist && dl.iDist < dl.sDist && !monitored_.count(dlId)) { toggleDistanceLimitMonitor(dlId, &dl); }
+    if(distance < dl.iDist && dl.iDist < dl.sDist && monitored_.count(dlId)) { toggleDistanceLimitMonitor(dlId, &dl); }
   }
 }
 
@@ -590,14 +584,14 @@ void DistanceConstraint::removeFromSolverImpl(QPSolver & solver)
   {
     case QPSolver::Backend::Tasks:
     {
-      auto & collConstr = *tasks_constraint(constraint_);
+      auto & distConstr = *tasks_constraint(constraint_);
       auto & qpsolver = tasks_solver(solver);
-      collConstr.removeFromSolver(qpsolver.solver());
+      distConstr.removeFromSolver(qpsolver.solver());
       break;
     }
     case QPSolver::Backend::TVM:
     {
-      tvm_constraint(constraint_)->deleteDistances(tvm_solver(solver));
+      tvm_constraint(constraint_)->deleteDistanceLimits(tvm_solver(solver));
       tvm_constraint(constraint_)->solver = nullptr;
       break;
     }
@@ -609,8 +603,8 @@ void DistanceConstraint::removeFromSolverImpl(QPSolver & solver)
 
 void DistanceConstraint::reset()
 {
-  cols.clear();
-  collIdDict.clear();
+  dls.clear();
+  dlIdDict.clear();
   switch(backend_)
   {
     case QPSolver::Backend::Tasks:
@@ -625,42 +619,42 @@ void DistanceConstraint::reset()
   if(gui_) { gui_->removeCategory(category_); }
 }
 
-std::string DistanceConstraint::__keyByNames(const mc_rbdyn::Collision & col)
+std::string DistanceConstraint::__keyByNames(const mc_rbdyn::DistanceLimit & dl)
 {
-  return col.body1 + "/" + col.body2 + (col.iDist > col.sDist ? "_min" : "_max");
+  return dl.body1 + "/" + dl.body2 + (dl.iDist > dl.sDist ? "_min" : "_max");
 }
 
-int DistanceConstraint::__createCollId(const mc_rbdyn::Collision & col)
+int DistanceConstraint::__createDistanceLimitId(const mc_rbdyn::DistanceLimit & dl)
 {
-  std::string key = __keyByNames(col);
+  std::string key = __keyByNames(dl);
 
-  auto it = collIdDict.find(key);
-  if(it != collIdDict.end()) { return -1; }
+  auto it = dlIdDict.find(key);
+  if(it != dlIdDict.end()) { return -1; }
 
-  int collId = this->collId;
-  collIdDict[key] = std::pair<int, mc_rbdyn::Collision>(collId, col);
-  this->collId += 1;
-  return collId;
+  int dlId = this->dlId;
+  dlIdDict[key] = std::pair<int, mc_rbdyn::DistanceLimit>(dlId, dl);
+  this->dlId += 1;
+  return dlId;
 }
 
-std::pair<int, mc_rbdyn::Collision> DistanceConstraint::__popCollId(const mc_rbdyn::Collision & col)
+std::pair<int, mc_rbdyn::DistanceLimit> DistanceConstraint::__popDistanceLimitId(const mc_rbdyn::DistanceLimit & dl)
 {
-  std::string key = __keyByNames(col);
+  std::string key = __keyByNames(dl);
 
-  if(collIdDict.count(key))
+  if(dlIdDict.count(key))
   {
-    std::pair<int, mc_rbdyn::Collision> p = collIdDict[key];
-    collIdDict.erase(key);
+    std::pair<int, mc_rbdyn::DistanceLimit> p = dlIdDict[key];
+    dlIdDict.erase(key);
     return p;
   }
 
-  return std::pair<unsigned int, mc_rbdyn::Collision>(0, mc_rbdyn::Collision());
+  return std::pair<unsigned int, mc_rbdyn::DistanceLimit>(0, mc_rbdyn::DistanceLimit());
 }
 
-bool DistanceConstraint::hasCollision(const std::string & c1, const std::string & c2) const noexcept
+bool DistanceConstraint::hasDistanceLimit(const std::string & c1, const std::string & c2) const noexcept
 {
-  auto it = std::find_if(cols.begin(), cols.end(), [&](const auto & c) { return c.body1 == c1 && c.body2 == c2; });
-  return it != cols.end();
+  auto it = std::find_if(dls.begin(), dls.end(), [&](const auto & c) { return c.body1 == c1 && c.body2 == c2; });
+  return it != dls.end();
 }
 
 } // namespace mc_solver
@@ -680,15 +674,16 @@ static auto registered = mc_solver::ConstraintSetLoader::register_load_function(
       {
         if(config("useCommon", false))
         {
-          ret->addCollisions(solver, solver.robots().robotModule(ret->r1Index).commonSelfCollisions());
+          ret->addDistanceLimits(
+              solver, solver.robots().robotModule(ret->r1Index).commonSelfCollisions()); // create commonDistanceLimits
         }
         else if(config("useMinimal", false))
         {
-          ret->addCollisions(solver, solver.robots().robotModule(ret->r1Index).minimalSelfCollisions());
+          ret->addDistanceLimits(solver, solver.robots().robotModule(ret->r1Index).minimalSelfCollisions());
         }
       }
-      std::vector<mc_rbdyn::Collision> collisions = config("distances", std::vector<mc_rbdyn::Collision>{});
-      ret->addCollisions(solver, collisions);
+      std::vector<mc_rbdyn::DistanceLimit> distLims = config("distances", std::vector<mc_rbdyn::DistanceLimit>{});
+      ret->addDistanceLimits(solver, distLims);
       return ret;
     });
 } // namespace

--- a/src/mc_solver/DistanceConstraint.cpp
+++ b/src/mc_solver/DistanceConstraint.cpp
@@ -235,7 +235,7 @@ bool DistanceConstraint::removeDistanceLimit(QPSolver & solver, const mc_rbdyn::
       {
         auto distConstr = tasks_constraint(constraint_);
         auto & qpsolver = tasks_solver(solver);
-        bool ret = distConstr->rmCollision(p.first); // need Tasks change? Yep
+        bool ret = distConstr->rmDistanceLimit(p.first);
 
         if(ret)
         {
@@ -281,7 +281,7 @@ bool DistanceConstraint::removeDistanceLimitByBody(QPSolver & solver,
         case QPSolver::Backend::Tasks:
         {
           auto distConstr = tasks_constraint(constraint_);
-          distConstr->rmCollision(out.first);
+          distConstr->rmDistanceLimit(out.first);
           break;
         }
         case QPSolver::Backend::TVM:
@@ -383,19 +383,19 @@ void DistanceConstraint::__addDistanceLimit(mc_solver::QPSolver & solver, const 
       auto distConstr = tasks_constraint(constraint_);
       const auto & body1 = r1.convex(dl.body1);
       const auto & body2 = r2.convex(dl.body2);
-      const sva::PTransformd & X_b1_c = r1.collisionTransform(dl.body1); // why is it called collisionTransform
-      const sva::PTransformd & X_b2_c = r2.collisionTransform(dl.body2);
+      const sva::PTransformd & X_b1_c = r1.convexTransform(dl.body1);
+      const sva::PTransformd & X_b2_c = r2.convexTransform(dl.body2);
       if(r1.mb().nrDof() == 0)
       {
-        distConstr->addCollision(robots.mbs(), dlId, static_cast<int>(r2Index), body2.first, body2.second.get(), X_b2_c,
-                                 static_cast<int>(r1Index), body1.first, body1.second.get(), X_b1_c, dl.iDist, dl.sDist,
-                                 dl.damping, defaultDampingOffset, r2Selector, r1Selector);
+        distConstr->addDistanceLimit(robots.mbs(), dlId, static_cast<int>(r2Index), body2.first, body2.second.get(),
+                                     X_b2_c, static_cast<int>(r1Index), body1.first, body1.second.get(), X_b1_c,
+                                     dl.iDist, dl.sDist, dl.damping, defaultDampingOffset, r2Selector, r1Selector);
       }
       else
       {
-        distConstr->addCollision(robots.mbs(), dlId, static_cast<int>(r1Index), body1.first, body1.second.get(), X_b1_c,
-                                 static_cast<int>(r2Index), body2.first, body2.second.get(), X_b2_c, dl.iDist, dl.sDist,
-                                 dl.damping, defaultDampingOffset, r1Selector, r2Selector);
+        distConstr->addDistanceLimit(robots.mbs(), dlId, static_cast<int>(r1Index), body1.first, body1.second.get(),
+                                     X_b1_c, static_cast<int>(r2Index), body2.first, body2.second.get(), X_b2_c,
+                                     dl.iDist, dl.sDist, dl.damping, defaultDampingOffset, r1Selector, r2Selector);
       }
       break;
     }
@@ -471,9 +471,9 @@ void DistanceConstraint::toggleDistanceLimitMonitor(int dlId, const mc_rbdyn::Di
       case QPSolver::Backend::Tasks:
       {
         auto distConstr = tasks_constraint(constraint_);
-        addMonitor([distConstr, dlId]() { return distConstr->getCollisionData(dlId).distance; }, // needs Tasks change?
-                   [distConstr, dlId]() -> const Eigen::Vector3d & { return distConstr->getCollisionData(dlId).p1; },
-                   [distConstr, dlId]() -> const Eigen::Vector3d & { return distConstr->getCollisionData(dlId).p2; });
+        addMonitor([distConstr, dlId]() { return distConstr->getDistanceData(dlId).distance; }, // needs Tasks change?
+                   [distConstr, dlId]() -> const Eigen::Vector3d & { return distConstr->getDistanceData(dlId).p1; },
+                   [distConstr, dlId]() -> const Eigen::Vector3d & { return distConstr->getDistanceData(dlId).p2; });
         break;
       }
       case QPSolver::Backend::TVM:
@@ -521,7 +521,7 @@ void DistanceConstraint::addToSolverImpl(QPSolver & solver)
   gui_ = solver.gui();
   const mc_rbdyn::Robot & r1 = solver.robots().robot(r1Index);
   const mc_rbdyn::Robot & r2 = solver.robots().robot(r2Index);
-  category_ = {"Collisions", r1.name() + "/" + r2.name()};
+  category_ = {"DistanceLimits", r1.name() + "/" + r2.name()};
   gui_->addElement(category_, mc_rtc::gui::Checkbox("Automatic monitor", autoMonitor_));
   switch(backend_)
   {
@@ -555,7 +555,7 @@ void DistanceConstraint::update(QPSolver &)
       case QPSolver::Backend::Tasks:
       {
         auto distConstr = tasks_constraint(constraint_);
-        return distConstr->getCollisionData(dlId).distance;
+        return distConstr->getDistanceData(dlId).distance;
       }
       case QPSolver::Backend::TVM:
       {
@@ -674,8 +674,7 @@ static auto registered = mc_solver::ConstraintSetLoader::register_load_function(
       {
         if(config("useCommon", false))
         {
-          ret->addDistanceLimits(
-              solver, solver.robots().robotModule(ret->r1Index).commonSelfCollisions()); // create commonDistanceLimits
+          ret->addDistanceLimits(solver, solver.robots().robotModule(ret->r1Index).commonSelfCollisions());
         }
         else if(config("useMinimal", false))
         {

--- a/src/mc_solver/DistanceConstraint.cpp
+++ b/src/mc_solver/DistanceConstraint.cpp
@@ -471,7 +471,7 @@ void DistanceConstraint::toggleDistanceLimitMonitor(int dlId, const mc_rbdyn::Di
       case QPSolver::Backend::Tasks:
       {
         auto distConstr = tasks_constraint(constraint_);
-        addMonitor([distConstr, dlId]() { return distConstr->getDistanceData(dlId).distance; }, // needs Tasks change?
+        addMonitor([distConstr, dlId]() { return distConstr->getDistanceData(dlId).distance; },
                    [distConstr, dlId]() -> const Eigen::Vector3d & { return distConstr->getDistanceData(dlId).p1; },
                    [distConstr, dlId]() -> const Eigen::Vector3d & { return distConstr->getDistanceData(dlId).p2; });
         break;

--- a/src/mc_solver/DistanceConstraint.cpp
+++ b/src/mc_solver/DistanceConstraint.cpp
@@ -1,0 +1,694 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#include <mc_solver/DistanceConstraint.h>
+
+#include <mc_solver/ConstraintSetLoader.h>
+#include <mc_solver/TVMQPSolver.h>
+#include <mc_solver/TasksQPSolver.h>
+
+#include <mc_tvm/DistanceFunction.h>
+
+#include <mc_rbdyn/SCHAddon.h>
+#include <mc_rbdyn/configuration_io.h>
+
+#include <mc_rtc/gui/Arrow.h>
+#include <mc_rtc/gui/Checkbox.h>
+#include <mc_rtc/gui/Label.h>
+
+#include <Tasks/QPConstr.h>
+
+#include <tvm/task_dynamics/VelocityDamper.h>
+
+#include "utils/jointsToSelector.h"
+
+namespace mc_solver
+{
+
+namespace details
+{
+
+struct TVMDistanceConstraint
+{
+  struct DistanceData
+  {
+    DistanceData(int id, const mc_rbdyn::Collision & col) : id(id), collision(col) {}
+    int id;
+    mc_rbdyn::Collision collision;
+    mc_tvm::DistanceFunctionPtr function;
+    tvm::TaskWithRequirementsPtr task;
+  };
+  /** All distances handled by this constraint */
+  std::vector<DistanceData> data_;
+  /** Solver this has been added to */
+  mc_solver::TVMQPSolver * solver;
+
+  auto getData(const mc_rbdyn::Collision & col)
+  {
+    return std::find_if(data_.begin(), data_.end(), [&](const auto & d) { return d.collision == col; });
+  }
+
+  auto getData(int id)
+  {
+    return std::find_if(data_.begin(), data_.end(), [&](const auto & d) { return d.id == id; });
+  }
+
+  template<bool Delete>
+  std::vector<DistanceData>::iterator removeOrDeleteDistance(TVMQPSolver & solver,
+                                                             std::vector<DistanceData>::iterator it)
+  {
+    if(it == data_.end()) { return data_.end(); }
+    if(it->task)
+    {
+      solver.problem().remove(*it->task);
+      if constexpr(!Delete) { it->task.reset(); }
+    }
+    if constexpr(Delete) { return data_.erase(it); }
+    else
+    {
+      return it;
+    }
+  }
+
+  void deleteDistance(TVMQPSolver & solver, const mc_rbdyn::Collision & col)
+  {
+    removeOrDeleteDistance<true>(solver, getData(col));
+  }
+
+  void deleteDistance(TVMQPSolver & solver, int id) { removeOrDeleteDistance<true>(solver, getData(id)); }
+
+  void deleteDistances(mc_solver::TVMQPSolver & solver)
+  {
+    for(auto it = data_.begin(); it != data_.end(); ++it) { removeOrDeleteDistance<false>(solver, it); }
+  }
+
+  void clear()
+  {
+    if(!solver)
+    {
+      data_.clear();
+      return;
+    }
+    auto it = data_.begin();
+    while(it != data_.end()) { it = removeOrDeleteDistance<true>(*solver, it); }
+  }
+
+  DistanceData & createDistance(TVMQPSolver & solver,
+                                const mc_rbdyn::Robot & r1,
+                                const mc_rbdyn::Robot & r2,
+                                const mc_rbdyn::Collision & col,
+                                int id,
+                                const Eigen::VectorXd & r1Selector,
+                                const Eigen::VectorXd & r2Selector)
+  {
+    data_.push_back({id, col});
+    auto & data = data_.back();
+    auto & c1 = r1.tvmConvex(col.body1);
+    auto & c2 = r2.tvmConvex(col.body2);
+    data.function = std::make_shared<mc_tvm::DistanceFunction>(c1, c2, r1Selector, r2Selector, solver.dt());
+    return data;
+  }
+
+  void addDistance(TVMQPSolver & solver, DistanceData & data)
+  {
+    const auto & col = data.collision;
+
+    if(col.iDist > col.sDist)
+    {
+      data.task = solver.problem().add(
+          data.function >= 0.,
+          tvm::task_dynamics::VelocityDamper(
+              solver.dt(), {col.iDist, col.sDist, col.damping, mc_solver::DistanceConstraint::defaultDampingOffset},
+              tvm::constant::big_number),
+          {tvm::requirements::PriorityLevel(0)});
+    }
+    else
+    {
+      data.task = solver.problem().add(
+          data.function <= 0.,
+          tvm::task_dynamics::VelocityDamper(
+              solver.dt(), {-col.iDist, -col.sDist, col.damping, mc_solver::DistanceConstraint::defaultDampingOffset},
+              tvm::constant::big_number),
+          {tvm::requirements::PriorityLevel(0)});
+    }
+  }
+};
+
+} // namespace details
+
+/** Helper to cast the constraint */
+static inline mc_rtc::void_ptr_caster<tasks::qp::DistanceConstr> tasks_constraint{};
+static inline mc_rtc::void_ptr_caster<details::TVMDistanceConstraint> tvm_constraint{};
+
+/** Helper for wildcard
+ *
+ * Returns false if body is not a wildcard
+ *
+ * Throws if body is a wildcard but there's no match in robot
+ */
+template<typename Callback>
+bool handle_wildcard(const mc_rbdyn::Robot & robot, const std::string & body, Callback cb)
+{
+  if(body.back() != '*') { return false; }
+  std::string search = body.substr(0, body.size() - 1);
+  bool match = false;
+  for(const auto & convex : robot.convexes())
+  {
+    const auto & cName = convex.first;
+    if(cName.size() < search.size()) { continue; }
+    if(cName.substr(0, search.size()) == search)
+    {
+      match = true;
+      cb(cName);
+    }
+  }
+  if(!match) { mc_rtc::log::error_and_throw("No match found for collision wildcard {} in {}", body, robot.name()); }
+  return true;
+}
+
+static mc_rtc::void_ptr make_constraint(QPSolver::Backend backend, const mc_rbdyn::Robots & robots, double timeStep)
+{
+  switch(backend)
+  {
+    case QPSolver::Backend::Tasks:
+      return mc_rtc::make_void_ptr<tasks::qp::DistanceConstr>(robots.mbs(), timeStep);
+    case QPSolver::Backend::TVM:
+      return mc_rtc::make_void_ptr<details::TVMDistanceConstraint>();
+    default:
+      mc_rtc::log::error_and_throw("[DistanceConstr] Not implemented for solver backend: {}", backend);
+  }
+}
+
+DistanceConstraint::DistanceConstraint(const mc_rbdyn::Robots & robots,
+                                       unsigned int r1Index,
+                                       unsigned int r2Index,
+                                       double timeStep)
+: constraint_(make_constraint(backend_, robots, timeStep)), r1Index(r1Index), r2Index(r2Index), collId(0), collIdDict()
+{
+}
+
+bool DistanceConstraint::removeCollision(QPSolver & solver, const mc_rbdyn::Collision & col)
+{
+  const auto & robots = solver.robots();
+  const mc_rbdyn::Robot & r1 = robots.robot(r1Index);
+  const mc_rbdyn::Robot & r2 = robots.robot(r2Index);
+
+  auto on_b1_wildcard = [&](const std::string & nb1)
+  {
+    auto nCol = col;
+    nCol.body1 = nb1;
+    removeCollision(solver, nCol);
+  };
+
+  auto on_b2_wildcard = [&](const std::string & nb2)
+  {
+    auto nCol = col;
+    nCol.body2 = nb2;
+    removeCollision(solver, nCol);
+  };
+
+  if(handle_wildcard(r1, col.body1, on_b1_wildcard) || handle_wildcard(r2, col.body2, on_b2_wildcard)) { return true; }
+
+  auto p = __popCollId(col);
+
+  if(!p.second.isNone())
+  {
+    if(monitored_.count(p.first)) { toggleCollisionMonitor(p.first, &p.second); }
+
+    category_.push_back("Monitors");
+    std::string name = "Monitor " + p.second.body1 + "/" + p.second.body2;
+    gui_->removeElement(category_, name);
+    category_.pop_back();
+
+    cols.erase(std::find(cols.begin(), cols.end(), p.second));
+
+    switch(backend_)
+    {
+      case QPSolver::Backend::Tasks:
+      {
+        auto collConstr = tasks_constraint(constraint_);
+        auto & qpsolver = tasks_solver(solver);
+        bool ret = collConstr->rmCollision(p.first);
+
+        if(ret)
+        {
+          collConstr->updateNrVars({}, qpsolver.data());
+          qpsolver.updateConstrSize();
+        }
+
+        return ret;
+      }
+
+      case QPSolver::Backend::TVM:
+        tvm_constraint(constraint_)->deleteDistance(tvm_solver(solver), p.second);
+        break;
+
+      default:
+        break;
+    }
+  }
+
+  return false;
+}
+
+void DistanceConstraint::removeCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols)
+{
+  for(const auto & c : cols) { removeCollision(solver, c); }
+}
+
+bool DistanceConstraint::removeCollisionByBody(QPSolver & solver,
+                                               const std::string & b1Name,
+                                               const std::string & b2Name)
+{
+  const auto & r1 = solver.robots().robot(r1Index);
+  const auto & r2 = solver.robots().robot(r2Index);
+  std::vector<mc_rbdyn::Collision> toRm;
+  for(const auto & col : cols)
+  {
+    if(r1.convex(col.body1).first == b1Name && r2.convex(col.body2).first == b2Name)
+    {
+      auto out = __popCollId(col);
+      toRm.push_back(out.second);
+      switch(backend_)
+      {
+        case QPSolver::Backend::Tasks:
+        {
+          auto collConstr = tasks_constraint(constraint_);
+          collConstr->rmCollision(out.first);
+          break;
+        }
+        case QPSolver::Backend::TVM:
+          tvm_constraint(constraint_)->deleteDistance(tvm_solver(solver), out.first);
+          break;
+        default:
+          break;
+      }
+      if(monitored_.count(out.first)) { toggleCollisionMonitor(out.first, &out.second); }
+      category_.push_back("Monitors");
+      std::string name = "Monitor " + __keyByNames(out.second);
+      gui_->removeElement(category_, name);
+      category_.pop_back();
+    }
+  }
+  for(const auto & it : toRm) { cols.erase(std::find(cols.begin(), cols.end(), it)); }
+  if(toRm.size())
+  {
+    switch(backend_)
+    {
+      case QPSolver::Backend::Tasks:
+      {
+        auto collConstr = tasks_constraint(constraint_);
+        auto & qpsolver = tasks_solver(solver);
+        collConstr->updateNrVars({}, qpsolver.data());
+        qpsolver.updateConstrSize();
+        break;
+      }
+      case QPSolver::Backend::TVM:
+        break;
+      default:
+        break;
+    }
+  }
+  return toRm.size() > 0;
+}
+
+void DistanceConstraint::__addCollision(mc_solver::QPSolver & solver, const mc_rbdyn::Collision & col)
+{
+  const auto & robots = solver.robots();
+  const mc_rbdyn::Robot & r1 = robots.robot(r1Index);
+  const mc_rbdyn::Robot & r2 = robots.robot(r2Index);
+  if(col.body1.size() == 0 || col.body2.size() == 0)
+  {
+    mc_rtc::log::error("Attempted to add a collision without a specific body");
+    return;
+  }
+  auto on_b1_wildcard = [&](const std::string & nb1)
+  {
+    auto nCol = col;
+    nCol.body1 = nb1;
+    __addCollision(solver, nCol);
+  };
+  auto on_b2_wildcard = [&](const std::string & nb2)
+  {
+    auto nCol = col;
+    nCol.body2 = nb2;
+    __addCollision(solver, nCol);
+  };
+  if(handle_wildcard(r1, col.body1, on_b1_wildcard) || handle_wildcard(r2, col.body2, on_b2_wildcard)) { return; }
+  int collId = __createCollId(col);
+  if(collId < 0) { return; }
+  cols.push_back(col);
+
+  auto computeJointsSelector =
+      [&robots](const std::optional<std::vector<std::string>> & joints, bool inactive, auto rIndex)
+  {
+    if(joints)
+    {
+      // check that all joints exist
+      for(const auto & j : *joints)
+      {
+        if(!robots.robot(rIndex).hasJoint(j))
+        {
+          mc_rtc::log::error_and_throw("[DistanceConstraint] No joint named \"{}\" in robot \"{}\"", j,
+                                       robots.robot(rIndex).name());
+        }
+      }
+      if(inactive) { return jointsToSelector<false>(robots.robot(rIndex), *joints); }
+      else
+      {
+        return jointsToSelector<true>(robots.robot(rIndex), *joints);
+      }
+    }
+    else
+    {
+      return Eigen::VectorXd::Zero(0).eval();
+    }
+  };
+
+  auto r1Selector = computeJointsSelector(col.r1Joints, col.r1JointsInactive, r1Index);
+  auto r2Selector = r1Index == r2Index ? Eigen::VectorXd::Zero(0).eval()
+                                       : computeJointsSelector(col.r2Joints, col.r2JointsInactive, r2Index);
+
+  switch(backend_)
+  {
+    case QPSolver::Backend::Tasks:
+    {
+      auto collConstr = tasks_constraint(constraint_);
+      const auto & body1 = r1.convex(col.body1);
+      const auto & body2 = r2.convex(col.body2);
+      const sva::PTransformd & X_b1_c = r1.collisionTransform(col.body1);
+      const sva::PTransformd & X_b2_c = r2.collisionTransform(col.body2);
+      if(r1.mb().nrDof() == 0)
+      {
+        collConstr->addCollision(robots.mbs(), collId, static_cast<int>(r2Index), body2.first, body2.second.get(),
+                                 X_b2_c, static_cast<int>(r1Index), body1.first, body1.second.get(), X_b1_c, col.iDist,
+                                 col.sDist, col.damping, defaultDampingOffset, r2Selector, r1Selector);
+      }
+      else
+      {
+        collConstr->addCollision(robots.mbs(), collId, static_cast<int>(r1Index), body1.first, body1.second.get(),
+                                 X_b1_c, static_cast<int>(r2Index), body2.first, body2.second.get(), X_b2_c, col.iDist,
+                                 col.sDist, col.damping, defaultDampingOffset, r1Selector, r2Selector);
+      }
+      break;
+    }
+    case QPSolver::Backend::TVM:
+    {
+      auto & data =
+          tvm_constraint(constraint_)->createDistance(tvm_solver(solver), r1, r2, col, collId, r1Selector, r2Selector);
+      if(inSolver_) { tvm_constraint(constraint_)->addDistance(tvm_solver(solver), data); }
+      break;
+    }
+    default:
+      break;
+  }
+  addMonitorButton(collId, col);
+}
+
+void DistanceConstraint::addMonitorButton(int collId, const mc_rbdyn::Collision & col)
+{
+  if(gui_ && inSolver_)
+  {
+    auto & gui = *gui_;
+    std::string name = col.body1 + "/" + col.body2;
+    category_.push_back("Monitors");
+    gui.addElement(category_, mc_rtc::gui::Checkbox(
+                                  "Monitor " + name, [collId, this]() { return monitored_.count(collId) != 0; },
+                                  [collId, this]() { toggleCollisionMonitor(collId); }));
+    category_.pop_back();
+  }
+}
+
+void DistanceConstraint::toggleCollisionMonitor(int collId, const mc_rbdyn::Collision * col_p)
+{
+  auto findCollisionById = [this, collId, &col_p]()
+  {
+    if(col_p) { return; }
+    for(const auto & c : collIdDict)
+    {
+      if(c.second.first == collId)
+      {
+        col_p = &c.second.second;
+        return;
+      }
+    }
+    mc_rtc::log::error_and_throw("[CollisionConstraint] Attempted to toggleCollisionMonitor on non-existent collision");
+  };
+  findCollisionById();
+  const auto & col = *col_p;
+  auto & gui = *gui_;
+  std::string label = col.body1 + "::" + col.body2;
+  if(monitored_.count(collId))
+  {
+    // Remove the monitor
+    gui.removeElement(category_, label);
+    category_.push_back("Arrows");
+    gui.removeElement(category_, label);
+    category_.pop_back();
+    monitored_.erase(collId);
+  }
+  else
+  {
+    auto addMonitor = [&](auto && distance_callback, auto && p1_callback, auto && p2_callback)
+    {
+      gui.addElement(category_, mc_rtc::gui::Label(label, [distance_callback]()
+                                                   { return fmt::format("{:0.2f} cm", 100.0 * distance_callback()); }));
+      category_.push_back("Arrows");
+      gui.addElement(category_, mc_rtc::gui::Arrow(label, p1_callback, p2_callback));
+      category_.pop_back();
+    };
+    // Add the monitor
+    switch(backend_)
+    {
+      case QPSolver::Backend::Tasks:
+      {
+        auto collConstr = tasks_constraint(constraint_);
+        addMonitor(
+            [collConstr, collId]() { return collConstr->getCollisionData(collId).distance; },
+            [collConstr, collId]() -> const Eigen::Vector3d & { return collConstr->getCollisionData(collId).p1; },
+            [collConstr, collId]() -> const Eigen::Vector3d & { return collConstr->getCollisionData(collId).p2; });
+        break;
+      }
+      case QPSolver::Backend::TVM:
+      {
+        auto collConstr = tvm_constraint(constraint_);
+        auto fn = collConstr->getData(collId)->function;
+        addMonitor([fn]() { return fn->distance(); }, [fn]() -> const Eigen::Vector3d & { return fn->p1(); },
+                   [fn]() -> const Eigen::Vector3d & { return fn->p2(); });
+        break;
+      }
+      default:
+        break;
+    }
+    monitored_.insert(collId);
+  }
+}
+
+void DistanceConstraint::addCollision(QPSolver & solver, const mc_rbdyn::Collision & col)
+{
+  addCollisions(solver, {col});
+}
+
+void DistanceConstraint::addCollisions(QPSolver & solver, const std::vector<mc_rbdyn::Collision> & cols)
+{
+  for(const auto & c : cols) { __addCollision(solver, c); }
+  switch(backend_)
+  {
+    case QPSolver::Backend::Tasks:
+    {
+      auto & collConstr = *tasks_constraint(constraint_);
+      auto & qpsolver = tasks_solver(solver);
+      collConstr.updateNrVars({}, qpsolver.data());
+      qpsolver.updateConstrSize();
+      break;
+    }
+    case QPSolver::Backend::TVM:
+      break;
+    default:
+      break;
+  }
+}
+
+void DistanceConstraint::addToSolverImpl(QPSolver & solver)
+{
+  gui_ = solver.gui();
+  const mc_rbdyn::Robot & r1 = solver.robots().robot(r1Index);
+  const mc_rbdyn::Robot & r2 = solver.robots().robot(r2Index);
+  category_ = {"Collisions", r1.name() + "/" + r2.name()};
+  gui_->addElement(category_, mc_rtc::gui::Checkbox("Automatic monitor", autoMonitor_));
+  switch(backend_)
+  {
+    case QPSolver::Backend::Tasks:
+    {
+      auto & collConstr = *tasks_constraint(constraint_);
+      auto & qpsolver = tasks_solver(solver);
+      collConstr.addToSolver(solver.robots().mbs(), qpsolver.solver());
+      break;
+    }
+    case QPSolver::Backend::TVM:
+    {
+      auto cstr = tvm_constraint(constraint_);
+      for(auto & c : cstr->data_) { tvm_constraint(constraint_)->addDistance(tvm_solver(solver), c); }
+      tvm_constraint(constraint_)->solver = &tvm_solver(solver);
+      break;
+    }
+    default:
+      break;
+  }
+  for(const auto & cols : collIdDict) { addMonitorButton(cols.second.first, cols.second.second); }
+}
+
+void DistanceConstraint::update(QPSolver &)
+{
+  if(!autoMonitor_) { return; }
+  auto getDistance = [this](int collId)
+  {
+    switch(backend_)
+    {
+      case QPSolver::Backend::Tasks:
+      {
+        auto collConstr = tasks_constraint(constraint_);
+        return collConstr->getCollisionData(collId).distance;
+      }
+      case QPSolver::Backend::TVM:
+      {
+        auto collConstr = tvm_constraint(constraint_);
+        auto & fn = collConstr->getData(collId)->function;
+        return fn->distance();
+      }
+      default:
+        mc_rtc::log::error_and_throw("Not implemented for this backend");
+    }
+  };
+  for(const auto & [name, info] : collIdDict)
+  {
+    const auto & [collId, coll] = info;
+    auto distance = getDistance(collId);
+    if(distance < coll.iDist && coll.iDist > coll.sDist && !monitored_.count(collId))
+    {
+      toggleCollisionMonitor(collId, &coll);
+    }
+    if(distance > coll.iDist && coll.iDist > coll.sDist && monitored_.count(collId))
+    {
+      toggleCollisionMonitor(collId, &coll);
+    }
+    if(distance > coll.iDist && coll.iDist < coll.sDist && !monitored_.count(collId))
+    {
+      toggleCollisionMonitor(collId, &coll);
+    }
+    if(distance < coll.iDist && coll.iDist < coll.sDist && monitored_.count(collId))
+    {
+      toggleCollisionMonitor(collId, &coll);
+    }
+  }
+}
+
+void DistanceConstraint::removeFromSolverImpl(QPSolver & solver)
+{
+  switch(backend_)
+  {
+    case QPSolver::Backend::Tasks:
+    {
+      auto & collConstr = *tasks_constraint(constraint_);
+      auto & qpsolver = tasks_solver(solver);
+      collConstr.removeFromSolver(qpsolver.solver());
+      break;
+    }
+    case QPSolver::Backend::TVM:
+    {
+      tvm_constraint(constraint_)->deleteDistances(tvm_solver(solver));
+      tvm_constraint(constraint_)->solver = nullptr;
+      break;
+    }
+    default:
+      break;
+  }
+  gui_->removeCategory(category_);
+}
+
+void DistanceConstraint::reset()
+{
+  cols.clear();
+  collIdDict.clear();
+  switch(backend_)
+  {
+    case QPSolver::Backend::Tasks:
+      tasks_constraint(constraint_)->reset();
+      break;
+    case QPSolver::Backend::TVM:
+      tvm_constraint(constraint_)->clear();
+      break;
+    default:
+      break;
+  }
+  if(gui_) { gui_->removeCategory(category_); }
+}
+
+std::string DistanceConstraint::__keyByNames(const mc_rbdyn::Collision & col)
+{
+  return col.body1 + "/" + col.body2 + (col.iDist > col.sDist ? "_min" : "_max");
+}
+
+int DistanceConstraint::__createCollId(const mc_rbdyn::Collision & col)
+{
+  std::string key = __keyByNames(col);
+
+  auto it = collIdDict.find(key);
+  if(it != collIdDict.end()) { return -1; }
+
+  int collId = this->collId;
+  collIdDict[key] = std::pair<int, mc_rbdyn::Collision>(collId, col);
+  this->collId += 1;
+  return collId;
+}
+
+std::pair<int, mc_rbdyn::Collision> DistanceConstraint::__popCollId(const mc_rbdyn::Collision & col)
+{
+  std::string key = __keyByNames(col);
+
+  if(collIdDict.count(key))
+  {
+    std::pair<int, mc_rbdyn::Collision> p = collIdDict[key];
+    collIdDict.erase(key);
+    return p;
+  }
+
+  return std::pair<unsigned int, mc_rbdyn::Collision>(0, mc_rbdyn::Collision());
+}
+
+bool DistanceConstraint::hasCollision(const std::string & c1, const std::string & c2) const noexcept
+{
+  auto it = std::find_if(cols.begin(), cols.end(), [&](const auto & c) { return c.body1 == c1 && c.body2 == c2; });
+  return it != cols.end();
+}
+
+} // namespace mc_solver
+
+namespace
+{
+
+static auto registered = mc_solver::ConstraintSetLoader::register_load_function(
+    "distance",
+    [](mc_solver::QPSolver & solver, const mc_rtc::Configuration & config)
+    {
+      auto ret = std::make_shared<mc_solver::DistanceConstraint>(
+          solver.robots(), robotIndexFromConfig(config, solver.robots(), "distance", false, "r1Index", "r1", ""),
+          robotIndexFromConfig(config, solver.robots(), "distance", false, "r2Index", "r2", ""), solver.dt());
+      ret->automaticMonitor(config("automaticMonitor", true));
+      if(ret->r1Index == ret->r2Index)
+      {
+        if(config("useCommon", false))
+        {
+          ret->addCollisions(solver, solver.robots().robotModule(ret->r1Index).commonSelfCollisions());
+        }
+        else if(config("useMinimal", false))
+        {
+          ret->addCollisions(solver, solver.robots().robotModule(ret->r1Index).minimalSelfCollisions());
+        }
+      }
+      std::vector<mc_rbdyn::Collision> collisions = config("distances", std::vector<mc_rbdyn::Collision>{});
+      ret->addCollisions(solver, collisions);
+      return ret;
+    });
+} // namespace

--- a/src/mc_tvm/DistanceFunction.cpp
+++ b/src/mc_tvm/DistanceFunction.cpp
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
+ */
+
+#include <mc_tvm/DistanceFunction.h>
+
+#include <mc_tvm/Robot.h>
+#include <mc_tvm/RobotFrame.h>
+
+#include <mc_rbdyn/Robot.h>
+#include <mc_rbdyn/RobotFrame.h>
+#include <mc_rbdyn/SCHAddon.h>
+
+namespace mc_tvm
+{
+
+static Convex * max(Convex & c1, Convex & c2)
+{
+  if(c1.frame().robot().mb().nrDof() < c2.frame().robot().mb().nrDof()) { return &c2; }
+  return &c1;
+}
+
+DistanceFunction::DistanceFunction(Convex & c1,
+                                   Convex & c2,
+                                   const Eigen::VectorXd & r1Selector,
+                                   const Eigen::VectorXd & r2Selector,
+                                   double dt)
+: tvm::function::abstract::Function(1), c1_(max(c1, c2)), c2_(c1_ == &c1 ? &c2 : &c1), dt_(dt),
+  pair_(c1_->convex().get(), c2_->convex().get())
+{
+  // clang-format off
+  registerUpdates(Update::Value, &DistanceFunction::updateValue,
+                  Update::Velocity, &DistanceFunction::updateVelocity,
+                  Update::Jacobian, &DistanceFunction::updateJacobian,
+                  Update::NormalAcceleration, &DistanceFunction::updateNormalAcceleration);
+  // clang-format on
+
+  addOutputDependency<DistanceFunction>(Output::Value, Update::Value);
+  addOutputDependency<DistanceFunction>(Output::Velocity, Update::Velocity);
+  addOutputDependency<DistanceFunction>(Output::Jacobian, Update::Jacobian);
+  addOutputDependency<DistanceFunction>(Output::NormalAcceleration, Update::NormalAcceleration);
+
+  addInternalDependency<DistanceFunction>(Update::Jacobian, Update::Value);
+  addInternalDependency<DistanceFunction>(Update::Velocity, Update::Jacobian);
+  addInternalDependency<DistanceFunction>(Update::NormalAcceleration, Update::Value);
+
+  const Eigen::VectorXd * r1Selector_ = c1_ == &c1 ? &r1Selector : &r2Selector;
+  const Eigen::VectorXd * r2Selector_ = c1_ == &c1 ? &r2Selector : &r1Selector;
+  auto addConvex = [this](Convex & convex, const Eigen::VectorXd & selector)
+  {
+    auto & r = convex.frame().robot();
+    if(r.mb().nrDof() > 0)
+    {
+      auto & tvm_robot = r.tvmRobot();
+      addInputDependency<DistanceFunction>(Update::Value, convex, Convex::Output::Position);
+      addInputDependency<DistanceFunction>(Update::Jacobian, tvm_robot, mc_tvm::Robot::Output::FV);
+      addInputDependency<DistanceFunction>(Update::NormalAcceleration, tvm_robot,
+                                           mc_tvm::Robot::Output::NormalAcceleration);
+      addVariable(tvm_robot.q(), false);
+      data_.push_back({Eigen::Vector3d::Zero(), convex.frame().tvm_frame().rbdJacobian(), selector});
+    }
+    return r.mb().nrDof();
+  };
+  // By construction c1's robot has more dofs than c2's
+  auto maxDof = addConvex(*c1_, *r1Selector_);
+  addConvex(*c2_, *r2Selector_);
+
+  fullJac_.resize(1, maxDof);
+  distJac_.resize(1, maxDof);
+}
+
+void DistanceFunction::updateValue()
+{
+  double dist = sch::mc_rbdyn::distance(pair_, p1_, p2_);
+  if(dist == 0) { dist = sch::epsilon; }
+  dist = dist >= 0 ? std::sqrt(dist) : -std::sqrt(-dist);
+  normVecDist_ = (p1_ - p2_) / dist;
+  if(iter_ == 1) { prevNormVecDist_ = normVecDist_; }
+  if(prevIter_ != iter_)
+  {
+    speedVec_ = (normVecDist_ - prevNormVecDist_) / dt_;
+    prevNormVecDist_ = normVecDist_;
+    prevIter_ = iter_;
+  }
+  auto object = std::ref(c1_);
+  auto point = std::ref(p1_);
+  for(size_t i = 0; i < data_.size(); ++i)
+  {
+    auto & d = data_[i];
+    d.nearestPoint_ = (sva::PTransformd(point) * object.get()->frame().position().inv()).translation();
+    d.jac_.point(d.nearestPoint_);
+    object = std::ref(c2_);
+    point = std::ref(p2_);
+  }
+  value_(0) = dist;
+}
+
+void DistanceFunction::tick()
+{
+  iter_++;
+}
+
+void DistanceFunction::updateJacobian()
+{
+  for(int i = 0; i < variables_.numberOfVariables(); ++i) { jacobian_[variables_[i].get()].setZero(); }
+  double sign = 1.0;
+  auto object = std::ref(c1_);
+  auto point = std::ref(p1_);
+  for(size_t i = 0; i < data_.size(); ++i)
+  {
+    auto & d = data_[i];
+    const auto & r = object.get()->frame().robot();
+    const auto & tvm_robot = r.tvmRobot();
+    const auto & jac = d.jac_.jacobian(r.mb(), r.mbc());
+    distJac_.block(0, 0, 1, d.jac_.dof()).noalias() =
+        (sign * normVecDist_).transpose() * jac.block(3, 0, 3, d.jac_.dof());
+    d.jac_.fullJacobian(r.mb(), distJac_.block(0, 0, 1, d.jac_.dof()), fullJac_);
+    if(d.selector_.size() == 0) { jacobian_[tvm_robot.q().get()] += fullJac_.block(0, 0, 1, r.mb().nrDof()); }
+    else
+    {
+      jacobian_[tvm_robot.q().get()] += fullJac_.block(0, 0, 1, r.mb().nrDof()) * d.selector_.asDiagonal();
+    }
+    sign = -1.0;
+    object = std::ref(c2_);
+    point = std::ref(p2_);
+  }
+}
+
+void DistanceFunction::updateVelocity()
+{
+  velocity_(0) = 0;
+  double sign = 1.0;
+  auto object = std::ref(c1_);
+  auto point = std::ref(p1_);
+  for(size_t i = 0; i < data_.size(); ++i)
+  {
+    auto & d = data_[i];
+    const auto & r = object.get()->frame().robot();
+    velocity_(0) += sign * d.jac_.velocity(r.mb(), r.mbc()).linear().dot(normVecDist_);
+    sign = -1.0;
+    object = std::ref(c2_);
+    point = std::ref(p2_);
+  }
+}
+
+void DistanceFunction::updateNormalAcceleration()
+{
+  normalAcceleration_(0) = 0;
+  double sign = 1.0;
+  auto object = std::ref(c1_);
+  auto point = std::ref(p1_);
+  for(size_t i = 0; i < data_.size(); ++i)
+  {
+    auto & d = data_[i];
+    const auto & r = object.get()->frame().robot();
+    const auto & tvm_robot = r.tvmRobot();
+    Eigen::Vector3d pNormalAcc = d.jac_.normalAcceleration(r.mb(), r.mbc(), tvm_robot.normalAccB()).linear();
+    Eigen::Vector3d pSpeed = d.jac_.velocity(r.mb(), r.mbc()).linear();
+    normalAcceleration_(0) += sign * (pNormalAcc.dot(normVecDist_) + pSpeed.dot(speedVec_));
+    sign = -1.0;
+    object = std::ref(c2_);
+    point = std::ref(p2_);
+  }
+}
+
+} // namespace mc_tvm

--- a/tests/controllers/TestFSMStateOptions.cpp
+++ b/tests/controllers/TestFSMStateOptions.cpp
@@ -2,6 +2,7 @@
  * Copyright 2015-2022 CNRS-UM LIRMM, CNRS-AIST JRL
  */
 
+#include "mc_rbdyn/DistanceLimit.h"
 #ifdef BOOST_TEST_MAIN
 #  undef BOOST_TEST_MAIN
 #endif
@@ -149,10 +150,10 @@ public:
     return ref.friction == c.friction && ref.dof == c.dof;
   }
 
-  bool hasCollision(const std::string & r1, const std::string & r2, const mc_rbdyn::Collision & col)
+  bool hasCollision(const std::string & r1, const std::string & r2, const mc_rbdyn::DistanceLimit & col)
   {
     if(!collision_constraints_.count({r1, r2})) { return false; }
-    const auto & cols = collision_constraints_.at({r1, r2})->cols;
+    const auto & cols = collision_constraints_.at({r1, r2})->dls;
     return std::find(cols.begin(), cols.end(), col) != cols.end();
   }
 

--- a/tests/testJsonIO.cpp
+++ b/tests/testJsonIO.cpp
@@ -347,7 +347,7 @@ bool operator==(const mc_rbdyn::RobotModule & lhs, const mc_rbdyn::RobotModule &
          && lhs._accelerationBounds == rhs._accelerationBounds && lhs._jerkBounds == rhs._jerkBounds
          && lhs._torqueDerivativeBounds == rhs._torqueDerivativeBounds && lhs._stance == rhs._stance
          && compareHulls(lhs._convexHull, rhs._convexHull) && compareHulls(lhs._stpbvHull, rhs._stpbvHull)
-         && compare_vector_maps(lhs._visual, rhs._visual) && lhs._collisionTransforms == rhs._collisionTransforms
+         && compare_vector_maps(lhs._visual, rhs._visual) && lhs._convexTransforms == rhs._convexTransforms
          && compare_vectors(lhs._flexibility, rhs._flexibility) && compare_vectors(lhs._forceSensors, rhs._forceSensors)
          && compare_vectors(lhs._bodySensors, rhs._bodySensors) && lhs._springs == rhs._springs
          && lhs._minimalSelfCollisions == rhs._minimalSelfCollisions

--- a/tests/test_mc_rbdyn_robots.cpp
+++ b/tests/test_mc_rbdyn_robots.cpp
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(TestRobotLoadingWithCollisionObjects)
   configureRobotLoader();
   auto rm = mc_rbdyn::RobotLoader::get_robot_module("JVRC1");
   rm->_collisionObjects["L_HAND_SPHERE"] = {"L_WRIST_Y_S", std::make_shared<sch::S_Sphere>(0.09)};
-  rm->_collisionTransforms["L_HAND_SPHERE"] = sva::PTransformd::Identity();
+  rm->_convexTransforms["L_HAND_SPHERE"] = sva::PTransformd::Identity();
   auto envrm = mc_rbdyn::RobotLoader::get_robot_module("env", std::string(mc_rtc::MC_ENV_DESCRIPTION_PATH),
                                                        std::string("ground"));
   TestRobotLoadingCommon(rm, envrm);


### PR DESCRIPTION
This PR replaces #572 

This PR (together with [#131](https://github.com/jrl-umi3218/Tasks/pull/131) of `Tasks` allows to use `CollisionConstraint` for defining both min and max distance constraints. 

For min distance (or collision) constraint, the interaction distance $d_i$ is greater than security distance $d_s$. 
When constraint is defined with $d_i$ less than $d_s$, the constraint behaviour is that of maximum distance constraint.

Remaining changes to be done associated to this PR:
* Rename `CollisionConstraint` in `mc_rtc` into `DistanceConstraint`, while taking care of backward compatibility
* Add loader `AddDstanceConstraint` (alongside `AddCollisions`)
* Implement the TVM part
* Update constraint documentation
* anything else?