### PR TITLE
fix: update tutorial website to match latest code

### DIFF
--- a/doc/_i18n/en/tutorials/introduction/dual-arm-controller/add_collision_constraint.py
+++ b/doc/_i18n/en/tutorials/introduction/dual-arm-controller/add_collision_constraint.py
@@ -2,6 +2,6 @@
 iDist, sDist, damping = 0.1, 0.05, 0.0
 self.addCollisions(
     "ur5e",
-    "kinova_default",
+    "kinova",
     [mc_rbdyn.Collision("*", "*", iDist, sDist, damping)],
 )

--- a/doc/_i18n/en/tutorials/introduction/dual-arm-controller/add_ur5e_tasks.cpp
+++ b/doc/_i18n/en/tutorials/introduction/dual-arm-controller/add_ur5e_tasks.cpp
@@ -4,6 +4,7 @@
 struct DualArmController_DLLAPI DualArmController : public mc_control::MCController
 {
   // ...
+private:
   std::shared_ptr<mc_tasks::EndEffectorTask> urEndEffectorTask_;
   // ...
 }

--- a/doc/_i18n/en/tutorials/introduction/dual-arm-controller/p3.cpp
+++ b/doc/_i18n/en/tutorials/introduction/dual-arm-controller/p3.cpp
@@ -1,4 +1,4 @@
-// ヘッダー内
+// In the header
 enum ControllerState
 {
   GO = 0,

--- a/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/add_collision_constraint.cpp
+++ b/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/add_collision_constraint.cpp
@@ -2,4 +2,4 @@
 double iDist = 0.1;
 double sDist = 0.05;
 double damping = 0.0;
-addCollisions("ur5e", "kinova_default", {{"*", "*", iDist, sDist, damping}});
+addCollisions("ur5e", "kinova", {{"*", "*", iDist, sDist, damping}});

--- a/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/add_collision_constraint.py
+++ b/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/add_collision_constraint.py
@@ -2,6 +2,6 @@
 iDist, sDist, damping = 0.1, 0.05, 0.0
 self.addCollisions(
     "ur5e",
-    "kinova_default",
+    "kinova",
     [mc_rbdyn.Collision("*", "*", iDist, sDist, damping)],
 )

--- a/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/add_kinova_tasks.cpp
+++ b/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/add_kinova_tasks.cpp
@@ -1,6 +1,7 @@
 // ヘッダー内
 std::shared_ptr<mc_tasks::PostureTask> kinovaPostureTask_;
 std::shared_ptr<mc_solver::KinematicsConstraint> kinovaKinematics_;
+
 // reset関数内
 kinovaPostureTask_ = std::make_shared<mc_tasks::PostureTask>(solver(), 1);
 solver().addTask(kinovaPostureTask_);

--- a/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/add_ur5e_tasks.cpp
+++ b/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/add_ur5e_tasks.cpp
@@ -4,6 +4,7 @@
 struct DualArmController_DLLAPI DualArmController : public mc_control::MCController
 {
   // ...
+private:
   std::shared_ptr<mc_tasks::EndEffectorTask> urEndEffectorTask_;
   // ...
 }

--- a/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/logic_setup.cpp
+++ b/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/logic_setup.cpp
@@ -5,8 +5,10 @@ enum ControllerPhase
   STARTED,
   MOVE
 };
+
 // コントローラーのプライベートプロパティ
 ControllerPhase phase = IDLE;
+
 // run関数内
 bool DualArmController::run()
 {

--- a/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/p3.py
+++ b/doc/_i18n/jp/tutorials/introduction/dual-arm-controller/p3.py
@@ -52,7 +52,7 @@ def _run_ur5e(self):
         self._urEndEffectorTask.add_ef_pose(sva.PTransformd(
             sva.RotZ(0), eigen.Vector3d(0.0, 0.5, 0.0)
         ))
-        
+
 # runコールバック関数内
 def run_callback(self):
     # ...

--- a/doc/_includes/tutorials/introduction/dual-arm-controller/controller.cpp
+++ b/doc/_includes/tutorials/introduction/dual-arm-controller/controller.cpp
@@ -3,13 +3,15 @@
 #include <mc_rbdyn/RobotLoader.h>
 
 DualArmController::DualArmController(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & config)
-: mc_control::MCController({rm, mc_rbdyn::RobotLoader::get_robot_module("KinovaDefault")}, dt)
+: mc_control::MCController({rm, mc_rbdyn::RobotLoader::get_robot_module("Kinova")}, dt)
 {
   solver().addConstraintSet(contactConstraint);
   solver().addConstraintSet(kinematicsConstraint);
   solver().addConstraintSet(selfCollisionConstraint);
 
-  addCollisions("ur5e", "kinova_default", {{"*", "*", iDist, sDist, 0}});
+  robots().robot("kinova").posW(sva::PTransformd(sva::RotZ(0.0), Eigen::Vector3d(0.7, 0.5, 0)));
+
+  addCollisions("ur5e", "kinova", {{"*", "*", iDist, sDist, damping}});
 
   postureTask->stiffness(1);
   postureTask->weight(1);
@@ -77,11 +79,8 @@ void DualArmController::reset(const mc_control::ControllerResetData & reset_data
 
   kinovaPostureTask_ = std::make_shared<mc_tasks::PostureTask>(solver(), 1, 1, 1);
   solver().addTask(kinovaPostureTask_);
-
   kinovaKinematics_ = std::make_unique<mc_solver::KinematicsConstraint>(robots(), 1, solver().dt());
   solver().addConstraintSet(kinovaKinematics_);
-
-  robots().robot(1).posW(sva::PTransformd(sva::RotZ(0.0), Eigen::Vector3d(0.7, 0.5, 0)));
 }
 
 CONTROLLER_CONSTRUCTOR("DualArmController", DualArmController)

--- a/doc/_includes/tutorials/introduction/dual-arm-controller/controller.h
+++ b/doc/_includes/tutorials/introduction/dual-arm-controller/controller.h
@@ -29,15 +29,20 @@ public:
   void reset(const mc_control::ControllerResetData & reset_data) override;
 
 private:
-  void runUr();
-  void runKinova();
-  ControllerPhase phase_ = IDLE;
-  ControllerState urState_ = RETURN;
-  ControllerState kinovaState_ = RETURN;
-  std::shared_ptr<mc_tasks::PostureTask> kinovaPostureTask_;
   std::shared_ptr<mc_tasks::EndEffectorTask> urEndEffectorTask_;
+
+  std::shared_ptr<mc_tasks::PostureTask> kinovaPostureTask_;
   std::unique_ptr<mc_solver::KinematicsConstraint> kinovaKinematics_;
 
   const double iDist = 0.1;
   const double sDist = 0.05;
+  const double damping = 0.0;
+
+  ControllerPhase phase_ = IDLE;
+
+  ControllerState urState_ = RETURN;
+  ControllerState kinovaState_ = RETURN;
+
+  void runUr();
+  void runKinova();
 };

--- a/doc/_includes/tutorials/introduction/dual-arm-controller/controller.py
+++ b/doc/_includes/tutorials/introduction/dual-arm-controller/controller.py
@@ -26,7 +26,7 @@ class DualArmController(mc_control.MCPythonController):
         iDist, sDist, damping = 0.1, 0.05, 0.1
         self.addCollisions(
             "ur5e",
-            "kinova_default",
+            "kinova",
             [mc_rbdyn.Collision("*", "*", iDist, sDist, damping)],
         )
         self.postureTask.stiffness(1)
@@ -77,7 +77,7 @@ class DualArmController(mc_control.MCPythonController):
 
     @staticmethod
     def create(robot, dt):
-        kinova = mc_rbdyn.get_robot_module("KinovaDefault")
+        kinova = mc_rbdyn.get_robot_module("Kinova")
         return DualArmController([robot, kinova], dt)
 
     def _run_kinova(self):

--- a/doc/_includes/tutorials/introduction/mobile-arm-controller/controller.cpp
+++ b/doc/_includes/tutorials/introduction/mobile-arm-controller/controller.cpp
@@ -3,6 +3,7 @@
 #include <mc_rbdyn/RobotLoader.h>
 #include <mc_tasks/TransformTask.h>
 #include <chrono>
+#include <memory>
 #include <thread>
 
 MobileArmController::MobileArmController(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & config)
@@ -66,16 +67,18 @@ bool MobileArmController::run()
 void MobileArmController::reset(const mc_control::ControllerResetData & reset_data)
 {
   mc_control::MCController::reset(reset_data);
+
   robots().robot(0).posW(sva::PTransformd(sva::RotZ(0.0), Eigen::Vector3d(0.0, 0.0, 0.5)));
   robots().robot(1).posW(sva::PTransformd(sva::RotZ(0.0), Eigen::Vector3d(-0.25, 0.0, 0.0)));
   robots().robot(2).posW(sva::PTransformd(sva::RotZ(M_PI), Eigen::Vector3d(2.0, 1.0, 0)));
+
   addContact({"dingo", "ur5e", "Base", "Base"});
 
   handTask_ = std::make_shared<mc_tasks::SurfaceTransformTask>("Tool", robots(), 0);
   dingoBaseTask_ = std::make_shared<mc_tasks::TransformTask>("base_link", robots(), 1, 2.0, 1000);
 
-  doorKinematics_ = std::make_shared<mc_solver::KinematicsConstraint>(robots(), 2, solver().dt());
-  solver().addConstraintSet(*doorKinematics_);
+  doorKinematics_ = std::make_unique<mc_solver::KinematicsConstraint>(robots(), 2, solver().dt());
+  solver().addConstraintSet(doorKinematics_);
   doorPostureTask_ = std::make_shared<mc_tasks::PostureTask>(solver(), 2, 1.0, 1.0);
   solver().addTask(doorPostureTask_);
 

--- a/doc/_includes/tutorials/introduction/mobile-arm-controller/controller.cpp
+++ b/doc/_includes/tutorials/introduction/mobile-arm-controller/controller.cpp
@@ -2,9 +2,6 @@
 
 #include <mc_rbdyn/RobotLoader.h>
 #include <mc_tasks/TransformTask.h>
-#include <chrono>
-#include <memory>
-#include <thread>
 
 MobileArmController::MobileArmController(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & config)
 : mc_control::MCController({rm, mc_rbdyn::RobotLoader::get_robot_module("dingo"),

--- a/doc/tutorials/introduction/dual-arm-controller.html
+++ b/doc/tutorials/introduction/dual-arm-controller.html
@@ -8,14 +8,13 @@ constructor_sources:
       #include <mc_rbdyn/RobotLoader.h>
 
       DualArmController::DualArmController(mc_rbdyn::RobotModulePtr rm, double dt, const mc_rtc::Configuration & config)
-      : mc_control::MCController({rm,
-          mc_rbdyn::RobotLoader::get_robot_module("KinovaDefault")}, dt)
+      : mc_control::MCController({rm, mc_rbdyn::RobotLoader::get_robot_module("Kinova")}, dt)
   - name: Python
     lang: python
     source: |
       @staticmethod
       def create(robot, dt):
-          kinova = mc_rbdyn.get_robot_module("KinovaDefault")
+          kinova = mc_rbdyn.get_robot_module("Kinova")
           return DualArmController([robot, kinova], dt)
 reposition_kinova_sources:
   - name: C++
@@ -46,7 +45,7 @@ add_collision_constraint_sources:
         double iDist = 0.1;
         double sDist = 0.05;
         double damping = 0.0;
-        addCollisions("ur5e", "kinova_default", {{"*", "*", iDist, sDist, damping}});
+        addCollisions("ur5e", "kinova", {{"*", "*", iDist, sDist, damping}});
   - name: Python
     lang: python
     translate: tutorials/introduction/dual-arm-controller/add_collision_constraint.py

--- a/doc/tutorials/introduction/mobile-arm-controller.html
+++ b/doc/tutorials/introduction/mobile-arm-controller.html
@@ -36,6 +36,7 @@ set_contact_sources:
       dof[4] = 0.0;
       double friction = mc_rbdyn::Contact::defaultFriction;
       addContact({"dingo", "ground", "Base", "AllGround", friction, dof});
+
       // In the reset function after setting up initial position
       addContact({"dingo", "ur5e", "Base", "Base"});
   - name: Python
@@ -52,6 +53,7 @@ set_contact_sources:
               "dingo", "ground", "Base", "AllGround", friction, dof
           )
       )
+
       # In the reset function after setting up initial position
       self.addContact(mc_control.Contact("dingo", "ur5e", "Base", "Base"))
 reposition_sources:
@@ -235,9 +237,11 @@ p1_sources:
   - name: C++
     lang: cpp
     source: |
+      // In the constructor
+      solver().addTask(postureTask);
+
       // In the reset function
       solver().addTask(dingoBaseTask_);
-      solver().addTask(postureTask.get());
       postureTask->target({{"shoulder_lift_joint", {-M_PI / 2}}});
       dingoBaseTask_->target({Eigen::Vector3d(1.5, 0.0, 0.0)});
   - name: Python
@@ -363,22 +367,22 @@ phase_conditions:
             and self._dingoBaseTask.eval().norm() < 1e-2
             and self._dingoBaseTask.speed().norm() < 1e-5
         ):
-        # ...
+      # ...
       elif (
             self._phase == ControllerPhase.HANDLE
             and self._handTask.eval().norm() < 0.1
             and self._handTask.speed().norm() < 1e-4
         ):
-        # ...
+      # ...
       elif (
             self._phase == ControllerPhase.OPEN
             and self._doorPosture.eval().norm() < 0.01
         ):
-        # ...
+      # ...
       elif (
             self._phase == ControllerPhase.DONE
             and self._doorPosture.eval().norm() < 0.01
         ):
-        # ...
+      # ...
 ---
 {% translate_file tutorials/introduction/mobile-arm-controller.html %}


### PR DESCRIPTION
Hello,

These are some updates for the websites (tutorials for Dual Arm Controller and Mobile Arm Controller). The main fix are changing robot's name of KinovaG3 from `KinovaDefault/kinova_default` to `Kinova/kinova`. Others are some cosmetic changes I noticed along the way.

Ref:
- https://github.com/isri-aist/mc_kinova/pull/3
- https://github.com/isri-aist/mc_rtc_tutorials