### PR TITLE
feat(observer): sync jointTorque into realRobot in EncoderObserver

### DIFF
--- a/doc/_data/schemas/Observers/Encoder.json
+++ b/doc/_data/schemas/Observers/Encoder.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "title": "mc_observers::EncoderObserver",
-  "description": "The Encoder Observer updates the state of a robot kinematic properties (body positions and velocities) using joint sensor values. It can use various sources as sensor input: encoder position, encoder velocity, values from another robot, and can also estimate joint velocities from encoder position by finite differences.",
+  "description": "The Encoder Observer updates the state of a robot kinematic properties (body positions and velocities) using joint sensor values. It can use various sources as sensor input: encoder position, encoder velocity, encoder torque, values from another robot, and can also estimate joint velocities from encoder position by finite differences.",
   "properties":
   {
     "type": { "const": "Encoder" },
@@ -9,6 +9,7 @@
     "updateRobot": { "type": "string", "default": "&lt;robot&gt;", "description": "Name of the robot to update" },
     "position": { "enum": ["encoderValues", "control", "none"], "default": "encoderValues", "description": "Sensor/method used to observe joint position" },
     "velocity": { "enum": ["encoderFiniteDifferences", "encoderVelocities", "control", "none"], "default": "encoderFiniteDifferences", "description": "Sensor/method used to observe joint velocity" },
+    "torque": { "enum": ["jointTorques", "control", "none"], "default": "jointTorques", "description": "Sensor/method used to observe joint torque" },
     "computeFK": { "type": "boolean", "default": true, "description": "When true, the update computes forward kinematics" },
     "computeFV": { "type": "boolean", "default": true, "description": "When true, the update computes forward velocity" },
     "log":
@@ -18,7 +19,8 @@
       "properties":
       {
         "position": { "type": "boolean", "default": false, "description": "When true, logs the estimated position of all actuated joints" },
-        "velocity": { "type": "boolean", "default": true, "description": "When true, logs the estimated velocity of all actuated joints" }
+        "velocity": { "type": "boolean", "default": true, "description": "When true, logs the estimated velocity of all actuated joints" },
+        "torque": { "type": "boolean", "default": false, "description": "When true, logs the estimated torque of all actuated joints" }
       }
     }
   }

--- a/doc/_data/schemas/Observers/ObserverPipeline.json
+++ b/doc/_data/schemas/Observers/ObserverPipeline.json
@@ -1,7 +1,7 @@
 {
   "type": "object",
   "title": "mc_observers::ObserverPipeline",
-  "description": "State observation pipeline.<br/>Observers are responsible for estimating some of the robot properties from sensor measurements and/or fusing several source of information (e.g the Encoder observer estimates the joint position and velocity based on joint sensors, the KinematicInertial observers the state of the floating base from kinematics and IMU information, etc).<br/>These observers may be grouped into a \"State observation pipeline\", that will run each observer sequentially. Some observers may be used to update the state of the real robots instances used by the controller, while others may only be used for logging estimated values for comparison purposes.",
+  "description": "State observation pipeline.<br/>Observers are responsible for estimating some of the robot properties from sensor measurements and/or fusing several source of information (e.g the Encoder observer estimates the joint position, velocity and torque based on joint sensors, the KinematicInertial observers the state of the floating base from kinematics and IMU information, etc).<br/>These observers may be grouped into a \"State observation pipeline\", that will run each observer sequentially. Some observers may be used to update the state of the real robots instances used by the controller, while others may only be used for logging estimated values for comparison purposes.",
   "properties": {
     "name": {
       "type": "string",
@@ -36,7 +36,7 @@
         "properties": {
           "type": {
             "type": "string",
-            "description": "Name of the observer. This is the name exported by each observer library, for default observers see the entries in \"Observer objects\". The main default observers are:<br /><ul><li><b>Encoder</b>: estimates a robot's joint state (position and velocity)</li><li><b>KinematicInertial</b>: estimates a robot's floating base state based on IMU and a kinematic information</li><li><b>BodySensor</b>: sets the floating base state based on a BodySensor (typically used to obtain groundtruth state from a simulator)</li></ul>"
+            "description": "Name of the observer. This is the name exported by each observer library, for default observers see the entries in \"Observer objects\". The main default observers are:<br /><ul><li><b>Encoder</b>: estimates a robot's joint state (position, velocity, torque)</li><li><b>KinematicInertial</b>: estimates a robot's floating base state based on IMU and a kinematic information</li><li><b>BodySensor</b>: sets the floating base state based on a BodySensor (typically used to obtain groundtruth state from a simulator)</li></ul>"
           },
           "name": {
             "type": "string",

--- a/doc/_examples/json/Observers/Encoder.json
+++ b/doc/_examples/json/Observers/Encoder.json
@@ -3,9 +3,11 @@
   "updateRobot": "jvrc1",
   "position": "encoderValues",
   "velocity": "encoderFiniteDifferences",
+  "torque": "jointTorques",
   "log":
   {
     "position": false,
-    "velocity": true
+    "velocity": true,
+    "torque": false
   }
 }

--- a/doc/_examples/yaml/Observers/Encoder.yaml
+++ b/doc/_examples/yaml/Observers/Encoder.yaml
@@ -3,6 +3,8 @@ robot: jvrc1
 updateRobot: jvrc1
 position: encoderValues
 velocity: encoderFiniteDifferences
+torque: jointTorques
 log:
   position: false
   velocity: true
+  torque: false

--- a/doc/_i18n/en/tutorials/recipes/observers.md
+++ b/doc/_i18n/en/tutorials/recipes/observers.md
@@ -4,7 +4,7 @@ Each controller has its own requirements on what the state of the observed robot
 
 The framework provides a mechanism, refered to as **State Observation Pipelines**, to simplify and generalize the observation of a robot, or multiple robots states. The concept is to view state observation as a pipelines, where each pipeline is composed of multiple observers executed sequentially. Each observer is a component responsible for estimating part of the robot state. When combined together, all observers in a pipeline contribute to provide a full estimation of the desired robot state. Multiple pipelines can be defined and executed allowing to estimate the state of multiple robots, or to perform comparisons between multiple estimation methods. The observers themselves are, as is the case for controller, tasks, plugins, loaded from libraries with a simple interface, allowing to conveniently define your own. The framework currently provides the following observers by default:
 
-- **Encoder Observer**: estimates a robot's joint state (position and velocity) and computes forward kinematics and velocities to obtain body positions and velocities. Various inputs may be used: encoder position, encoder velocity (obtained from a velocity sensor or by finite differences of position), another robot's joint values, etc.
+- **Encoder Observer**: estimates a robot's joint state (position, velocity and torque) and computes forward kinematics and velocities to obtain body positions and velocities. Various inputs may be used: encoder position, encoder velocity (obtained from a velocity sensor or by finite differences of position), another robot's joint values, etc.
 - **BodySensor Observer**: sets a robot's floating base state from measurements provided by a sensor attached to a robot body and the kinematics between the sensor and the floating base. This is typically be used to exploit ground truth measurement from a simulator, or exploit the results of an external component providing information about the floating base (MOCAP, embedded estimator on the robot plateform, etc).
 - **KinematicInertial Observer**: estimates a robot's floating base pose (position + orientation) and velocity (low-pass filtered finite differences of position) from a {% doxygen mc_rbdyn::BodySensor %} (IMU orientation) and a kinematic anchor frame.
 
@@ -71,13 +71,13 @@ When creating a controller with the above pipeline, the framework will display a
 
 ```
 ObserverPipelines:
-- ExamplePipeline: Encoder (position=encoderValues,velocity=encoderFiniteDifferences) -> [BodySensor (sensor=FloatingBase,update=sensor)] ->  KinematicInertial (sensor=Accelerometer,cutoff=0.010000)
+- ExamplePipeline: Encoder (position=encoderValues,velocity=encoderFiniteDifferences, torque=jointTorques) -> [BodySensor (sensor=FloatingBase,update=sensor)] ->  KinematicInertial (sensor=Accelerometer,cutoff=0.010000)
 ```
 
 This displays information about the running pipelines, and their sequence of observers. Observers displayed between `[..]` brackets are run but do not affect the state of the `realRobots` instance. After running the pipelines, the `realRobots` instances now contain the estimated robot states, and can be used in the controller.
 
 For instance, with the above pipeline you can:
-- Get joint position `readRobot().mbc().q()` and velocity `realRobot().mbc().alpha()`
+- Get joint position `readRobot().mbc().q()`, velocity `realRobot().mbc().alpha()` and torque `realRobot().mbc().jointTorque()`
 - Get the floating base pose `realRobot().posW()`
 - Get the floating base velocity `realRobot().velW()`
 - Get the pose of a body: `realRobot().bodyPosW("bodyName");`
@@ -113,10 +113,11 @@ This section provides a brief description of the default observers provided with
 - API: {% doxygen mc_observers::EncoderObserver %}
 - [JSON Schema](../../json.html#Observers/Encoder)
 
-The encoder observer may be used to obtain the position and velocity of all actuated joints.
+The encoder observer may be used to obtain the position, velocity and torque of all actuated joints.
 
 - Joint values can be obtained from sensor as provided by {% doxygen mc_rbdyn::Robot::encoderValues() %} or using the joint state of another robot {% doxygen mc_rbdyn::Robot::q() %}.
 - Joint velocities can be obtained from a joint velocity sensor {% doxygen mc_rbdyn::Robot::encoderVelocities() %}, estimated by finite differences of the (estimated) position, or using the joint velocities of another robot {% doxygen mc_rbdyn::Robot::alpha() %}
+- Joint torques can be obtained from a joint torque sensor {% doxygen mc_rbdyn::Robot::jointTorques() %} or using the joint torques of another robot {% doxygen mc_rbdyn::Robot::alpha() %}
 - The observer will compute forward kinematics {% doxygen mc_rbdyn::Robot::forwardKinematics() %} and forward velocity {% doxygen mc_rbdyn::Robot::forwardVelocity() %} to update the corresponding body positions and velocities (which may be required by subsequent observers).
 
 ## BodySensor observer

--- a/include/mc_observers/EncoderObserver.h
+++ b/include/mc_observers/EncoderObserver.h
@@ -14,6 +14,7 @@ namespace mc_observers
  *
  * Position is directly obtained from sensor values
  * Velocity is then computed by finite differences
+ * Joint torque is synced from robot.jointTorques()
  *
  * The default behaviour is to update the real robot from the estimated position and velocity.
  *
@@ -76,9 +77,17 @@ protected:
     EncoderFiniteDifferences, ///< Joint velocity from finite differences of robot.encoderValues (encoder sensor)
     None ///< Do not compute/update value
   };
+  /*! Torque update type */
+  enum class TorqueUpdate
+  {
+    Control, ///< Use joint torques from robot.mbc.jointTorque (control)
+    JointTorques, ///< Joint torque from robot.jointTorques (torque sensor)
+    None ///< Do not compute/update value
+  };
 
   PosUpdate posUpdate_ = PosUpdate::EncoderValues;
   VelUpdate velUpdate_ = VelUpdate::EncoderFiniteDifferences;
+  TorqueUpdate torqueUpdate_ = TorqueUpdate::JointTorques;
   bool computeFK_ = true; ///< Whether to compute forward kinematics
   bool computeFV_ = true; ///< Whether to compute forward velocity
 
@@ -92,6 +101,7 @@ protected:
 
   bool logPosition_ = false;
   bool logVelocity_ = true;
+  bool logTorque_ = false;
 };
 
 } // namespace mc_observers

--- a/src/mc_observers/EncoderObserver.cpp
+++ b/src/mc_observers/EncoderObserver.cpp
@@ -48,6 +48,17 @@ void EncoderObserver::configure(const mc_control::MCController & ctl, const mc_r
     ;
   }
 
+  const std::string & torque = config("torque", std::string("jointTorques"));
+  if(torque == "control") { torqueUpdate_ = TorqueUpdate::Control; }
+  else if(torque == "jointTorques") { torqueUpdate_ = TorqueUpdate::JointTorques; }
+  else if(torque == "none") { torqueUpdate_ = TorqueUpdate::None; }
+  else
+  {
+    mc_rtc::log::error_and_throw("[EncoderObserver::{}] Invalid configuration value \"{}\" for field \"torque\" (valid "
+                                 "values are [control, jointTorques, none])",
+                                 name_, torque);
+  }
+
   config("computeFK", computeFK_);
   config("computeFV", computeFV_);
 
@@ -56,9 +67,10 @@ void EncoderObserver::configure(const mc_control::MCController & ctl, const mc_r
     auto lConfig = config("log");
     lConfig("position", logPosition_);
     lConfig("velocity", logVelocity_);
+    lConfig("torque", logTorque_);
   }
 
-  desc_ = name_ + " (position=" + position + ",velocity=" + velocity + ")";
+  desc_ = name_ + " (position=" + position + ",velocity=" + velocity + ",torque=" + torque + ")";
 }
 
 void EncoderObserver::reset(const mc_control::MCController &)
@@ -115,9 +127,13 @@ void EncoderObserver::update(mc_control::MCController & ctl)
   const auto & robot = ctl.robots().robot(robot_);
   auto & realRobot = realRobots.robot(updateRobot_);
   const auto & q = robot.encoderValues();
+  const auto & tau = robot.jointTorques();
 
   // Set all joint values and velocities from encoders
   size_t nJoints = realRobot.refJointOrder().size();
+
+  bool tauValid = (tau.size() == nJoints);
+
   for(size_t i = 0; i < nJoints; ++i)
   {
     const auto joint_index = robot.jointIndexInMBC(i);
@@ -137,6 +153,16 @@ void EncoderObserver::update(mc_control::MCController & ctl)
       else if(velUpdate_ == VelUpdate::EncoderVelocities)
       {
         realRobot.mbc().alpha[jidx][0] = robot.encoderVelocities()[i];
+      }
+
+      // Update torque
+      if(torqueUpdate_ == TorqueUpdate::Control)
+      {
+        realRobot.mbc().jointTorque[jidx][0] = robot.mbc().jointTorque[jidx][0];
+      }
+      else if(torqueUpdate_ == TorqueUpdate::JointTorques)
+      {
+        realRobot.mbc().jointTorque[jidx][0] = tauValid ? tau[i] : 0.0;
       }
     }
   }
@@ -204,6 +230,36 @@ void EncoderObserver::addToLogger(const mc_control::MCController & ctl,
                              }
                            }
                            return alpha;
+                         });
+    }
+  }
+  if(logTorque_)
+  {
+    if(torqueUpdate_ == TorqueUpdate::JointTorques)
+    {
+      logger.addLogEntry(category + "_jointTorques", this,
+                         [this, &ctl]() -> const std::vector<double> & { return ctl.robot(robot_).jointTorques(); });
+    }
+    else if(torqueUpdate_ == TorqueUpdate::Control)
+    {
+      std::vector<double> tau(ctl.robot(robot_).refJointOrder().size(), 0);
+      logger.addLogEntry(category + "_controlTorques", this,
+                         [this, &ctl, tau]() mutable -> const std::vector<double> &
+                         {
+                           tau.resize(ctl.robot(robot_).refJointOrder().size());
+                           for(size_t i = 0; i < tau.size(); ++i)
+                           {
+                             auto jIdx = ctl.robot(robot_).jointIndexInMBC(i);
+                             if(jIdx != -1)
+                             {
+                               tau[i] = ctl.robot(robot_).mbc().jointTorque[static_cast<size_t>(jIdx)][0];
+                             }
+                             else
+                             {
+                               tau[i] = 0.0;
+                             }
+                           }
+                           return tau;
                          });
     }
   }


### PR DESCRIPTION
This pull request extends `EncoderObserver` to synchronize and log joint torque measurements, in addition to the existing joint position and velocity support.

Before this change, `realRobot.mbc().jointTorque` was always empty, while torque measurements were only available through `robot.jointTorques()`. With this PR, joint position, velocity, and torque measurements are all synchronized into `realRobot.mbc()`, providing a consistent and unified interface for accessing robot state data. This aligns torque handling with the existing convention used for positions and velocities.
